### PR TITLE
Make histogram function faster

### DIFF
--- a/flate/crc32_amd64.s
+++ b/flate/crc32_amd64.s
@@ -150,17 +150,59 @@ TEXT ·histogram(SB), 7, $0
     MOVQ    b+0(FP),SI                  // SI: &b
     MOVQ    b_len+8(FP),R9              // R9: len(b)
     MOVQ    h+24(FP), DI                // DI: Histogram
+    MOVQ    R9, R8
+    SHRQ    $3, R8
+    JZ      hist1
+    XORQ    R11, R11
+
+loop_hist8:
+    MOVQ    (SI), R10
+
+    MOVB    R10, R11
+    INCL    (DI)(R11*4)
+    SHRQ    $8, R10
+
+    MOVB    R10, R11
+    INCL    (DI)(R11*4)
+    SHRQ    $8, R10
+
+    MOVB    R10, R11
+    INCL    (DI)(R11*4)
+    SHRQ    $8, R10
+
+    MOVB    R10, R11
+    INCL    (DI)(R11*4)
+    SHRQ    $8, R10
+
+    MOVB    R10, R11
+    INCL    (DI)(R11*4)
+    SHRQ    $8, R10
+
+    MOVB    R10, R11
+    INCL    (DI)(R11*4)
+    SHRQ    $8, R10
+
+    MOVB    R10, R11
+    INCL    (DI)(R11*4)
+    SHRQ    $8, R10
+
+    INCL    (DI)(R10*4)
+
+    ADDQ    $8, SI
+    DECQ    R8
+    JNZ     loop_hist8
+
+hist1:
+    ANDQ    $7, R9
+    JZ      end_hist
     XORQ    R10, R10
-    TESTQ   R9, R9
-    JZ end_hist
 
-loop_hist:
+loop_hist1:
     MOVB    (SI), R10
-    ADDL    $1, (DI)(R10*4)
-
-    ADDQ    $1, SI
-    SUBQ    $1, R9
-    JNZ     loop_hist
+    INCL    (DI)(R10*4)
+    INCQ    SI
+    DECQ    R9
+    JNZ     loop_hist1
 
 end_hist:
     RET


### PR DESCRIPTION
Not sure if it is worth it.

Benchstat results:

Intel(R) Core(TM) i3-4150 CPU @ 3.50GHz:

