### PR TITLE
Remove DUPOK and NOPROF flags from asm functions.

### DIFF
--- a/flate/crc32_amd64.s
+++ b/flate/crc32_amd64.s
@@ -3,8 +3,10 @@
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 
+#include "textflag.h"
+
 // func crc32sse(a []byte) hash
-TEXT ·crc32sse(SB), 7, $0
+TEXT ·crc32sse(SB), NOSPLIT, $0
 	MOVQ a+0(FP), R10
 	XORQ BX, BX
 
@@ -16,7 +18,7 @@ TEXT ·crc32sse(SB), 7, $0
 	RET
 
 // func crc32sseAll(a []byte, dst []hash)
-TEXT ·crc32sseAll(SB), 7, $0
+TEXT ·crc32sseAll(SB), NOSPLIT, $0
 	MOVQ  a+0(FP), R8      // R8: src
 	MOVQ  a_len+8(FP), R10 // input length
 	MOVQ  dst+24(FP), R9   // R9: dst
@@ -96,7 +98,7 @@ one_crc:
 	JMP  rem_loop
 
 // func matchLenSSE4(a, b []byte, max int) int
-TEXT ·matchLenSSE4(SB), 7, $0
+TEXT ·matchLenSSE4(SB), NOSPLIT, $0
 	MOVQ  a+0(FP), SI        // RSI: &a
 	MOVQ  b+24(FP), DI       // RDI: &b
 	MOVQ  max+48(FP), R10    // R10: max
@@ -157,7 +159,7 @@ done_matchlen:
 	RET
 
 // func histogram(b []byte, h []int32)
-TEXT ·histogram(SB), 7, $0
+TEXT ·histogram(SB), NOSPLIT, $0
 	MOVQ b+0(FP), SI     // SI: &b
 	MOVQ b_len+8(FP), R9 // R9: len(b)
 	MOVQ h+24(FP), DI    // DI: Histogram

--- a/flate/crc32_amd64.s
+++ b/flate/crc32_amd64.s
@@ -3,10 +3,8 @@
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 
-#include "textflag.h"
-
 // func crc32sse(a []byte) hash
-TEXT ·crc32sse(SB), NOSPLIT, $0
+TEXT ·crc32sse(SB), 4, $0
 	MOVQ a+0(FP), R10
 	XORQ BX, BX
 
@@ -18,7 +16,7 @@ TEXT ·crc32sse(SB), NOSPLIT, $0
 	RET
 
 // func crc32sseAll(a []byte, dst []hash)
-TEXT ·crc32sseAll(SB), NOSPLIT, $0
+TEXT ·crc32sseAll(SB), 4, $0
 	MOVQ  a+0(FP), R8      // R8: src
 	MOVQ  a_len+8(FP), R10 // input length
 	MOVQ  dst+24(FP), R9   // R9: dst
@@ -98,7 +96,7 @@ one_crc:
 	JMP  rem_loop
 
 // func matchLenSSE4(a, b []byte, max int) int
-TEXT ·matchLenSSE4(SB), NOSPLIT, $0
+TEXT ·matchLenSSE4(SB), 4, $0
 	MOVQ  a+0(FP), SI        // RSI: &a
 	MOVQ  b+24(FP), DI       // RDI: &b
 	MOVQ  max+48(FP), R10    // R10: max
@@ -159,7 +157,7 @@ done_matchlen:
 	RET
 
 // func histogram(b []byte, h []int32)
-TEXT ·histogram(SB), NOSPLIT, $0
+TEXT ·histogram(SB), 4, $0
 	MOVQ b+0(FP), SI     // SI: &b
 	MOVQ b_len+8(FP), R9 // R9: len(b)
 	MOVQ h+24(FP), DI    // DI: Histogram

--- a/snappy/asm_amd64.s
+++ b/snappy/asm_amd64.s
@@ -3,8 +3,10 @@
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 
+#include "textflag.h"
+
 // func matchLenSSE4(a, b []byte, max int) int
-TEXT ·matchLenSSE4(SB), 7, $0
+TEXT ·matchLenSSE4(SB), NOSPLIT, $0
 	MOVQ  a+0(FP), SI        // RSI: &a
 	MOVQ  b+24(FP), DI       // RDI: &b
 	MOVQ  max+48(FP), R10    // R10: max

--- a/snappy/asm_amd64.s
+++ b/snappy/asm_amd64.s
@@ -3,10 +3,8 @@
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 
-#include "textflag.h"
-
 // func matchLenSSE4(a, b []byte, max int) int
-TEXT ·matchLenSSE4(SB), NOSPLIT, $0
+TEXT ·matchLenSSE4(SB), 4, $0
 	MOVQ  a+0(FP), SI        // RSI: &a
 	MOVQ  b+24(FP), DI       // RDI: &b
 	MOVQ  max+48(FP), R10    // R10: max


### PR DESCRIPTION
runtime/textflag.h defines:
NOPROF  1
DUPOK   2
NOSPLIT 4

The DUPOK bit was why the bug in
https://github.com/klauspost/compress/commit/6ea72a38a8cdbe25966059c547d425e580c624a7
wasn't picked up earlier.

The existing 7 is presumably a copy/paste of some standard library asm
code. It's a legacy idiom that really should be 5 or 4. See
https://groups.google.com/d/msg/golang-nuts/uJTYuruvnZM/6j4KXgkdcf0J for
some history.

Asm code in the standard library uses NOSPLIT instead of 4 these days.