### PR TITLE
Constant time encoder

### DIFF
--- a/flate/crc32_amd64.go
+++ b/flate/crc32_amd64.go
@@ -12,6 +12,7 @@ import (
 func crc32sse(a []byte) hash
 func crc32sseAll(a []byte, dst []hash)
 func matchLenSSE4(a, b []byte, max int) int
+func histogram(b []byte, h []int32)
 
 func init() {
 	useSSE42 = cpuid.CPU.SSE42()

--- a/flate/crc32_amd64.s
+++ b/flate/crc32_amd64.s
@@ -144,3 +144,23 @@ match_ended:
 done_matchlen:
     MOVQ    R11, ret+56(FP)
     RET
+
+// func histogram(b []byte, h []int32)
+TEXT ·histogram(SB), 7, $0
+    MOVQ    b+0(FP),SI                  // SI: &b
+    MOVQ    b_len+8(FP),R9              // R9: len(b)
+    MOVQ    h+24(FP), DI                // DI: Histogram
+    XORQ    R10, R10
+    TESTQ   R9, R9
+    JZ end_hist
+
+loop_hist:
+    MOVB    (SI), R10
+    ADDL    $1, (DI)(R10*4)
+
+    ADDQ    $1, SI
+    SUBQ    $1, R9
+    JNZ     loop_hist
+
+end_hist:
+    RET

--- a/flate/crc32_noasm.go
+++ b/flate/crc32_noasm.go
@@ -20,3 +20,9 @@ func matchLenSSE4(a, b []byte, max int) int {
 	panic("no assembler")
 	return 0
 }
+
+func histogram(b []byte, h []int32) {
+	for _, t := range b {
+		h[t]++
+	}
+}

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -651,6 +651,7 @@ func (d *compressor) init(w io.Writer, level int) (err error) {
 	switch {
 	case level == NoCompression:
 		d.window = make([]byte, maxStoreBlockSize)
+		d.tokens = make([]token, 0)
 		d.fill = (*compressor).fillStore
 		d.step = (*compressor).store
 	case level == ConstantCompression:
@@ -688,9 +689,7 @@ func (d *compressor) reset(w io.Writer) {
 	case 0:
 		// level was NoCompression.
 		d.windowEnd = 0
-	case ConstantCompression:
-		d.windowEnd = 0
-		d.blockStart = 0
+		d.tokens = d.tokens[:0]
 	default:
 		d.chainHead = -1
 		for s := d.hashHead; len(s) > 0; {

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -17,7 +17,7 @@ const (
 	fastCompression     = 3
 	BestCompression     = 9
 	DefaultCompression  = -1
-	ConstantCompression = -2
+	ConstantCompression = -2 // Does only Huffman encoding
 	logWindowSize       = 15
 	windowSize          = 1 << logWindowSize
 	windowMask          = windowSize - 1
@@ -671,7 +671,7 @@ func (d *compressor) init(w io.Writer, level int) (err error) {
 			d.step = (*compressor).deflate
 		}
 	default:
-		return fmt.Errorf("flate: invalid compression level %d: want value in range [-1, 9]", level)
+		return fmt.Errorf("flate: invalid compression level %d: want value in range [-2, 9]", level)
 	}
 	return nil
 }

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -612,17 +612,14 @@ func (d *compressor) fillHuff(b []byte) int {
 }
 
 func (d *compressor) storeHuff() {
-	d.blockStart = 0
-	ntokens := d.windowEnd
+	// We only compress if we have >= 32KB (maxStoreBlockSize/2)
+	if d.windowEnd < (maxStoreBlockSize/2) && !d.sync {
+		return
+	}
 	if d.windowEnd == 0 {
 		return
 	}
-	for i, v := range d.window[:d.windowEnd] {
-		d.tokens[i] = literalToken(uint32(v))
-	}
-	if d.err = d.writeBlock(d.tokens[:ntokens], d.windowEnd, false); d.err != nil {
-		return
-	}
+	d.w.writeBlockHuff(false, d.window[:d.windowEnd])
 	d.windowEnd = 0
 }
 

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -651,12 +651,10 @@ func (d *compressor) init(w io.Writer, level int) (err error) {
 	switch {
 	case level == NoCompression:
 		d.window = make([]byte, maxStoreBlockSize)
-		d.tokens = make([]token, 0)
 		d.fill = (*compressor).fillStore
 		d.step = (*compressor).store
 	case level == ConstantCompression:
 		d.window = make([]byte, maxStoreBlockSize)
-		d.tokens = make([]token, maxStoreBlockSize+1)
 		d.fill = (*compressor).fillHuff
 		d.step = (*compressor).storeHuff
 	case level == DefaultCompression:
@@ -687,9 +685,8 @@ func (d *compressor) reset(w io.Writer) {
 	d.err = nil
 	switch d.compressionLevel.chain {
 	case 0:
-		// level was NoCompression.
+		// level was NoCompression or ConstantCompresssion.
 		d.windowEnd = 0
-		d.tokens = d.tokens[:0]
 	default:
 		d.chainHead = -1
 		for s := d.hashHead; len(s) > 0; {

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -381,6 +381,7 @@ func testToFromWithLimit(t *testing.T, input []byte, name string, limit [10]int)
 	for i := 0; i < 10; i++ {
 		testToFromWithLevelAndLimit(t, i, input, name, limit[i])
 	}
+	testToFromWithLevelAndLimit(t, -2, input, name, limit[0])
 }
 
 func TestDeflateInflate(t *testing.T) {

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -510,7 +510,10 @@ func TestRegression2508(t *testing.T) {
 }
 
 func TestWriterReset(t *testing.T) {
-	for level := 0; level <= 9; level++ {
+	for level := -2; level <= 9; level++ {
+		if level == -1 {
+			level++
+		}
 		if testing.Short() && level > 1 {
 			break
 		}

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -377,16 +377,16 @@ func testToFromWithLevelAndLimit(t *testing.T, level int, input []byte, name str
 	testSync(t, level, input, name)
 }
 
-func testToFromWithLimit(t *testing.T, input []byte, name string, limit [10]int) {
+func testToFromWithLimit(t *testing.T, input []byte, name string, limit [11]int) {
 	for i := 0; i < 10; i++ {
 		testToFromWithLevelAndLimit(t, i, input, name, limit[i])
 	}
-	testToFromWithLevelAndLimit(t, -2, input, name, limit[0])
+	testToFromWithLevelAndLimit(t, -2, input, name, limit[10])
 }
 
 func TestDeflateInflate(t *testing.T) {
 	for i, h := range deflateInflateTests {
-		testToFromWithLimit(t, h.in, fmt.Sprintf("#%d", i), [10]int{})
+		testToFromWithLimit(t, h.in, fmt.Sprintf("#%d", i), [11]int{})
 	}
 }
 
@@ -402,19 +402,19 @@ func TestReverseBits(t *testing.T) {
 type deflateInflateStringTest struct {
 	filename string
 	label    string
-	limit    [10]int
+	limit    [11]int // Number 11 is ConstantCompression
 }
 
 var deflateInflateStringTests = []deflateInflateStringTest{
 	{
 		"../testdata/e.txt",
 		"2.718281828...",
-		[...]int{100018, 50650, 50960, 51150, 50930, 50790, 50790, 50790, 50790, 50790},
+		[...]int{100018, 50650, 50960, 51150, 50930, 50790, 50790, 50790, 50790, 50790, 43683 + 100},
 	},
 	{
 		"../testdata/Mark.Twain-Tom.Sawyer.txt",
 		"Mark.Twain-Tom.Sawyer",
-		[...]int{407330, 187598, 180361, 172974, 169160, 163476, 160936, 160506, 160295, 160295},
+		[...]int{407330, 187598, 180361, 172974, 169160, 163476, 160936, 160506, 160295, 160295, 233460 + 100},
 	},
 }
 
@@ -431,7 +431,9 @@ func TestDeflateInflateString(t *testing.T) {
 			}
 			return -1
 		}, string(gold))
+
 		testToFromWithLimit(t, []byte(neutral), test.label, test.limit)
+
 		if testing.Short() {
 			break
 		}

--- a/flate/huffman_bit_writer.go
+++ b/flate/huffman_bit_writer.go
@@ -597,9 +597,8 @@ func (w *huffmanBitWriter) writeBlockHuff(eof bool, input []byte) {
 	copy(w.literalFreq, zeroLits[:])
 
 	// Add everything as literals
-	for _, t := range input {
-		w.literalFreq[t]++
-	}
+	histogram(input, w.literalFreq)
+
 	w.literalFreq[endBlockMarker]++
 
 	// get the number of literals

--- a/flate/huffman_bit_writer.go
+++ b/flate/huffman_bit_writer.go
@@ -113,10 +113,12 @@ func (w *huffmanBitWriter) reset(writer io.Writer) {
 			s[i] = 0
 		}
 	}
-	for _, enc := range [...]*huffmanEncoder{
-		w.literalEncoding,
-		w.offsetEncoding,
-		w.codegenEncoding} {
+	encs := []*huffmanEncoder{w.literalEncoding, w.codegenEncoding}
+	// Don't reset, if we are huffman only mode
+	if w.offsetEncoding != huffOffset {
+		encs = append(encs, w.offsetEncoding)
+	}
+	for _, enc := range encs {
 		for i := range enc.codes {
 			enc.codes[i] = 0
 		}
@@ -607,7 +609,6 @@ func (w *huffmanBitWriter) writeBlockHuff(eof bool, input []byte) {
 		numLiterals--
 	}
 
-	// we should count at least one offset to be sure that the offset huffman tree could be encoded.
 	numOffsets := 1
 
 	w.literalEncoding.generate(w.literalFreq, 15)

--- a/flate/huffman_code.go
+++ b/flate/huffman_code.go
@@ -326,30 +326,35 @@ func (h *huffmanEncoder) generate(freq []int32, maxBits int32) {
 	h.assignEncodingAndSize(bitCount, list)
 }
 
-type literalNodeSorter struct {
-	a    []literalNode
-	less func(i, j int) bool
-}
+type literalNodeSorter []literalNode
 
-func (s literalNodeSorter) Len() int { return len(s.a) }
+func (s literalNodeSorter) Len() int { return len(s) }
 
 func (s literalNodeSorter) Less(i, j int) bool {
-	return s.less(i, j)
+	return s[i].literal < s[j].literal
 }
 
-func (s literalNodeSorter) Swap(i, j int) { s.a[i], s.a[j] = s.a[j], s.a[i] }
+func (s literalNodeSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+type literalFreqSorter []literalNode
+
+func (s literalFreqSorter) Len() int { return len(s) }
+
+func (s literalFreqSorter) Less(i, j int) bool {
+	if s[i].freq == s[j].freq {
+		return s[i].literal < s[j].literal
+	}
+	return s[i].freq < s[j].freq
+}
+
+func (s literalFreqSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func sortByFreq(a []literalNode) {
-	s := &literalNodeSorter{a, func(i, j int) bool {
-		if a[i].freq == a[j].freq {
-			return a[i].literal < a[j].literal
-		}
-		return a[i].freq < a[j].freq
-	}}
-	sort.Sort(s)
+	sort.Sort(literalFreqSorter(a))
 }
 
 func sortByLiteral(a []literalNode) {
-	s := &literalNodeSorter{a, func(i, j int) bool { return a[i].literal < a[j].literal }}
+	// FIXME: Still a single 32B allocation left.
+	s := literalNodeSorter(a)
 	sort.Sort(s)
 }

--- a/flate/reader_test.go
+++ b/flate/reader_test.go
@@ -71,6 +71,7 @@ func benchmarkDecode(b *testing.B, testfile, level, n int) {
 // These short names are so that gofmt doesn't break the BenchmarkXxx function
 // bodies below over multiple lines.
 const (
+	constant = ConstantCompression
 	speed    = BestSpeed
 	default_ = DefaultCompression
 	compress = BestCompression

--- a/flate/writer_test.go
+++ b/flate/writer_test.go
@@ -44,6 +44,9 @@ func benchmarkEncoder(b *testing.B, testfile, level, n int) {
 	}
 }
 
+func BenchmarkEncodeDigitsConstant1e4(b *testing.B) { benchmarkEncoder(b, digits, constant, 1e4) }
+func BenchmarkEncodeDigitsConstant1e5(b *testing.B) { benchmarkEncoder(b, digits, constant, 1e5) }
+func BenchmarkEncodeDigitsConstant1e6(b *testing.B) { benchmarkEncoder(b, digits, constant, 1e6) }
 func BenchmarkEncodeDigitsSpeed1e4(b *testing.B)    { benchmarkEncoder(b, digits, speed, 1e4) }
 func BenchmarkEncodeDigitsSpeed1e5(b *testing.B)    { benchmarkEncoder(b, digits, speed, 1e5) }
 func BenchmarkEncodeDigitsSpeed1e6(b *testing.B)    { benchmarkEncoder(b, digits, speed, 1e6) }
@@ -53,6 +56,9 @@ func BenchmarkEncodeDigitsDefault1e6(b *testing.B)  { benchmarkEncoder(b, digits
 func BenchmarkEncodeDigitsCompress1e4(b *testing.B) { benchmarkEncoder(b, digits, compress, 1e4) }
 func BenchmarkEncodeDigitsCompress1e5(b *testing.B) { benchmarkEncoder(b, digits, compress, 1e5) }
 func BenchmarkEncodeDigitsCompress1e6(b *testing.B) { benchmarkEncoder(b, digits, compress, 1e6) }
+func BenchmarkEncodeTwainConstant1e4(b *testing.B)  { benchmarkEncoder(b, twain, constant, 1e4) }
+func BenchmarkEncodeTwainConstant1e5(b *testing.B)  { benchmarkEncoder(b, twain, constant, 1e5) }
+func BenchmarkEncodeTwainConstant1e6(b *testing.B)  { benchmarkEncoder(b, twain, constant, 1e6) }
 func BenchmarkEncodeTwainSpeed1e4(b *testing.B)     { benchmarkEncoder(b, twain, speed, 1e4) }
 func BenchmarkEncodeTwainSpeed1e5(b *testing.B)     { benchmarkEncoder(b, twain, speed, 1e5) }
 func BenchmarkEncodeTwainSpeed1e6(b *testing.B)     { benchmarkEncoder(b, twain, speed, 1e6) }

--- a/flate/writer_test.go
+++ b/flate/writer_test.go
@@ -29,14 +29,18 @@ func benchmarkEncoder(b *testing.B, testfile, level, n int) {
 	}
 	buf0 = nil
 	runtime.GC()
+	w, err := NewWriter(ioutil.Discard, level)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		w, err := NewWriter(ioutil.Discard, level)
+		w.Reset(ioutil.Discard)
+		_, err = w.Write(buf1)
 		if err != nil {
 			b.Fatal(err)
 		}
-		w.Write(buf1)
-		w.Close()
+		err = w.Close()
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -16,10 +16,11 @@ import (
 // These constants are copied from the flate package, so that code that imports
 // "compress/gzip" does not also have to import "compress/flate".
 const (
-	NoCompression      = flate.NoCompression
-	BestSpeed          = flate.BestSpeed
-	BestCompression    = flate.BestCompression
-	DefaultCompression = flate.DefaultCompression
+	NoCompression       = flate.NoCompression
+	BestSpeed           = flate.BestSpeed
+	BestCompression     = flate.BestCompression
+	DefaultCompression  = flate.DefaultCompression
+	ConstantCompression = flate.ConstantCompression
 )
 
 // A Writer is an io.WriteCloser.
@@ -56,11 +57,11 @@ func NewWriter(w io.Writer) *Writer {
 // NewWriterLevel is like NewWriter but specifies the compression level instead
 // of assuming DefaultCompression.
 //
-// The compression level can be DefaultCompression, NoCompression, or any
-// integer value between BestSpeed and BestCompression inclusive. The error
-// returned will be nil if the level is valid.
+// The compression level can be ConstantCompression, DefaultCompression,
+// NoCompression, or any integer value between BestSpeed and BestCompression
+// inclusive. The error returned will be nil if the level is valid.
 func NewWriterLevel(w io.Writer, level int) (*Writer, error) {
-	if level < DefaultCompression || level > BestCompression {
+	if level < ConstantCompression || level > BestCompression {
 		return nil, fmt.Errorf("gzip: invalid compression level: %d", level)
 	}
 	z := new(Writer)

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -347,9 +347,10 @@ func benchmarkGzipN(b *testing.B, level int) {
 	dat = append(dat, dat...)
 	dat = append(dat, dat...)
 	b.SetBytes(int64(len(dat)))
+	w, _ := NewWriterLevel(ioutil.Discard, level)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		w, _ := NewWriterLevel(ioutil.Discard, level)
+		w.Reset(ioutil.Discard)
 		w.Write(dat)
 		w.Flush()
 		w.Close()
@@ -375,9 +376,10 @@ func benchmarkOldGzipN(b *testing.B, level int) {
 	dat = append(dat, dat...)
 
 	b.SetBytes(int64(len(dat)))
+	w, _ := oldgz.NewWriterLevel(ioutil.Discard, level)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		w, _ := oldgz.NewWriterLevel(ioutil.Discard, level)
+		w.Reset(ioutil.Discard)
 		w.Write(dat)
 		w.Flush()
 		w.Close()

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -329,7 +329,7 @@ func testBigGzip(i int, t *testing.T) {
 		t.Fatal(err)
 	}
 	if int(n) != len(testbuf) {
-		t.Fatal("Short write:", n, "!=", testbuf)
+		t.Fatal("Short write:", n, "!=", len(testbuf))
 	}
 	err = w.Close()
 	if err != nil {

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -329,15 +329,16 @@ func TestGzip10M(t *testing.T) {
 	testBigGzip(10000000, t)
 }
 
-func BenchmarkGzipL1(b *testing.B) { benchmarkGzipN(b, 1) }
-func BenchmarkGzipL2(b *testing.B) { benchmarkGzipN(b, 2) }
-func BenchmarkGzipL3(b *testing.B) { benchmarkGzipN(b, 3) }
-func BenchmarkGzipL4(b *testing.B) { benchmarkGzipN(b, 4) }
-func BenchmarkGzipL5(b *testing.B) { benchmarkGzipN(b, 5) }
-func BenchmarkGzipL6(b *testing.B) { benchmarkGzipN(b, 6) }
-func BenchmarkGzipL7(b *testing.B) { benchmarkGzipN(b, 7) }
-func BenchmarkGzipL8(b *testing.B) { benchmarkGzipN(b, 8) }
-func BenchmarkGzipL9(b *testing.B) { benchmarkGzipN(b, 9) }
+func BenchmarkGzipLM2(b *testing.B) { benchmarkGzipN(b, -2) }
+func BenchmarkGzipL1(b *testing.B)  { benchmarkGzipN(b, 1) }
+func BenchmarkGzipL2(b *testing.B)  { benchmarkGzipN(b, 2) }
+func BenchmarkGzipL3(b *testing.B)  { benchmarkGzipN(b, 3) }
+func BenchmarkGzipL4(b *testing.B)  { benchmarkGzipN(b, 4) }
+func BenchmarkGzipL5(b *testing.B)  { benchmarkGzipN(b, 5) }
+func BenchmarkGzipL6(b *testing.B)  { benchmarkGzipN(b, 6) }
+func BenchmarkGzipL7(b *testing.B)  { benchmarkGzipN(b, 7) }
+func BenchmarkGzipL8(b *testing.B)  { benchmarkGzipN(b, 8) }
+func BenchmarkGzipL9(b *testing.B)  { benchmarkGzipN(b, 9) }
 
 func benchmarkGzipN(b *testing.B, level int) {
 	dat, _ := ioutil.ReadFile("testdata/test.json")

--- a/zlib/writer.go
+++ b/zlib/writer.go
@@ -100,7 +100,7 @@ func (z *Writer) writeHeader() (err error) {
 	// The next bit, FDICT, is set if a dictionary is given.
 	// The final five FCHECK bits form a mod-31 checksum.
 	switch z.level {
-	case 0, 1:
+	case -2, 0, 1:
 		z.scratch[1] = 0 << 6
 	case 2, 3, 4, 5:
 		z.scratch[1] = 1 << 6

--- a/zlib/writer.go
+++ b/zlib/writer.go
@@ -15,10 +15,11 @@ import (
 // These constants are copied from the flate package, so that code that imports
 // "compress/zlib" does not also have to import "compress/flate".
 const (
-	NoCompression      = flate.NoCompression
-	BestSpeed          = flate.BestSpeed
-	BestCompression    = flate.BestCompression
-	DefaultCompression = flate.DefaultCompression
+	NoCompression       = flate.NoCompression
+	BestSpeed           = flate.BestSpeed
+	BestCompression     = flate.BestCompression
+	DefaultCompression  = flate.DefaultCompression
+	ConstantCompression = flate.ConstantCompression
 )
 
 // A Writer takes data written to it and writes the compressed
@@ -60,7 +61,7 @@ func NewWriterLevel(w io.Writer, level int) (*Writer, error) {
 // The dictionary may be nil. If not, its contents should not be modified until
 // the Writer is closed.
 func NewWriterLevelDict(w io.Writer, level int, dict []byte) (*Writer, error) {
-	if level < DefaultCompression || level > BestCompression {
+	if level < ConstantCompression || level > BestCompression {
 		return nil, fmt.Errorf("zlib: invalid compression level: %d", level)
 	}
 	return &Writer{

--- a/zlib/writer_test.go
+++ b/zlib/writer_test.go
@@ -123,8 +123,11 @@ func testFileLevelDictReset(t *testing.T, fn string, level int, dict []byte) {
 	// Reset and compress again.
 	buf2 := new(bytes.Buffer)
 	zlibw.Reset(buf2)
-	_, err = zlibw.Write(b0)
+	n, err := zlibw.Write(b0)
 	if err == nil {
+		if int(n) != len(b0) {
+			t.Fatal("Short write:", n, "!=", len(b0))
+		}
 		err = zlibw.Close()
 	}
 	if err != nil {
@@ -134,7 +137,7 @@ func testFileLevelDictReset(t *testing.T, fn string, level int, dict []byte) {
 	out2 := buf2.String()
 
 	if out2 != out {
-		t.Errorf("%s (level=%d): different output after reset (got %d bytes, expected %d",
+		t.Errorf("%s (level=%d): different output after reset (got %d bytes, expected %d)",
 			fn, level, len(out2), len(out))
 	}
 }
@@ -177,8 +180,10 @@ func TestWriterReset(t *testing.T) {
 	for _, fn := range filenames {
 		testFileLevelDictReset(t, fn, NoCompression, nil)
 		testFileLevelDictReset(t, fn, DefaultCompression, nil)
+		testFileLevelDictReset(t, fn, ConstantCompression, nil)
 		testFileLevelDictReset(t, fn, NoCompression, []byte(dictionary))
 		testFileLevelDictReset(t, fn, DefaultCompression, []byte(dictionary))
+		testFileLevelDictReset(t, fn, ConstantCompression, []byte(dictionary))
 		if !testing.Short() {
 			for level := BestSpeed; level <= BestCompression; level++ {
 				testFileLevelDictReset(t, fn, level, nil)


### PR DESCRIPTION
Add encoder that does not attempt to do any back-matches. This gives much more predictable performance, but at a big compression size cost. Performance is currently approximately ~70MB/s.

Use level = ConstantCompression (-2) to enable.