```
name                       old time/op    new time/op    delta
EncodeDigitsConstant1e4-4    49.6µs ± 2%    48.8µs ± 1%  -1.80%  (p=0.008 n=5+5)
EncodeDigitsConstant1e5-4     467µs ± 1%     460µs ± 1%    ~     (p=0.056 n=5+5)
EncodeDigitsConstant1e6-4    4.67ms ± 0%    4.61ms ± 1%  -1.45%  (p=0.008 n=5+5)
EncodeDigitsSpeed1e4-4        182µs ± 0%     182µs ± 0%    ~     (p=0.841 n=5+5)
EncodeDigitsSpeed1e5-4       1.67ms ± 1%    1.68ms ± 1%    ~     (p=0.222 n=5+5)
EncodeDigitsSpeed1e6-4       16.8ms ± 3%    16.6ms ± 1%    ~     (p=0.421 n=5+5)
EncodeDigitsDefault1e4-4      364µs ± 0%     364µs ± 0%    ~     (p=1.000 n=5+5)
EncodeDigitsDefault1e5-4     5.04ms ± 1%    5.03ms ± 1%    ~     (p=0.841 n=5+5)
EncodeDigitsDefault1e6-4     53.1ms ± 0%    53.2ms ± 1%    ~     (p=0.421 n=5+5)
EncodeDigitsCompress1e4-4     363µs ± 1%     363µs ± 1%    ~     (p=0.690 n=5+5)
EncodeDigitsCompress1e5-4    4.98ms ± 1%    4.99ms ± 1%    ~     (p=0.690 n=5+5)
EncodeDigitsCompress1e6-4    52.6ms ± 1%    52.9ms ± 2%    ~     (p=0.548 n=5+5)
EncodeTwainConstant1e4-4     71.9µs ± 0%    70.5µs ± 0%  -1.94%  (p=0.008 n=5+5)
EncodeTwainConstant1e5-4      546µs ± 0%     535µs ± 0%  -2.00%  (p=0.016 n=4+5)
EncodeTwainConstant1e6-4     5.41ms ± 0%    5.31ms ± 0%  -1.86%  (p=0.016 n=4+5)
EncodeTwainSpeed1e4-4         204µs ± 0%     204µs ± 0%  +0.36%  (p=0.032 n=5+5)
EncodeTwainSpeed1e5-4        1.59ms ± 0%    1.60ms ± 0%    ~     (p=0.548 n=5+5)
EncodeTwainSpeed1e6-4        15.6ms ± 0%    15.6ms ± 0%    ~     (p=0.548 n=5+5)
EncodeTwainDefault1e4-4       408µs ± 0%     409µs ± 1%    ~     (p=1.000 n=5+5)
EncodeTwainDefault1e5-4      5.79ms ± 2%    5.76ms ± 1%    ~     (p=0.690 n=5+5)
EncodeTwainDefault1e6-4      60.9ms ± 2%    60.6ms ± 1%    ~     (p=0.841 n=5+5)
EncodeTwainCompress1e4-4      413µs ± 1%     412µs ± 1%    ~     (p=0.841 n=5+5)
EncodeTwainCompress1e5-4     6.31ms ± 1%    6.35ms ± 1%    ~     (p=0.421 n=5+5)
EncodeTwainCompress1e6-4     68.0ms ± 1%    68.4ms ± 2%    ~     (p=0.421 n=5+5)

name                       old speed      new speed      delta
EncodeDigitsConstant1e4-4   201MB/s ± 2%   205MB/s ± 1%  +1.83%  (p=0.008 n=5+5)
EncodeDigitsConstant1e5-4   214MB/s ± 1%   217MB/s ± 1%    ~     (p=0.056 n=5+5)
EncodeDigitsConstant1e6-4   214MB/s ± 0%   217MB/s ± 1%  +1.48%  (p=0.008 n=5+5)
EncodeDigitsSpeed1e4-4     55.0MB/s ± 0%  54.9MB/s ± 0%    ~     (p=0.802 n=5+5)
EncodeDigitsSpeed1e5-4     59.8MB/s ± 1%  59.6MB/s ± 1%    ~     (p=0.222 n=5+5)
EncodeDigitsSpeed1e6-4     59.7MB/s ± 3%  60.2MB/s ± 1%    ~     (p=0.341 n=5+5)
EncodeDigitsDefault1e4-4   27.4MB/s ± 0%  27.4MB/s ± 0%    ~     (p=0.952 n=5+5)
EncodeDigitsDefault1e5-4   19.8MB/s ± 1%  19.9MB/s ± 1%    ~     (p=0.889 n=5+5)
EncodeDigitsDefault1e6-4   18.8MB/s ± 0%  18.8MB/s ± 1%    ~     (p=0.460 n=5+5)
EncodeDigitsCompress1e4-4  27.6MB/s ± 1%  27.5MB/s ± 1%    ~     (p=0.690 n=5+5)
EncodeDigitsCompress1e5-4  20.1MB/s ± 1%  20.1MB/s ± 1%    ~     (p=0.643 n=5+5)
EncodeDigitsCompress1e6-4  19.0MB/s ± 0%  18.9MB/s ± 2%    ~     (p=0.500 n=5+5)
EncodeTwainConstant1e4-4    139MB/s ± 0%   142MB/s ± 0%  +1.98%  (p=0.008 n=5+5)
EncodeTwainConstant1e5-4    183MB/s ± 0%   187MB/s ± 0%  +2.05%  (p=0.016 n=4+5)
EncodeTwainConstant1e6-4    185MB/s ± 0%   188MB/s ± 0%  +1.90%  (p=0.016 n=4+5)
EncodeTwainSpeed1e4-4      49.1MB/s ± 0%  48.9MB/s ± 0%  -0.36%  (p=0.024 n=5+5)
EncodeTwainSpeed1e5-4      62.7MB/s ± 0%  62.7MB/s ± 0%    ~     (p=0.548 n=5+5)
EncodeTwainSpeed1e6-4      64.0MB/s ± 0%  64.1MB/s ± 0%    ~     (p=0.460 n=5+5)
EncodeTwainDefault1e4-4    24.5MB/s ± 0%  24.4MB/s ± 1%    ~     (p=0.913 n=5+5)
EncodeTwainDefault1e5-4    17.3MB/s ± 2%  17.4MB/s ± 1%    ~     (p=0.690 n=5+5)
EncodeTwainDefault1e6-4    16.4MB/s ± 2%  16.5MB/s ± 1%    ~     (p=0.794 n=5+5)
EncodeTwainCompress1e4-4   24.2MB/s ± 1%  24.3MB/s ± 1%    ~     (p=0.841 n=5+5)
EncodeTwainCompress1e5-4   15.8MB/s ± 1%  15.7MB/s ± 1%    ~     (p=0.333 n=5+5)
EncodeTwainCompress1e6-4   14.7MB/s ± 1%  14.6MB/s ± 2%    ~     (p=0.389 n=5+5)
```

