### PR TITLE
Split encode functions, so hash and match length can be inlined.

### DIFF
--- a/flate/crc32_amd64.go
+++ b/flate/crc32_amd64.go
@@ -11,22 +11,26 @@ import (
 
 // crc32sse returns a hash for the first 4 bytes of the slice
 // len(a) must be >= 4.
+//go:noescape
 func crc32sse(a []byte) hash
 
 // crc32sseAll calculates hashes for each 4-byte set in a.
 // dst must be east len(a) - 4 in size.
 // The size is not checked by the assembly.
+//go:noescape
 func crc32sseAll(a []byte, dst []hash)
 
 // matchLenSSE4 returns the number of matching bytes in a and b
 // up to length 'max'. Both slices must be at least 'max'
 // bytes in size.
 // It uses the PCMPESTRI SSE 4.2 instruction.
+//go:noescape
 func matchLenSSE4(a, b []byte, max int) int
 
 // histogram accumulates a histogram of b in h.
 // h must be at least 256 entries in length,
 // and must be cleared before calling this function.
+//go:noescape
 func histogram(b []byte, h []int32)
 
 // Detect SSE 4.2 feature.

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -240,7 +240,62 @@ func (d *compressor) findMatch(pos int, prevHead int, prevLength int, lookahead 
 
 	for i := prevHead; tries > 0; tries-- {
 		if wEnd == win[i+length] {
-			n := d.matcher(win[i:], wPos, minMatchLook)
+			n := matchLen(win[i:], wPos, minMatchLook)
+
+			if n > length && (n > minMatchLength || pos-i <= 4096) {
+				length = n
+				offset = pos - i
+				ok = true
+				if n >= nice {
+					// The match is good enough that we don't try to find a better one.
+					break
+				}
+				wEnd = win[pos+n]
+			}
+		}
+		if i == minIndex {
+			// hashPrev[i & windowMask] has already been overwritten, so stop now.
+			break
+		}
+		i = int(d.hashPrev[i&windowMask]) - d.hashOffset
+		if i < minIndex || i < 0 {
+			break
+		}
+	}
+	return
+}
+
+// Try to find a match starting at index whose length is greater than prevSize.
+// We only look at chainCount possibilities before giving up.
+// pos = d.index, prevHead = d.chainHead-d.hashOffset, prevLength=minMatchLength-1, lookahead
+func (d *compressor) findMatchSSE(pos int, prevHead int, prevLength int, lookahead int) (length, offset int, ok bool) {
+	minMatchLook := maxMatchLength
+	if lookahead < minMatchLook {
+		minMatchLook = lookahead
+	}
+
+	win := d.window[0 : pos+minMatchLook]
+
+	// We quit when we get a match that's at least nice long
+	nice := len(win) - pos
+	if d.nice < nice {
+		nice = d.nice
+	}
+
+	// If we've got a match that's good enough, only look in 1/4 the chain.
+	tries := d.chain
+	length = prevLength
+	if length >= d.good {
+		tries >>= 2
+	}
+
+	wEnd := win[pos+length]
+	wPos := win[pos:]
+	minIndex := pos - windowSize
+
+	for i := prevHead; tries > 0; tries-- {
+		if wEnd == win[i+length] {
+			n := matchLenSSE4(win[i:], wPos, minMatchLook)
 
 			if n > length && (n > minMatchLength || pos-i <= 4096) {
 				length = n
@@ -345,10 +400,9 @@ func (d *compressor) deflate() {
 
 	d.maxInsertIndex = d.windowEnd - (minMatchLength - 1)
 	if d.index < d.maxInsertIndex {
-		d.hash = d.hasher(d.window[d.index:d.index+minMatchLength]) & hashMask
+		d.hash = oldHash(d.window[d.index:d.index+minMatchLength]) & hashMask
 	}
 
-Loop:
 	for {
 		if sanity && d.index > d.windowEnd {
 			panic("index > windowEnd")
@@ -356,7 +410,7 @@ Loop:
 		lookahead := d.windowEnd - d.index
 		if lookahead < minMatchLength+maxMatchLength {
 			if !d.sync {
-				break Loop
+				return
 			}
 			if sanity && d.index > d.windowEnd {
 				panic("index > windowEnd")
@@ -368,12 +422,12 @@ Loop:
 					}
 					d.tokens.n = 0
 				}
-				break Loop
+				return
 			}
 		}
 		if d.index < d.maxInsertIndex {
 			// Update the hash
-			d.hash = d.hasher(d.window[d.index:d.index+minMatchLength]) & hashMask
+			d.hash = oldHash(d.window[d.index:d.index+minMatchLength]) & hashMask
 			ch := d.hashHead[d.hash]
 			d.chainHead = int(ch)
 			d.hashPrev[d.index&windowMask] = ch
@@ -420,7 +474,7 @@ Loop:
 				dstSize := len(tocheck) - minMatchLength + 1
 				if dstSize > 0 {
 					dst := d.hashMatch[:dstSize]
-					d.bulkHasher(tocheck, dst)
+					oldBulkHash(tocheck, dst)
 					var newH hash
 					for i, val := range dst {
 						di := i + startindex
@@ -439,7 +493,7 @@ Loop:
 				// item into the table.
 				d.index += d.length
 				if d.index < d.maxInsertIndex {
-					d.hash = d.hasher(d.window[d.index:d.index+minMatchLength]) & hashMask
+					d.hash = oldHash(d.window[d.index:d.index+minMatchLength]) & hashMask
 				}
 			}
 			if d.tokens.n == maxFlateBlockTokens {
@@ -484,7 +538,7 @@ func (d *compressor) deflateLazy() {
 
 	d.maxInsertIndex = d.windowEnd - (minMatchLength - 1)
 	if d.index < d.maxInsertIndex {
-		d.hash = d.hasher(d.window[d.index:d.index+minMatchLength]) & hashMask
+		d.hash = oldHash(d.window[d.index:d.index+minMatchLength]) & hashMask
 	}
 
 	for {
@@ -518,7 +572,7 @@ func (d *compressor) deflateLazy() {
 		}
 		if d.index < d.maxInsertIndex {
 			// Update the hash
-			d.hash = d.hasher(d.window[d.index:d.index+minMatchLength]) & hashMask
+			d.hash = oldHash(d.window[d.index:d.index+minMatchLength]) & hashMask
 			ch := d.hashHead[d.hash]
 			d.chainHead = int(ch)
 			d.hashPrev[d.index&windowMask] = ch
@@ -565,7 +619,323 @@ func (d *compressor) deflateLazy() {
 			dstSize := len(tocheck) - minMatchLength + 1
 			if dstSize > 0 {
 				dst := d.hashMatch[:dstSize]
-				d.bulkHasher(tocheck, dst)
+				oldBulkHash(tocheck, dst)
+				var newH hash
+				for i, val := range dst {
+					di := i + startindex
+					newH = val & hashMask
+					// Get previous value with the same hash.
+					// Our chain should point to the previous value.
+					d.hashPrev[di&windowMask] = d.hashHead[newH]
+					// Set the head of the hash chain to us.
+					d.hashHead[newH] = hashid(di + d.hashOffset)
+				}
+				d.hash = newH
+			}
+
+			d.index = newIndex
+			d.byteAvailable = false
+			d.length = minMatchLength - 1
+			if d.tokens.n == maxFlateBlockTokens {
+				// The block includes the current character
+				if d.err = d.writeBlock(d.tokens, d.index, false); d.err != nil {
+					return
+				}
+				d.tokens.n = 0
+			}
+		} else {
+			// Reset, if we got a match this run.
+			if d.length >= minMatchLength {
+				d.ii = 0
+			}
+			// We have a byte waiting. Emit it.
+			if d.byteAvailable {
+				d.ii++
+				d.tokens.tokens[d.tokens.n] = literalToken(uint32(d.window[d.index-1]))
+				d.tokens.n++
+				if d.tokens.n == maxFlateBlockTokens {
+					if d.err = d.writeBlock(d.tokens, d.index, false); d.err != nil {
+						return
+					}
+					d.tokens.n = 0
+				}
+				d.index++
+
+				// If we have a long run of no matches, skip additional bytes
+				// Resets when d.ii overflows after 64KB.
+				if d.ii > 31 {
+					n := int(d.ii >> 6)
+					for j := 0; j < n; j++ {
+						if d.index >= d.windowEnd-1 {
+							break
+						}
+
+						d.tokens.tokens[d.tokens.n] = literalToken(uint32(d.window[d.index-1]))
+						d.tokens.n++
+						if d.tokens.n == maxFlateBlockTokens {
+							if d.err = d.writeBlock(d.tokens, d.index, false); d.err != nil {
+								return
+							}
+							d.tokens.n = 0
+						}
+						d.index++
+					}
+					// Flush last byte
+					d.tokens.tokens[d.tokens.n] = literalToken(uint32(d.window[d.index-1]))
+					d.tokens.n++
+					d.byteAvailable = false
+					// d.length = minMatchLength - 1 // not needed, since d.ii is reset above, so it should never be > minMatchLength
+					if d.tokens.n == maxFlateBlockTokens {
+						if d.err = d.writeBlock(d.tokens, d.index, false); d.err != nil {
+							return
+						}
+						d.tokens.n = 0
+					}
+				}
+			} else {
+				d.index++
+				d.byteAvailable = true
+			}
+		}
+	}
+}
+
+// Assumes that d.fastSkipHashing != skipNever,
+// otherwise use deflateNoSkip
+func (d *compressor) deflateSSE() {
+
+	// Sanity enables additional runtime tests.
+	// It's intended to be used during development
+	// to supplement the currently ad-hoc unit tests.
+	const sanity = false
+
+	if d.windowEnd-d.index < minMatchLength+maxMatchLength && !d.sync {
+		return
+	}
+
+	d.maxInsertIndex = d.windowEnd - (minMatchLength - 1)
+	if d.index < d.maxInsertIndex {
+		d.hash = oldHash(d.window[d.index:d.index+minMatchLength]) & hashMask
+	}
+
+	for {
+		if sanity && d.index > d.windowEnd {
+			panic("index > windowEnd")
+		}
+		lookahead := d.windowEnd - d.index
+		if lookahead < minMatchLength+maxMatchLength {
+			if !d.sync {
+				return
+			}
+			if sanity && d.index > d.windowEnd {
+				panic("index > windowEnd")
+			}
+			if lookahead == 0 {
+				if d.tokens.n > 0 {
+					if d.err = d.writeBlock(d.tokens, d.index, false); d.err != nil {
+						return
+					}
+					d.tokens.n = 0
+				}
+				return
+			}
+		}
+		if d.index < d.maxInsertIndex {
+			// Update the hash
+			d.hash = crc32sse(d.window[d.index:d.index+minMatchLength]) & hashMask
+			ch := d.hashHead[d.hash]
+			d.chainHead = int(ch)
+			d.hashPrev[d.index&windowMask] = ch
+			d.hashHead[d.hash] = hashid(d.index + d.hashOffset)
+		}
+		d.length = minMatchLength - 1
+		d.offset = 0
+		minIndex := d.index - windowSize
+		if minIndex < 0 {
+			minIndex = 0
+		}
+
+		if d.chainHead-d.hashOffset >= minIndex && lookahead > minMatchLength-1 {
+			if newLength, newOffset, ok := d.findMatchSSE(d.index, d.chainHead-d.hashOffset, minMatchLength-1, lookahead); ok {
+				d.length = newLength
+				d.offset = newOffset
+			}
+		}
+		if d.length >= minMatchLength {
+			d.ii = 0
+			// There was a match at the previous step, and the current match is
+			// not better. Output the previous match.
+			// "d.length-3" should NOT be "d.length-minMatchLength", since the format always assume 3
+			d.tokens.tokens[d.tokens.n] = matchToken(uint32(d.length-3), uint32(d.offset-minOffsetSize))
+			d.tokens.n++
+			// Insert in the hash table all strings up to the end of the match.
+			// index and index-1 are already inserted. If there is not enough
+			// lookahead, the last two strings are not inserted into the hash
+			// table.
+			if d.length <= d.fastSkipHashing {
+				var newIndex int
+				newIndex = d.index + d.length
+				// Calculate missing hashes
+				end := newIndex
+				if end > d.maxInsertIndex {
+					end = d.maxInsertIndex
+				}
+				end += minMatchLength - 1
+				startindex := d.index + 1
+				if startindex > d.maxInsertIndex {
+					startindex = d.maxInsertIndex
+				}
+				tocheck := d.window[startindex:end]
+				dstSize := len(tocheck) - minMatchLength + 1
+				if dstSize > 0 {
+					dst := d.hashMatch[:dstSize]
+
+					crc32sseAll(tocheck, dst)
+					var newH hash
+					for i, val := range dst {
+						di := i + startindex
+						newH = val & hashMask
+						// Get previous value with the same hash.
+						// Our chain should point to the previous value.
+						d.hashPrev[di&windowMask] = d.hashHead[newH]
+						// Set the head of the hash chain to us.
+						d.hashHead[newH] = hashid(di + d.hashOffset)
+					}
+					d.hash = newH
+				}
+				d.index = newIndex
+			} else {
+				// For matches this long, we don't bother inserting each individual
+				// item into the table.
+				d.index += d.length
+				if d.index < d.maxInsertIndex {
+					d.hash = crc32sse(d.window[d.index:d.index+minMatchLength]) & hashMask
+				}
+			}
+			if d.tokens.n == maxFlateBlockTokens {
+				// The block includes the current character
+				if d.err = d.writeBlock(d.tokens, d.index, false); d.err != nil {
+					return
+				}
+				d.tokens.n = 0
+			}
+		} else {
+			d.ii++
+			end := d.index + int(d.ii>>uint(d.fastSkipHashing)) + 1
+			if end > d.windowEnd {
+				end = d.windowEnd
+			}
+			for i := d.index; i < end; i++ {
+				d.tokens.tokens[d.tokens.n] = literalToken(uint32(d.window[i]))
+				d.tokens.n++
+				if d.tokens.n == maxFlateBlockTokens {
+					if d.err = d.writeBlock(d.tokens, i+1, false); d.err != nil {
+						return
+					}
+					d.tokens.n = 0
+				}
+			}
+			d.index = end
+		}
+	}
+}
+
+// deflateLazy is the same as deflate, but with d.fastSkipHashing == skipNever,
+// meaning it always has lazy matching on.
+func (d *compressor) deflateLazySSE() {
+	// Sanity enables additional runtime tests.
+	// It's intended to be used during development
+	// to supplement the currently ad-hoc unit tests.
+	const sanity = false
+
+	if d.windowEnd-d.index < minMatchLength+maxMatchLength && !d.sync {
+		return
+	}
+
+	d.maxInsertIndex = d.windowEnd - (minMatchLength - 1)
+	if d.index < d.maxInsertIndex {
+		d.hash = crc32sse(d.window[d.index:d.index+minMatchLength]) & hashMask
+	}
+
+	for {
+		if sanity && d.index > d.windowEnd {
+			panic("index > windowEnd")
+		}
+		lookahead := d.windowEnd - d.index
+		if lookahead < minMatchLength+maxMatchLength {
+			if !d.sync {
+				return
+			}
+			if sanity && d.index > d.windowEnd {
+				panic("index > windowEnd")
+			}
+			if lookahead == 0 {
+				// Flush current output block if any.
+				if d.byteAvailable {
+					// There is still one pending token that needs to be flushed
+					d.tokens.tokens[d.tokens.n] = literalToken(uint32(d.window[d.index-1]))
+					d.tokens.n++
+					d.byteAvailable = false
+				}
+				if d.tokens.n > 0 {
+					if d.err = d.writeBlock(d.tokens, d.index, false); d.err != nil {
+						return
+					}
+					d.tokens.n = 0
+				}
+				return
+			}
+		}
+		if d.index < d.maxInsertIndex {
+			// Update the hash
+			d.hash = crc32sse(d.window[d.index:d.index+minMatchLength]) & hashMask
+			ch := d.hashHead[d.hash]
+			d.chainHead = int(ch)
+			d.hashPrev[d.index&windowMask] = ch
+			d.hashHead[d.hash] = hashid(d.index + d.hashOffset)
+		}
+		prevLength := d.length
+		prevOffset := d.offset
+		d.length = minMatchLength - 1
+		d.offset = 0
+		minIndex := d.index - windowSize
+		if minIndex < 0 {
+			minIndex = 0
+		}
+
+		if d.chainHead-d.hashOffset >= minIndex && lookahead > prevLength && prevLength < d.lazy {
+			if newLength, newOffset, ok := d.findMatchSSE(d.index, d.chainHead-d.hashOffset, minMatchLength-1, lookahead); ok {
+				d.length = newLength
+				d.offset = newOffset
+			}
+		}
+		if prevLength >= minMatchLength && d.length <= prevLength {
+			// There was a match at the previous step, and the current match is
+			// not better. Output the previous match.
+			d.tokens.tokens[d.tokens.n] = matchToken(uint32(prevLength-3), uint32(prevOffset-minOffsetSize))
+			d.tokens.n++
+
+			// Insert in the hash table all strings up to the end of the match.
+			// index and index-1 are already inserted. If there is not enough
+			// lookahead, the last two strings are not inserted into the hash
+			// table.
+			var newIndex int
+			newIndex = d.index + prevLength - 1
+			// Calculate missing hashes
+			end := newIndex
+			if end > d.maxInsertIndex {
+				end = d.maxInsertIndex
+			}
+			end += minMatchLength - 1
+			startindex := d.index + 1
+			if startindex > d.maxInsertIndex {
+				startindex = d.maxInsertIndex
+			}
+			tocheck := d.window[startindex:end]
+			dstSize := len(tocheck) - minMatchLength + 1
+			if dstSize > 0 {
+				dst := d.hashMatch[:dstSize]
+				crc32sseAll(tocheck, dst)
 				var newH hash
 				for i, val := range dst {
 					di := i + startindex
@@ -758,9 +1128,18 @@ func (d *compressor) init(w io.Writer, level int) (err error) {
 		d.initDeflate()
 		d.fill = (*compressor).fillDeflate
 		if d.fastSkipHashing == skipNever {
-			d.step = (*compressor).deflateLazy
+			if useSSE42 {
+				d.step = (*compressor).deflateLazySSE
+			} else {
+				d.step = (*compressor).deflateLazy
+			}
 		} else {
-			d.step = (*compressor).deflate
+			if useSSE42 {
+				d.step = (*compressor).deflateSSE
+			} else {
+				d.step = (*compressor).deflate
+
+			}
 		}
 	default:
 		return fmt.Errorf("flate: invalid compression level %d: want value in range [-2, 9]", level)

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -67,9 +67,7 @@ type compressor struct {
 	compressionLevel
 
 	w          *huffmanBitWriter
-	hasher     func([]byte) hash
 	bulkHasher func([]byte, []hash)
-	matcher    func(a, b []byte, max int) int
 
 	// compression algorithm
 	fill func(*compressor, []byte) int // copy data to window
@@ -375,13 +373,9 @@ func (d *compressor) initDeflate() {
 	d.index = 0
 	d.hash = 0
 	d.chainHead = -1
-	d.hasher = oldHash
 	d.bulkHasher = oldBulkHash
-	d.matcher = matchLen
 	if useSSE42 {
-		d.hasher = crc32sse
 		d.bulkHasher = crc32sseAll
-		d.matcher = matchLenSSE4
 	}
 }
 

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -537,9 +537,7 @@ func TestWriterReset(t *testing.T) {
 		// DeepEqual doesn't compare functions.
 		w.d.fill, wref.d.fill = nil, nil
 		w.d.step, wref.d.step = nil, nil
-		w.d.hasher, wref.d.hasher = nil, nil
 		w.d.bulkHasher, wref.d.bulkHasher = nil, nil
-		w.d.matcher, wref.d.matcher = nil, nil
 		// hashMatch is always overwritten when used.
 		copy(w.d.hashMatch[:], wref.d.hashMatch[:])
 		if w.d.tokens.n != 0 {


### PR DESCRIPTION
3-5% on no assembly. 1-3% with assembly.
```
benchmark                              old ns/op     new ns/op     delta
BenchmarkEncodeDigitsDefault1e4-8      392822        385422        -1.88%
BenchmarkEncodeDigitsDefault1e5-8      5360306       5160295       -3.73%
BenchmarkEncodeDigitsDefault1e6-8      56553235      54469783      -3.68%
BenchmarkEncodeDigitsCompress1e4-8     387022        383421        -0.93%
BenchmarkEncodeDigitsCompress1e5-8     5310303       5143627       -3.14%
BenchmarkEncodeDigitsCompress1e6-8     55203155      55003143      -0.36%
BenchmarkEncodeTwainDefault1e4-8       431358        427024        -1.00%
BenchmarkEncodeTwainDefault1e5-8       5910338       5837000       -1.24%
BenchmarkEncodeTwainDefault1e6-8       61903540      61103495      -1.29%
BenchmarkEncodeTwainCompress1e4-8      432358        432358        +0.00%
BenchmarkEncodeTwainCompress1e5-8      6455369       6410366       -0.70%
BenchmarkEncodeTwainCompress1e6-8      69703990      68453915      -1.79%
```
No assembly:
```
benchmark                              old ns/op     new ns/op     delta
BenchmarkEncodeDigitsDefault1e4-8      497361        471693        -5.16%
BenchmarkEncodeDigitsDefault1e5-8      8640494       8330476       -3.59%
BenchmarkEncodeDigitsDefault1e6-8      94255390      91855255      -2.55%
BenchmarkEncodeDigitsCompress1e4-8     493028        470360        -4.60%
BenchmarkEncodeDigitsCompress1e5-8     8640494       8330476       -3.59%
BenchmarkEncodeDigitsCompress1e6-8     95105440      90905200      -4.42%
BenchmarkEncodeTwainDefault1e4-8       538697        513029        -4.76%
BenchmarkEncodeTwainDefault1e5-8       8535488       8270473       -3.10%
BenchmarkEncodeTwainDefault1e6-8       90505175      87855025      -2.93%
BenchmarkEncodeTwainCompress1e4-8      547031        519696        -5.00%
BenchmarkEncodeTwainCompress1e5-8      9820562       9325533       -5.04%
BenchmarkEncodeTwainCompress1e6-8      104805990     100805770     -3.82%
```
It is a lot of duplicated code, though.