### PR TITLE
Fix out of bounds read

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It offers slightly better compression at lower compression settings, and up to 3
 
 # changelog
 
+* Dec 8 2015: Fixed rare [one byte out-of bounds read](https://github.com/klauspost/compress/issues/20). Please update!
 * Nov 20 2015: Small optimization to bit writer on 64 bit systems.
 * Nov 17 2015: Fixed out-of-bound errors if the underlying Writer returned an error. See [#15](https://github.com/klauspost/compress/issues/15).
 * Nov 12 2015: Added [io.WriterTo](https://golang.org/pkg/io/#WriterTo) support to gzip/inflate.


### PR DESCRIPTION
When length was 7, an extra byte would be read from the input. In rare cases that would hit a page boundary when flushing and crash.

The test has been extended to increase the chance of detecting a situation like this.

Fixes #20