Intel(R) Core(TM) i5-2400 CPU @ 3.10GHz:

```
name                       old time/op    new time/op    delta
EncodeDigitsConstant1e4-4    64.9µs ± 0%    64.5µs ± 0%  -0.58%  (p=0.008 n=5+5)
EncodeDigitsConstant1e5-4     610µs ± 0%     609µs ± 0%  -0.28%  (p=0.008 n=5+5)
EncodeDigitsConstant1e6-4    6.12ms ± 0%    6.11ms ± 0%    ~     (p=0.056 n=5+5)
EncodeDigitsSpeed1e4-4        224µs ± 0%     224µs ± 0%    ~     (p=0.730 n=4+5)
EncodeDigitsSpeed1e5-4       2.11ms ± 0%    2.11ms ± 0%    ~     (p=1.000 n=5+5)
EncodeDigitsSpeed1e6-4       21.0ms ± 0%    21.0ms ± 0%    ~     (p=0.841 n=5+5)
EncodeDigitsDefault1e4-4      439µs ± 0%     439µs ± 0%    ~     (p=0.690 n=5+5)
EncodeDigitsDefault1e5-4     6.01ms ± 1%    6.00ms ± 1%    ~     (p=0.690 n=5+5)
EncodeDigitsDefault1e6-4     63.2ms ± 0%    63.1ms ± 1%    ~     (p=0.548 n=5+5)
EncodeDigitsCompress1e4-4     440µs ± 0%     439µs ± 0%    ~     (p=0.548 n=5+5)
EncodeDigitsCompress1e5-4    6.00ms ± 1%    5.97ms ± 0%    ~     (p=0.151 n=5+5)
EncodeDigitsCompress1e6-4    63.1ms ± 1%    62.9ms ± 0%    ~     (p=0.548 n=5+5)
EncodeTwainConstant1e4-4     93.0µs ± 1%    91.8µs ± 0%  -1.31%  (p=0.008 n=5+5)
EncodeTwainConstant1e5-4      701µs ± 0%     693µs ± 0%  -1.15%  (p=0.008 n=5+5)
EncodeTwainConstant1e6-4     6.96ms ± 0%    6.91ms ± 1%  -0.74%  (p=0.008 n=5+5)
EncodeTwainSpeed1e4-4         248µs ± 0%     248µs ± 0%  +0.17%  (p=0.016 n=4+5)
EncodeTwainSpeed1e5-4        2.00ms ± 0%    2.00ms ± 0%    ~     (p=0.421 n=5+5)
EncodeTwainSpeed1e6-4        19.5ms ± 0%    19.5ms ± 0%    ~     (p=0.095 n=5+5)
EncodeTwainDefault1e4-4       491µs ± 0%     491µs ± 0%    ~     (p=1.000 n=5+5)
EncodeTwainDefault1e5-4      6.86ms ± 2%    6.81ms ± 1%    ~     (p=0.548 n=5+5)
EncodeTwainDefault1e6-4      71.7ms ± 1%    71.7ms ± 0%    ~     (p=1.000 n=5+5)
EncodeTwainCompress1e4-4      496µs ± 0%     496µs ± 0%    ~     (p=0.841 n=5+5)
EncodeTwainCompress1e5-4     7.55ms ± 3%    7.51ms ± 1%    ~     (p=1.000 n=5+5)
EncodeTwainCompress1e6-4     80.7ms ± 1%    80.7ms ± 1%    ~     (p=0.841 n=5+5)

name                       old speed      new speed      delta
EncodeDigitsConstant1e4-4   154MB/s ± 0%   155MB/s ± 0%  +0.59%  (p=0.008 n=5+5)
EncodeDigitsConstant1e5-4   164MB/s ± 0%   164MB/s ± 0%  +0.28%  (p=0.008 n=5+5)
EncodeDigitsConstant1e6-4   163MB/s ± 0%   164MB/s ± 0%    ~     (p=0.056 n=5+5)
EncodeDigitsSpeed1e4-4     44.5MB/s ± 0%  44.6MB/s ± 0%    ~     (p=0.667 n=4+5)
EncodeDigitsSpeed1e5-4     47.3MB/s ± 0%  47.3MB/s ± 0%    ~     (p=1.000 n=5+5)
EncodeDigitsSpeed1e6-4     47.7MB/s ± 0%  47.6MB/s ± 0%    ~     (p=0.841 n=5+5)
EncodeDigitsDefault1e4-4   22.8MB/s ± 0%  22.8MB/s ± 0%    ~     (p=0.905 n=5+5)
EncodeDigitsDefault1e5-4   16.6MB/s ± 1%  16.7MB/s ± 1%    ~     (p=0.563 n=5+5)
EncodeDigitsDefault1e6-4   15.8MB/s ± 0%  15.8MB/s ± 1%    ~     (p=0.500 n=5+5)
EncodeDigitsCompress1e4-4  22.7MB/s ± 0%  22.8MB/s ± 0%    ~     (p=0.524 n=5+5)
EncodeDigitsCompress1e5-4  16.7MB/s ± 1%  16.7MB/s ± 0%    ~     (p=0.119 n=5+5)
EncodeDigitsCompress1e6-4  15.9MB/s ± 1%  15.9MB/s ± 0%    ~     (p=0.595 n=5+5)
EncodeTwainConstant1e4-4    108MB/s ± 1%   109MB/s ± 0%  +1.33%  (p=0.008 n=5+5)
EncodeTwainConstant1e5-4    143MB/s ± 0%   144MB/s ± 0%  +1.16%  (p=0.008 n=5+5)
EncodeTwainConstant1e6-4    144MB/s ± 0%   145MB/s ± 1%  +0.75%  (p=0.008 n=5+5)
EncodeTwainSpeed1e4-4      40.4MB/s ± 0%  40.3MB/s ± 0%  -0.16%  (p=0.016 n=4+5)
EncodeTwainSpeed1e5-4      50.1MB/s ± 0%  50.0MB/s ± 0%    ~     (p=0.333 n=5+5)
EncodeTwainSpeed1e6-4      51.3MB/s ± 0%  51.2MB/s ± 0%    ~     (p=0.111 n=5+5)
EncodeTwainDefault1e4-4    20.4MB/s ± 0%  20.4MB/s ± 0%    ~     (p=0.754 n=5+5)
EncodeTwainDefault1e5-4    14.6MB/s ± 2%  14.7MB/s ± 1%    ~     (p=0.452 n=5+5)
EncodeTwainDefault1e6-4    13.9MB/s ± 1%  14.0MB/s ± 0%    ~     (p=1.000 n=5+5)
EncodeTwainCompress1e4-4   20.2MB/s ± 0%  20.2MB/s ± 0%    ~     (p=0.825 n=5+5)
EncodeTwainCompress1e5-4   13.3MB/s ± 3%  13.3MB/s ± 1%    ~     (p=1.000 n=5+5)
EncodeTwainCompress1e6-4   12.4MB/s ± 1%  12.4MB/s ± 1%    ~     (p=0.952 n=5+5)
```