### PR TITLE
Convert switch block to if block

### DIFF
--- a/flate/token.go
+++ b/flate/token.go
@@ -95,13 +95,11 @@ func lengthCode(len uint32) uint32 { return lengthCodes[len] }
 
 // Returns the offset code corresponding to a specific offset
 func offsetCode(off uint32) uint32 {
-	const n = uint32(len(offsetCodes))
-	switch {
-	case off < n:
+	if off < uint32(len(offsetCodes)) {
 		return offsetCodes[off]
-	case off>>7 < n:
+	} else if off>>7 < uint32(len(offsetCodes)) {
 		return offsetCodes[off>>7] + 14
-	default:
+	} else {
 		return offsetCodes[off>>14] + 28
 	}
 }


### PR DESCRIPTION
Switch statements cannot be inlined. If statements can. Reference:
	golang/go#7655
	golang/go#13071

```
BenchmarkEncodeDigitsSpeed1e4-4        52.22        53.77        1.03x
BenchmarkEncodeDigitsSpeed1e5-4        55.01        57.05        1.04x
BenchmarkEncodeDigitsSpeed1e6-4        54.36        57.03        1.05x
BenchmarkEncodeDigitsDefault1e4-4      20.33        20.38        1.00x
BenchmarkEncodeDigitsDefault1e5-4      11.65        11.71        1.01x
BenchmarkEncodeDigitsDefault1e6-4      10.68        10.78        1.01x
BenchmarkEncodeDigitsCompress1e4-4     20.38        20.77        1.02x
BenchmarkEncodeDigitsCompress1e5-4     11.65        11.85        1.02x
BenchmarkEncodeDigitsCompress1e6-4     10.76        10.97        1.02x
BenchmarkEncodeTwainSpeed1e4-4         46.40        47.77        1.03x
BenchmarkEncodeTwainSpeed1e5-4         57.42        59.34        1.03x
BenchmarkEncodeTwainSpeed1e6-4         58.72        61.09        1.04x
BenchmarkEncodeTwainDefault1e4-4       18.69        18.91        1.01x
BenchmarkEncodeTwainDefault1e5-4       11.64        11.85        1.02x
BenchmarkEncodeTwainDefault1e6-4       10.87        10.87        1.00x
BenchmarkEncodeTwainCompress1e4-4      18.61        18.81        1.01x
BenchmarkEncodeTwainCompress1e5-4      10.34        10.50        1.02x
BenchmarkEncodeTwainCompress1e6-4      9.58         9.69         1.01x
```