### PR TITLE
Optimize bitwriter code lookups

### DIFF
--- a/flate/huffman_bit_writer.go
+++ b/flate/huffman_bit_writer.go
@@ -286,11 +286,10 @@ func (w *huffmanBitWriter) writeCode(code *huffmanEncoder, literal uint32) {
 }
 */
 
-func (w *huffmanBitWriter) writeCode(code *huffmanEncoder, literal uint32) {
+func (w *huffmanBitWriter) writeCode(c hcode) {
 	if w.err != nil {
 		return
 	}
-	c := code.codes[literal]
 	w.bits |= uint64(c.code()) << w.nbits
 	w.nbits += c.bits()
 	if w.nbits >= 48 {
@@ -345,7 +344,7 @@ func (w *huffmanBitWriter) writeDynamicHeader(numLiterals int, numOffsets int, n
 			break
 		}
 		// The low byte contains the actual code to generate.
-		w.writeCode(w.codegenEncoding, uint32(codeWord))
+		w.writeCode(w.codegenEncoding.codes[uint32(codeWord)])
 
 		switch codeWord {
 		case 16:
@@ -406,10 +405,9 @@ func (w *huffmanBitWriter) writeBlock(tok tokens, eof bool, input []byte) {
 	tokens := tok.tokens[0 : tok.n+1]
 
 	for _, t := range tokens {
-		switch t.typ() {
-		case literalType:
+		if t < matchType {
 			w.literalFreq[t.literal()]++
-		case matchType:
+		} else {
 			length := t.length()
 			offset := t.offset()
 			w.literalFreq[lengthCodesStart+lengthCode(length)]++
@@ -508,16 +506,17 @@ func (w *huffmanBitWriter) writeBlock(tok tokens, eof bool, input []byte) {
 	} else {
 		w.writeDynamicHeader(numLiterals, numOffsets, numCodegens, eof)
 	}
+
+	leCodes := literalEncoding.codes
+	oeCodes := offsetEncoding.codes
 	for _, t := range tokens {
-		switch t.typ() {
-		case literalType:
-			w.writeCode(literalEncoding, t.literal())
-			break
-		case matchType:
+		if t < matchType {
+			w.writeCode(leCodes[t.literal()])
+		} else {
 			// Write the length
 			length := t.length()
 			lengthCode := lengthCode(length)
-			w.writeCode(literalEncoding, lengthCode+lengthCodesStart)
+			w.writeCode(leCodes[lengthCode+lengthCodesStart])
 			extraLengthBits := uint(lengthExtraBits[lengthCode])
 			if extraLengthBits > 0 {
 				extraLength := int32(length - lengthBase[lengthCode])
@@ -526,15 +525,12 @@ func (w *huffmanBitWriter) writeBlock(tok tokens, eof bool, input []byte) {
 			// Write the offset
 			offset := t.offset()
 			offsetCode := offsetCode(offset)
-			w.writeCode(offsetEncoding, offsetCode)
+			w.writeCode(oeCodes[offsetCode])
 			extraOffsetBits := uint(offsetExtraBits[offsetCode])
 			if extraOffsetBits > 0 {
 				extraOffset := int32(offset - offsetBase[offsetCode])
 				w.writeBits(extraOffset, extraOffsetBits)
 			}
-			break
-		default:
-			panic("unknown token type: " + string(t))
 		}
 	}
 }
@@ -557,10 +553,9 @@ func (w *huffmanBitWriter) writeBlockDynamic(tok tokens, eof bool, input []byte)
 	tokens := tok.tokens[0 : tok.n+1]
 
 	for _, t := range tokens {
-		switch t.typ() {
-		case literalType:
+		if t < matchType {
 			w.literalFreq[t.literal()]++
-		case matchType:
+		} else {
 			length := t.length()
 			offset := t.offset()
 			w.literalFreq[lengthCodesStart+lengthCode(length)]++
@@ -603,16 +598,17 @@ func (w *huffmanBitWriter) writeBlockDynamic(tok tokens, eof bool, input []byte)
 
 	// Write Huffman table.
 	w.writeDynamicHeader(numLiterals, numOffsets, numCodegens, eof)
+	leCodes := literalEncoding.codes
+	oeCodes := offsetEncoding.codes
+
 	for _, t := range tokens {
-		switch t.typ() {
-		case literalType:
-			w.writeCode(literalEncoding, t.literal())
-			break
-		case matchType:
+		if t < matchType {
+			w.writeCode(leCodes[t.literal()])
+		} else {
 			// Write the length
 			length := t.length()
 			lengthCode := lengthCode(length)
-			w.writeCode(literalEncoding, lengthCode+lengthCodesStart)
+			w.writeCode(leCodes[lengthCode+lengthCodesStart])
 			extraLengthBits := uint(lengthExtraBits[lengthCode])
 			if extraLengthBits > 0 {
 				extraLength := int32(length - lengthBase[lengthCode])
@@ -621,15 +617,12 @@ func (w *huffmanBitWriter) writeBlockDynamic(tok tokens, eof bool, input []byte)
 			// Write the offset
 			offset := t.offset()
 			offsetCode := offsetCode(offset)
-			w.writeCode(offsetEncoding, offsetCode)
+			w.writeCode(oeCodes[offsetCode])
 			extraOffsetBits := uint(offsetExtraBits[offsetCode])
 			if extraOffsetBits > 0 {
 				extraOffset := int32(offset - offsetBase[offsetCode])
 				w.writeBits(extraOffset, extraOffsetBits)
 			}
-			break
-		default:
-			panic("unknown token type: " + string(t))
 		}
 	}
 }
@@ -704,9 +697,10 @@ func (w *huffmanBitWriter) writeBlockHuff(eof bool, input []byte) {
 
 	// Huffman.
 	w.writeDynamicHeader(numLiterals, numOffsets, numCodegens, eof)
+	encoding := w.literalEncoding.codes
 	for _, t := range input {
 		// Bitwriting inlined, ~30% speedup
-		c := w.literalEncoding.codes[t]
+		c := encoding[t]
 		w.bits |= uint64(c.code()) << w.nbits
 		w.nbits += c.bits()
 		if w.nbits >= 48 {
@@ -732,5 +726,5 @@ func (w *huffmanBitWriter) writeBlockHuff(eof bool, input []byte) {
 			}
 		}
 	}
-	w.writeCode(w.literalEncoding, endBlockMarker)
+	w.writeCode(encoding[endBlockMarker])
 }


### PR DESCRIPTION
Optimize bitwriter, by eliminating some nil checks and use a simpler test to determine the token type.

```
name                       old time/op    new time/op    delta
EncodeDigitsConstant1e4-4   159MB/s ± 0%   184MB/s ± 2%  +15.30%
EncodeDigitsConstant1e5-4   173MB/s ± 0%   186MB/s ± 7%   +7.21%
EncodeDigitsConstant1e6-4   171MB/s ± 0%   195MB/s ± 1%  +13.94%
EncodeDigitsSpeed1e4-4     45.4MB/s ± 1%  47.5MB/s ± 2%   +4.60%
EncodeDigitsSpeed1e5-4     70.5MB/s ± 0%  71.7MB/s ± 2%   +1.72%
EncodeDigitsSpeed1e6-4      110MB/s ± 0%   118MB/s ± 0%   +7.96%
EncodeDigitsDefault1e4-4   26.6MB/s ± 0%  26.3MB/s ± 0%   -0.83%
EncodeDigitsDefault1e5-4   21.3MB/s ± 1%  22.0MB/s ± 0%   +3.00%
EncodeDigitsDefault1e6-4   19.7MB/s ± 0%  21.2MB/s ± 0%   +8.03%
EncodeDigitsCompress1e4-4  22.9MB/s ± 1%  22.8MB/s ± 2%   -0.65%
EncodeDigitsCompress1e5-4  16.7MB/s ± 0%  16.9MB/s ± 1%   +1.14%
EncodeDigitsCompress1e6-4  15.3MB/s ± 0%  16.2MB/s ± 1%   +5.75%
EncodeTwainConstant1e4-4    117MB/s ± 1%   128MB/s ± 1%   +9.73%
EncodeTwainConstant1e5-4    149MB/s ± 0%   169MB/s ± 1%  +13.13%
EncodeTwainConstant1e6-4    146MB/s ± 2%   167MB/s ± 1%  +14.26%
EncodeTwainSpeed1e4-4      43.0MB/s ± 0%  44.0MB/s ± 1%   +2.54%
EncodeTwainSpeed1e5-4      50.5MB/s ± 0%  52.4MB/s ± 1%   +3.61%
EncodeTwainSpeed1e6-4      52.0MB/s ± 0%  53.9MB/s ± 0%   +3.71%
EncodeTwainDefault1e4-4    25.2MB/s ± 2%  25.6MB/s ± 2%   +1.47%
EncodeTwainDefault1e5-4    28.0MB/s ± 1%  27.7MB/s ± 0%   -1.07%
EncodeTwainDefault1e6-4    28.0MB/s ± 0%  27.2MB/s ± 5%   -2.86%
EncodeTwainCompress1e4-4   20.2MB/s ± 0%  20.1MB/s ± 2%   -0.64%
EncodeTwainCompress1e5-4   13.5MB/s ± 0%  13.5MB/s ± 0%   -0.48%
EncodeTwainCompress1e6-4   12.4MB/s ± 1%  12.0MB/s ± 3%   -2.87%
```