### PR TITLE
Rebalance compression levels.

### DIFF
--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -1094,7 +1094,7 @@ func (d *compressor) storeSnappy() {
 	if d.tokens.n == d.windowEnd {
 		d.err = d.writeStoredBlock(d.window[:d.windowEnd])
 		// If we removed less than 10 literals, huffman compress the block.
-	} else if d.tokens.n > d.windowEnd-10 {
+	} else if d.tokens.n > d.windowEnd-(d.windowEnd>>4) {
 		d.w.writeBlockHuff(false, d.window[:d.windowEnd])
 		d.err = d.w.err
 	} else {

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -14,7 +14,6 @@ import (
 const (
 	NoCompression       = 0
 	BestSpeed           = 1
-	fastCompression     = 3
 	BestCompression     = 9
 	DefaultCompression  = -1
 	ConstantCompression = -2 // Does only Huffman encoding
@@ -45,19 +44,24 @@ type compressionLevel struct {
 	good, lazy, nice, chain, fastSkipHashing, level int
 }
 
+// Compression levels have been rebalanced from zlib deflate defaults
+// to give a bigger spread in speed and compression.
+// See https://blog.klauspost.com/rebalancing-deflate-compression-levels/
 var levels = []compressionLevel{
 	{}, // 0
-	// For levels 1-3 we don't bother trying with lazy matches
-	{4, 0, 8, 4, 4, 1},
-	{4, 0, 16, 8, 5, 2},
-	{4, 0, 24, 24, 6, 3},
-	// Levels 4-9 use increasingly more lazy matching
+	// Level 1+2 uses snappy algorithm - values not used
+	{0, 0, 0, 0, 0, 1},
+	{0, 0, 0, 0, 0, 2},
+	// For levels 3-6 we don't bother trying with lazy matches.
+	// Lazy matching is at least 30% slower, with 1.5% increase.
+	{4, 0, 8, 4, 4, 3},
+	{4, 0, 12, 6, 5, 4},
+	{6, 0, 24, 16, 6, 5},
+	{8, 0, 32, 32, 7, 6},
+	// Levels 7-9 use increasingly more lazy matching
 	// and increasingly stringent conditions for "good enough".
-	{4, 4, 16, 16, skipNever, 4},
-	{8, 16, 32, 32, skipNever, 5},
-	{8, 16, 128, 128, skipNever, 6},
-	{8, 32, 128, 256, skipNever, 7},
-	{32, 128, 258, 1024, skipNever, 8},
+	{4, 8, 16, 16, skipNever, 7},
+	{6, 16, 32, 64, skipNever, 8},
 	{32, 258, 258, 4096, skipNever, 9},
 }
 
@@ -102,6 +106,7 @@ type compressor struct {
 	err            error
 	ii             uint16 // position of last match, intended to overflow to reset.
 
+	snap      snappyEnc
 	hashMatch [maxMatchLength + minMatchLength]hash
 }
 
@@ -189,7 +194,8 @@ func (d *compressor) writeBlockSkip(tok tokens, index int, eof bool) error {
 func (d *compressor) fillWindow(b []byte) {
 	// Do not fill window if we are in store-only mode,
 	// use constant or Snappy compression.
-	if d.compressionLevel.level == 0 {
+	switch d.compressionLevel.level {
+	case 0, 1, 2:
 		return
 	}
 	// If we are given too much, cut it.
@@ -1083,7 +1089,7 @@ func (d *compressor) storeSnappy() {
 	if d.windowEnd == 0 {
 		return
 	}
-	snappyEncode(&d.tokens, d.window[:d.windowEnd])
+	d.snap.Encode(&d.tokens, d.window[:d.windowEnd])
 	// If we made zero matches, store the block as is.
 	if d.tokens.n == d.windowEnd {
 		d.err = d.writeStoredBlock(d.window[:d.windowEnd])
@@ -1143,15 +1149,16 @@ func (d *compressor) init(w io.Writer, level int) (err error) {
 		d.window = make([]byte, maxStoreBlockSize)
 		d.fill = (*compressor).fillHuff
 		d.step = (*compressor).storeHuff
-	case level == 1:
+	case level >= 1 && level <= 3:
+		d.snap = newSnappy(level)
 		d.window = make([]byte, maxStoreBlockSize)
 		d.fill = (*compressor).fillHuff
 		d.step = (*compressor).storeSnappy
 		d.tokens.tokens = make([]token, maxStoreBlockSize+1)
 	case level == DefaultCompression:
-		level = 6
+		level = 5
 		fallthrough
-	case 2 <= level && level <= 9:
+	case 4 <= level && level <= 9:
 		d.compressionLevel = levels[level]
 		d.initDeflate()
 		d.fill = (*compressor).fillDeflate
@@ -1208,6 +1215,9 @@ func (d *compressor) reset(w io.Writer) {
 		d.ii = 0
 		d.maxInsertIndex = 0
 	}
+	if d.snap != nil {
+		d.snap.Reset()
+	}
 }
 
 func (d *compressor) close() error {
@@ -1228,10 +1238,10 @@ func (d *compressor) close() error {
 
 // NewWriter returns a new Writer compressing data at the given level.
 // Following zlib, levels range from 1 (BestSpeed) to 9 (BestCompression);
-// higher levels typically run slower but compress more. Level 0
-// (NoCompression) does not attempt any compression; it only adds the
-// necessary DEFLATE framing. Level -1 (DefaultCompression) uses the default
-// compression level.
+// higher levels typically run slower but compress more.
+// Level 0 (NoCompression) does not attempt any compression; it only adds the
+// necessary DEFLATE framing.
+// Level -1 (DefaultCompression) uses the default compression level.
 // Level -2 (ConstantCompression) will use Huffman compression only, giving
 // a very fast compression for all types of input, but sacrificing considerable
 // compression efficiency.

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -414,10 +414,6 @@ func (e *snappyGen) matchlen(s, t int, src []byte) int {
 
 // Reset the encoding table.
 func (e *snappyGen) Reset() {
-	for i := range e.table {
-		e.table[i] = 0
-	}
-	e.cur = 0
 	e.prev = nil
 }
 

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -23,25 +23,74 @@ func emitCopy(dst *tokens, offset, length int) {
 	dst.n++
 }
 
-// snappyEncode uses Snappy-like compression, but stores as Huffman
+type snappyEnc interface {
+	Encode(dst *tokens, src []byte)
+	Reset()
+}
+
+func newSnappy(level int) snappyEnc {
+	if useSSE42 {
+		e := &snappySSE4{}
+		switch level {
+		case 1:
+			e.enc = e.encodeL1
+		case 2:
+			e.enc = e.encodeL2
+		case 3:
+			e.enc = e.encodeL3
+		default:
+			panic("invalid level specified")
+		}
+		return e
+	}
+	e := &snappyGen{}
+	switch level {
+	case 1:
+		e.enc = e.encodeL1
+	case 2:
+		e.enc = e.encodeL2
+	case 3:
+		e.enc = e.encodeL3
+	default:
+		panic("invalid level specified")
+	}
+	return e
+}
+
+const tableBits = 14             // Bits used in the table
+const tableSize = 1 << tableBits // Size of the table
+
+// snappyGen maintains the table for matches,
+// and the previous byte block for level 2.
+// This is the generic implementation.
+type snappyGen struct {
+	table [tableSize]int64
+	block [maxStoreBlockSize]byte
+	prev  []byte
+	cur   int
+	enc   func(dst *tokens, src []byte)
+}
+
+func (e *snappyGen) Encode(dst *tokens, src []byte) {
+	e.enc(dst, src)
+}
+
+// EncodeL1 uses Snappy-like compression, but stores as Huffman
 // blocks.
-func snappyEncode(dst *tokens, src []byte) {
+func (e *snappyGen) encodeL1(dst *tokens, src []byte) {
 	// Return early if src is short.
 	if len(src) <= 4 {
 		if len(src) != 0 {
 			emitLiteral(dst, src)
 		}
+		e.cur += 4
 		return
 	}
 
-	// Initialize the hash table. Its size ranges from 1<<8 to 1<<14 inclusive.
-	const maxTableSize = 1 << 14
-	shift, tableSize := uint(32-8), 1<<8
-	for tableSize < maxTableSize && tableSize < len(src) {
-		shift--
-		tableSize *= 2
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 0
 	}
-	var table [maxTableSize]int
 
 	// Iterate over the source bytes.
 	var (
@@ -54,14 +103,17 @@ func snappyEncode(dst *tokens, src []byte) {
 		// Update the hash table.
 		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
 		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
-		p := &table[(h*0x1e35a7bd)>>shift]
+		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
 		// We need to to store values in [-1, inf) in table. To save
 		// some initialization time, (re)use the table's zero value
 		// and shift the values against this zero: add 1 on writes,
 		// subtract 1 on reads.
-		t, *p = *p-1, s+1
+		t, *p = int(*p)-1-e.cur, int64(s+1+e.cur)
+
+		offset := uint(s - t - 1)
+
 		// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-		if t < 0 || s-t >= maxOffset || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
+		if t < 0 || offset >= (maxOffset-1) || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
 			// Skip 1 byte for 16 consecutive missed.
 			s += 1 + ((s - lit) >> 4)
 			continue
@@ -93,4 +145,629 @@ func snappyEncode(dst *tokens, src []byte) {
 	if lit != len(src) {
 		emitLiteral(dst, src[lit:])
 	}
+	e.cur += len(src)
+}
+
+// EncodeL2 uses a similar algorithm to level 1, but is capable
+// of matching across blocks giving better compression at a small slowdown.
+func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
+	// Return early if src is short.
+	if len(src) <= 4 {
+		if len(src) != 0 {
+			emitLiteral(dst, src)
+		}
+		e.prev = nil
+		e.cur += len(src)
+		return
+	}
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 0
+	}
+
+	// Iterate over the source bytes.
+	var (
+		s   int // The iterator position.
+		t   int // The last position with the same hash as s.
+		lit int // The start position of any pending literal bytes.
+	)
+
+	for s+3 < len(src) {
+		// Update the hash table.
+		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
+		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
+		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
+		// We need to to store values in [-1, inf) in table. To save
+		// some initialization time, (re)use the table's zero value
+		// and shift the values against this zero: add 1 on writes,
+		// subtract 1 on reads.
+		t, *p = int(*p)-1-e.cur, int64(s+1+e.cur)
+
+		// If t is positive, the match starts in the current block
+		if t >= 0 {
+			offset := s - t
+			// Check that the offset is valid and that we match at least 4 bytes
+			if offset >= maxOffset || offset == 0 || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
+				// Skip 1 byte for 32 consecutive missed.
+				s += 1 + ((s - lit) >> 5)
+				continue
+			}
+			// Otherwise, we have a match. First, emit any pending literal bytes.
+			if lit != s {
+				emitLiteral(dst, src[lit:s])
+			}
+			// Extend the match to be as long as possible.
+			s0 := s
+			s1 := s + maxMatchLength
+			if s1 > len(src) {
+				s1 = len(src)
+			}
+			s, t = s+4, t+4
+			for s < s1 && src[s] == src[t] {
+				s++
+				t++
+			}
+			// Emit the copied bytes.
+			// inlined: emitCopy(dst, s-t, s-s0)
+			dst.tokens[dst.n] = matchToken(uint32(s-s0-3), uint32(s-t-minOffsetSize))
+			dst.n++
+			lit = s
+			continue
+		}
+		// We found a match in the previous block.
+		tp := len(e.prev) + t
+		if tp < 0 || t > -5 || s-t >= maxOffset || b0 != e.prev[tp] || b1 != e.prev[tp+1] || b2 != e.prev[tp+2] || b3 != e.prev[tp+3] {
+			// Skip 1 byte for 32 consecutive missed.
+			s += 1 + ((s - lit) >> 5)
+			continue
+		}
+		// Otherwise, we have a match. First, emit any pending literal bytes.
+		if lit != s {
+			emitLiteral(dst, src[lit:s])
+		}
+		// Extend the match to be as long as possible.
+		s0 := s
+		s1 := s + maxMatchLength
+		if s1 > len(src) {
+			s1 = len(src)
+		}
+		s, tp = s+4, tp+4
+		for s < s1 && src[s] == e.prev[tp] {
+			s++
+			tp++
+			if tp == len(e.prev) {
+				t = 0
+				// continue in current buffer
+				for s < s1 && src[s] == src[t] {
+					s++
+					t++
+				}
+				goto l
+			}
+		}
+	l:
+		// Emit the copied bytes.
+		// inlined: emitCopy(dst, s-t, s-s0)
+		if t < 0 {
+			t = tp - len(e.prev)
+		}
+		dst.tokens[dst.n] = matchToken(uint32(s-s0-3), uint32(s-t-minOffsetSize))
+		dst.n++
+		lit = s
+
+	}
+
+	// Emit any final pending literal bytes and return.
+	if lit != len(src) {
+		emitLiteral(dst, src[lit:])
+	}
+	e.cur += len(src)
+	// Store this block, if it was full length.
+	if len(src) == maxStoreBlockSize {
+		copy(e.block[:], src)
+		e.prev = e.block[:len(src)]
+	} else {
+		e.prev = nil
+	}
+}
+
+// EncodeL3 uses a similar algorithm to level 2, but is capable
+// will keep two matches per hash.
+// Both hashes are checked if the first isn't ok, and the longest is selected.
+func (e *snappyGen) encodeL3(dst *tokens, src []byte) {
+	// Return early if src is short.
+	if len(src) <= 4 {
+		if len(src) != 0 {
+			emitLiteral(dst, src)
+		}
+		e.prev = nil
+		e.cur += len(src)
+		return
+	}
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 0
+	}
+
+	// Iterate over the source bytes.
+	var (
+		s   int // The iterator position.
+		lit int // The start position of any pending literal bytes.
+	)
+
+	for s+3 < len(src) {
+		// Update the hash table.
+		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
+		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
+		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
+		tmp := *p
+		p1 := int(tmp & 0xffffffff) // Closest match position
+		p2 := int(tmp >> 32)        // Furthest match position
+
+		// We need to to store values in [-1, inf) in table. To save
+		// some initialization time, (re)use the table's zero value
+		// and shift the values against this zero: add 1 on writes,
+		// subtract 1 on reads.
+		t1 := int(p1) - 1 - e.cur
+
+		var l2 int
+		var t2 int
+		l1 := e.matchlen(s, t1, src, b0, b1, b2, b3)
+		// If fist match was ok, don't do the second.
+		if l1 < 24 {
+			t2 = int(p2) - 1 - e.cur
+			l2 = e.matchlen(s, t2, src, b0, b1, b2, b3)
+
+			// If both are short, continue
+			if l1 < 4 && l2 < 4 {
+				// Update hash table
+				*p = int64(s+1+e.cur) | (int64(p1) << 32)
+				//*p1, *p2 = s+1+e.cur, *p1
+				// Skip 1 byte for 32 consecutive missed.
+				s += 1 + ((s - lit) >> 5)
+				continue
+			}
+		}
+
+		// Otherwise, we have a match. First, emit any pending literal bytes.
+		if lit != s {
+			emitLiteral(dst, src[lit:s])
+		}
+		// Update hash table
+		*p = int64(s+1+e.cur) | (int64(p1) << 32)
+
+		// Store the longest match l1 will be closest, so we prefer that if equal length
+		if l1 >= l2 {
+			dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
+			s += l1
+		} else {
+			dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
+			s += l2
+		}
+		dst.n++
+		lit = s
+	}
+
+	// Emit any final pending literal bytes and return.
+	if lit != len(src) {
+		emitLiteral(dst, src[lit:])
+	}
+	e.cur += len(src)
+	// Store this block, if it was full length.
+	if len(src) == maxStoreBlockSize {
+		copy(e.block[:], src)
+		e.prev = e.block[:len(src)]
+	} else {
+		e.prev = nil
+	}
+}
+
+func (e *snappyGen) matchlen(s, t int, src []byte, b0, b1, b2, b3 byte) int {
+	// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
+	offset := s - t
+
+	// If we are inside the current block
+	if t >= 0 {
+		if offset >= maxOffset || offset <= 0 || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
+			return 0
+		}
+		// Extend the match to be as long as possible.
+		s0 := s
+		s1 := s + maxMatchLength
+		if s1 > len(src) {
+			s1 = len(src)
+		}
+		s, t = s+4, t+4
+		for s < s1 && src[s] == src[t] {
+			s++
+			t++
+		}
+		return s - s0
+	}
+
+	// We found a match in the previous block.
+	tp := len(e.prev) + t
+	if tp < 0 || t > -5 || offset >= maxOffset || b0 != e.prev[tp] || b1 != e.prev[tp+1] || b2 != e.prev[tp+2] || b3 != e.prev[tp+3] {
+		return 0
+	}
+
+	// Extend the match to be as long as possible.
+	s0 := s
+	s1 := s + maxMatchLength
+	if s1 > len(src) {
+		s1 = len(src)
+	}
+	s, tp = s+4, tp+4
+	for s < s1 && src[s] == e.prev[tp] {
+		s++
+		tp++
+		if tp == len(e.prev) {
+			t = 0
+			// continue in current buffer
+			for s < s1 && src[s] == src[t] {
+				s++
+				t++
+			}
+			return s - s0
+		}
+	}
+	return s - s0
+}
+
+// Reset the encoding table.
+func (e *snappyGen) Reset() {
+	for i := range e.table {
+		e.table[i] = 0
+	}
+	e.cur = 0
+	e.prev = nil
+}
+
+// snappySSE4 extends snappyGen.
+// This implementation can use SSE 4.2 for length matching.
+type snappySSE4 struct {
+	snappyGen
+}
+
+// EncodeL1 uses Snappy-like compression, but stores as Huffman
+// blocks.
+func (e *snappySSE4) encodeL1(dst *tokens, src []byte) {
+	// Return early if src is short.
+	if len(src) <= 4 {
+		if len(src) != 0 {
+			emitLiteral(dst, src)
+		}
+		e.cur += 4
+		return
+	}
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 0
+	}
+
+	// Iterate over the source bytes.
+	var (
+		s   int // The iterator position.
+		t   int // The last position with the same hash as s.
+		lit int // The start position of any pending literal bytes.
+	)
+
+	for s+3 < len(src) {
+		// Update the hash table.
+		h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
+		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
+		// We need to to store values in [-1, inf) in table. To save
+		// some initialization time, (re)use the table's zero value
+		// and shift the values against this zero: add 1 on writes,
+		// subtract 1 on reads.
+		t, *p = int(*p)-1-e.cur, int64(s+1+e.cur)
+
+		offset := uint(s - t - 1)
+
+		// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
+		if t < 0 || offset >= (maxOffset-1) {
+			// Skip 1 byte for 16 consecutive missed.
+			s += 1 + ((s - lit) >> 4)
+			continue
+		}
+
+		length := maxMatchLength
+		if length > len(src)-s {
+			length = len(src) - s
+		}
+		// Extend the match to be as long as possible.
+		match := matchLenSSE4(src[t:], src[s:], length)
+
+		// Return if short.
+		if match < 4 {
+			s += 1 + (s-lit)>>4
+			continue
+		}
+
+		// Otherwise, we have a match. First, emit any pending literal bytes.
+		if lit != s {
+			emitLiteral(dst, src[lit:s])
+		}
+
+		dst.tokens[dst.n] = matchToken(uint32(match-3), uint32(offset))
+		dst.n++
+		s += match
+		lit = s
+	}
+
+	// Emit any final pending literal bytes and return.
+	if lit != len(src) {
+		emitLiteral(dst, src[lit:])
+	}
+	e.cur += len(src)
+}
+
+// EncodeL2 uses a similar algorithm to level 1, but is capable
+// of matching across blocks giving better compression at a small slowdown.
+func (e *snappySSE4) encodeL2(dst *tokens, src []byte) {
+	// Return early if src is short.
+	if len(src) <= 4 {
+		if len(src) != 0 {
+			emitLiteral(dst, src)
+		}
+		e.prev = nil
+		e.cur += len(src)
+		return
+	}
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 0
+	}
+
+	// Iterate over the source bytes.
+	var (
+		s   int // The iterator position.
+		t   int // The last position with the same hash as s.
+		lit int // The start position of any pending literal bytes.
+	)
+
+	for s+3 < len(src) {
+		// Update the hash table.
+		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
+		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
+		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
+		// We need to to store values in [-1, inf) in table. To save
+		// some initialization time, (re)use the table's zero value
+		// and shift the values against this zero: add 1 on writes,
+		// subtract 1 on reads.
+		t, *p = int(*p)-1-e.cur, int64(s+1+e.cur)
+
+		// If t is positive, the match starts in the current block
+		if t >= 0 {
+			offset := uint(s - t - 1)
+
+			// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
+			if t < 0 || offset >= (maxOffset-1) {
+				// Skip 1 byte for 16 consecutive missed.
+				s += 1 + ((s - lit) >> 4)
+				continue
+			}
+
+			length := maxMatchLength
+			if length > len(src)-s {
+				length = len(src) - s
+			}
+			// Extend the match to be as long as possible.
+			match := matchLenSSE4(src[t:], src[s:], length)
+
+			// Return if short.
+			if match < 4 {
+				s += 1 + (s-lit)>>4
+				continue
+			}
+
+			// Otherwise, we have a match. First, emit any pending literal bytes.
+			if lit != s {
+				emitLiteral(dst, src[lit:s])
+			}
+
+			dst.tokens[dst.n] = matchToken(uint32(match-3), uint32(offset))
+			s += match
+			dst.n++
+			lit = s
+			continue
+		}
+
+		// We found a match in the previous block.
+		tp := len(e.prev) + t
+		if tp < 0 || t > -5 || s-t >= maxOffset || b0 != e.prev[tp] || b1 != e.prev[tp+1] || b2 != e.prev[tp+2] || b3 != e.prev[tp+3] {
+			// Skip 1 byte for 32 consecutive missed.
+			s += 1 + ((s - lit) >> 5)
+			continue
+		}
+		// Otherwise, we have a match. First, emit any pending literal bytes.
+		if lit != s {
+			emitLiteral(dst, src[lit:s])
+		}
+		// Extend the match to be as long as possible.
+		s0 := s
+		s1 := s + maxMatchLength
+		if s1 > len(src) {
+			s1 = len(src)
+		}
+		s, tp = s+4, tp+4
+		for s < s1 && src[s] == e.prev[tp] {
+			s++
+			tp++
+			if tp == len(e.prev) {
+				t = 0
+				// continue in current buffer
+				for s < s1 && src[s] == src[t] {
+					s++
+					t++
+				}
+				goto l
+			}
+		}
+	l:
+		// Emit the copied bytes.
+		// inlined: emitCopy(dst, s-t, s-s0)
+		if t < 0 {
+			t = tp - len(e.prev)
+		}
+		dst.tokens[dst.n] = matchToken(uint32(s-s0-3), uint32(s-t-minOffsetSize))
+		dst.n++
+		lit = s
+		continue
+
+	}
+
+	// Emit any final pending literal bytes and return.
+	if lit != len(src) {
+		emitLiteral(dst, src[lit:])
+	}
+	e.cur += len(src)
+	// Store this block, if it was full length.
+	if len(src) == maxStoreBlockSize {
+		copy(e.block[:], src)
+		e.prev = e.block[:len(src)]
+	} else {
+		e.prev = nil
+	}
+}
+
+// EncodeL3 uses a similar algorithm to level 2, but is capable
+// will keep two matches per hash.
+// Both hashes are checked if the first isn't ok, and the longest is selected.
+func (e *snappySSE4) encodeL3(dst *tokens, src []byte) {
+	// Return early if src is short.
+	if len(src) <= 4 {
+		if len(src) != 0 {
+			emitLiteral(dst, src)
+		}
+		e.prev = nil
+		e.cur += len(src)
+		return
+	}
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 0
+	}
+
+	// Iterate over the source bytes.
+	var (
+		s   int // The iterator position.
+		lit int // The start position of any pending literal bytes.
+	)
+
+	for s+3 < len(src) {
+		// Update the hash table.
+		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
+		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
+		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
+		tmp := *p
+		p1 := int(tmp & 0xffffffff) // Closest match position
+		p2 := int(tmp >> 32)        // Furthest match position
+
+		// We need to to store values in [-1, inf) in table. To save
+		// some initialization time, (re)use the table's zero value
+		// and shift the values against this zero: add 1 on writes,
+		// subtract 1 on reads.
+		t1 := int(p1) - 1 - e.cur
+
+		var l2 int
+		var t2 int
+		l1 := e.matchlen(s, t1, src, b0, b1, b2, b3)
+		// If fist match was ok, don't do the second.
+		if l1 < 24 {
+			t2 = int(p2) - 1 - e.cur
+			l2 = e.matchlen(s, t2, src, b0, b1, b2, b3)
+
+			// If both are short, continue
+			if l1 < 4 && l2 < 4 {
+				// Update hash table
+				*p = int64(s+1+e.cur) | (int64(p1) << 32)
+				// Skip 1 byte for 32 consecutive missed.
+				s += 1 + ((s - lit) >> 5)
+				continue
+			}
+		}
+
+		// Otherwise, we have a match. First, emit any pending literal bytes.
+		if lit != s {
+			emitLiteral(dst, src[lit:s])
+		}
+		// Update hash table
+		*p = int64(s+1+e.cur) | (int64(p1) << 32)
+
+		// Store the longest match l1 will be closest, so we prefer that if equal length
+		if l1 >= l2 {
+			dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
+			s += l1
+		} else {
+			dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
+			s += l2
+		}
+		dst.n++
+		lit = s
+	}
+
+	// Emit any final pending literal bytes and return.
+	if lit != len(src) {
+		emitLiteral(dst, src[lit:])
+	}
+	e.cur += len(src)
+	// Store this block, if it was full length.
+	if len(src) == maxStoreBlockSize {
+		copy(e.block[:], src)
+		e.prev = e.block[:len(src)]
+	} else {
+		e.prev = nil
+	}
+}
+
+func (e *snappySSE4) matchlen(s, t int, src []byte, b0, b1, b2, b3 byte) int {
+	// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
+	offset := s - t
+
+	// If we are inside the current block
+	if t >= 0 {
+		if offset >= maxOffset || offset <= 0 {
+			return 0
+		}
+		length := len(src) - s
+		if length > maxMatchLength {
+			length = maxMatchLength
+		}
+		// Extend the match to be as long as possible.
+		return matchLenSSE4(src[t:], src[s:], length)
+	}
+
+	// We found a match in the previous block.
+	tp := len(e.prev) + t
+	if tp < 0 || t > -5 || offset >= maxOffset || b0 != e.prev[tp] || b1 != e.prev[tp+1] || b2 != e.prev[tp+2] || b3 != e.prev[tp+3] {
+		return 0
+	}
+
+	// Extend the match to be as long as possible.
+	s0 := s
+	s1 := s + maxMatchLength
+	if s1 > len(src) {
+		s1 = len(src)
+	}
+	s, tp = s+4, tp+4
+	for s < s1 && src[s] == e.prev[tp] {
+		s++
+		tp++
+		if tp == len(e.prev) {
+			t = 0
+			// continue in current buffer
+			for s < s1 && src[s] == src[t] {
+				s++
+				t++
+			}
+			return s - s0
+		}
+	}
+	return s - s0
 }

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -629,8 +629,8 @@ func (e *snappySSE4) encodeL2(dst *tokens, src []byte) {
 }
 */
 
-// EncodeL3 uses a similar algorithm to level 2, but is capable
-// will keep two matches per hash.
+// EncodeL3 uses a similar algorithm to level 2,
+// but will keep two matches per hash.
 // Both hashes are checked if the first isn't ok, and the longest is selected.
 func (e *snappySSE4) encodeL3(dst *tokens, src []byte) {
 	// Return early if src is short.


### PR DESCRIPTION
This will rebalance the compression levels to have a more even distribution of compression levels. The general trend of this is to make compression faster, which means that a given compression level (except 1 and 9) will be faster.

The existing implementation favors compression, and from level 5 and up, very small compresssion improvements are added for very high computation cost.

Rough guidelines: Previous level 3 speed is now equal to level 6.

New default is level 5, which in most cases offers a quite good compression, without getting diminished returns from additional computation power.

See "rebalance" tabs for benchmarks of rebalanced levels:

https://docs.google.com/spreadsheets/d/1nuNE2nPfuINCZJRMt6wFWhKpToF95I47XjSsc-1rbPQ/edit?usp=sharing