### PR TITLE
Fix error propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It offers slightly better compression at lower compression settings, and up to 3
 
 # changelog
 
+* Nov 17 2015: Fixed out-of-bound errors if the underlying Writer returned an error. See [#15](https://github.com/klauspost/compress/issues/15).
 * Nov 12 2015: Added [io.WriterTo](https://golang.org/pkg/io/#WriterTo) support to gzip/inflate.
 * Nov 11 2015: Merged [CL 16669](https://go-review.googlesource.com/#/c/16669/4): archive/zip: enable overriding (de)compressors per file
 * Oct 15 2015: Added skipping on uncompressible data. Random data speed up >5x.

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -540,6 +540,8 @@ func TestWriterReset(t *testing.T) {
 		w.d.hasher, wref.d.hasher = nil, nil
 		w.d.bulkHasher, wref.d.bulkHasher = nil, nil
 		w.d.matcher, wref.d.matcher = nil, nil
+		// hashMatch is always overwritten when used.
+		copy(w.d.hashMatch[:], wref.d.hashMatch[:])
 		if w.d.tokens.n != 0 {
 			t.Errorf("level %d Writer not reset after Reset. %d tokens were present", level, w.d.tokens.n)
 		}
@@ -600,4 +602,68 @@ func testResetOutput(t *testing.T, newWriter func(w io.Writer) (*Writer, error))
 		}
 	}
 	t.Logf("got %d bytes", len(out1))
+}
+
+// A writer that fails after N writes.
+type errorWriter struct {
+	N int
+}
+
+func (e *errorWriter) Write(b []byte) (int, error) {
+	if e.N <= 0 {
+		return 0, io.ErrClosedPipe
+	}
+	e.N--
+	return len(b), nil
+}
+
+// Test if errors from the underlying writer is passed upwards.
+func TestWriteError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	for i := 0; i < 1024*1024; i++ {
+		buf.WriteString(fmt.Sprintf("asdasfasf%d%dfghfgujyut%dyutyu\n", i, i, i))
+	}
+	in := buf.Bytes()
+	for l := -2; l < 10; l++ {
+		for fail := 1; fail <= 512; fail *= 2 {
+			// Fail after 2 writes
+			ew := &errorWriter{N: fail}
+			w, err := NewWriter(ew, l)
+			if err != nil {
+				t.Errorf("NewWriter: level %d: %v", l, err)
+			}
+			n, err := io.Copy(w, bytes.NewBuffer(in))
+			if err == nil {
+				t.Errorf("Level %d: Expected an error, writer was %#v", l, ew)
+			}
+			n2, err := w.Write([]byte{1, 2, 2, 3, 4, 5})
+			if n2 != 0 {
+				t.Error("Level", l, "Expected 0 length write, got", n)
+			}
+			if err == nil {
+				t.Error("Level", l, "Expected an error")
+			}
+			err = w.Flush()
+			if err == nil {
+				t.Error("Level", l, "Expected an error on close")
+			}
+			err = w.Close()
+			if err == nil {
+				t.Error("Level", l, "Expected an error on close")
+			}
+
+			w.Reset(ioutil.Discard)
+			n2, err = w.Write([]byte{1, 2, 3, 4, 5, 6})
+			if err != nil {
+				t.Error("Level", l, "Got unexpected error after reset:", err)
+			}
+			if n2 == 0 {
+				t.Error("Level", l, "Got 0 length write, expected > 0")
+			}
+			if testing.Short() {
+				return
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Errors from the underlying writer was not being forwarded/returned, so that is now done, and tests have been added to test that functionality.

Fixes #15