### PR TITLE
Fast skipping on long non-matches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ Currently there is only minor speedup on decompression (primarily CRC32 calculat
 
 * Minimum matches are 4 bytes, this leads to fewer searches and better compression.
 * Stronger hash (iSCSI CRC32) for matches on x64 with SSE 4.2 support. This leads to fewer hash collisions.
-* Literal byte matching using SSE 4.2 for faster string comparisons.
+* Literal byte matching using SSE 4.2 for faster match comparisons.
 * Bulk hashing on matches.
 * Much faster dictionary indexing with `NewWriterDict()`/`Reset()`.
 * Make Bit Coder faster by assuming we are on a 64 bit CPU.
 * Level 1 compression replaced by converted "Snappy" algorithm.
-
+* Uncompressible content is detected and skipped faster.
+* A lot of branching eliminated by having two encoders for levels 2+3 and 4+.
+* All heap memory allocacations eliminated.
 
 ```
 benchmark                              old ns/op     new ns/op     delta

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Currently there is only minor speedup on decompression (primarily CRC32 calculat
 * Level 1 compression replaced by converted "Snappy" algorithm.
 * Uncompressible content is detected and skipped faster.
 * A lot of branching eliminated by having two encoders for levels 2+3 and 4+.
-* All heap memory allocacations eliminated.
+* All heap memory allocations eliminated.
 
 ```
 benchmark                              old ns/op     new ns/op     delta

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -62,7 +62,8 @@ func snappyEncode(dst *tokens, src []byte) {
 		// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
 		if t < 0 || s-t >= maxOffset || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
 			misses++
-			s += 1 + (misses >> 5)
+			// Skip 1 byte for 16 consecutive missed.
+			s += 1 + (misses >> 4)
 			continue
 		}
 		// Otherwise, we have a match. First, emit any pending literal bytes.


### PR DESCRIPTION
Add fast skipping on consecutive missed matches. ~2x-10x as fast on precompressed/uncompressible content.

If there is more than X consecutive match failures, it will start skipping bytes. The number of bytes required and the number of bytes skipped is dependent on the compression level.

Level 1, random bytes: Before: 56.13MB/s. After: 139.54MB/s.
