### PR TITLE
Level 4-7: Always attempt Huffman

### DIFF
--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -169,10 +169,9 @@ func (d *compressor) writeBlockSkip(tok tokens, index int, eof bool) error {
 	if index > 0 || eof {
 		if d.blockStart <= index {
 			window := d.window[d.blockStart:index]
-			if tok.n == len(window) && !eof {
-				d.writeStoredBlock(window)
-				// If we removed less than 10 literals, huffman compress the block.
-			} else if tok.n > len(window)-10 {
+			// If we removed less than a 64th of all literals
+			// we huffman compress the block.
+			if tok.n > len(window)-(tok.n>>6) {
 				d.w.writeBlockHuff(eof, window)
 			} else {
 				// Write a dynamic huffman block.


### PR DESCRIPTION
Always at least attempt to Huffman compress the blocks.

Since this part is now used for level 4-7, we can afford some more expensive checks. This should make base64 encoding of random input better.

Also, use variable threshold, instead of constant 10 literals.