### PR TITLE
Fix (!noasm AND !appengine) build tag.

### DIFF
--- a/flate/crc32_amd64.s
+++ b/flate/crc32_amd64.s
@@ -1,4 +1,5 @@
-//+build !noasm !appengine
+//+build !noasm
+//+build !appengine
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 

--- a/snappy/asm_amd64.s
+++ b/snappy/asm_amd64.s
@@ -1,4 +1,5 @@
-//+build !noasm !appengine
+//+build !noasm
+//+build !appengine
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 


### PR DESCRIPTION
It was correct for the *_amd64.go files, just not the *_amd64.s files,
which used OR instead of AND.

See the "Build Constraints" section of https://golang.org/pkg/go/build/