### PR TITLE
Rewrite level 2+3+4 compression

### DIFF
--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -67,13 +67,13 @@ var levels = []compressionLevel{
 	{0, 0, 0, 0, 0, 3},
 	// For levels 4-6 we don't bother trying with lazy matches.
 	// Lazy matching is at least 30% slower, with 1.5% increase.
-	{4, 0, 8, 4, 4, 4},
-	{4, 0, 12, 6, 5, 5},
-	{8, 0, 32, 32, 6, 6},
+	{4, 0, 6, 6, 12, 4},
+	{6, 0, 12, 8, 12, 5},
+	{8, 0, 24, 16, 16, 6},
 	// Levels 7-9 use increasingly more lazy matching
 	// and increasingly stringent conditions for "good enough".
-	{4, 6, 8, 8, skipNever, 7},
-	{6, 16, 16, 32, skipNever, 8},
+	{8, 8, 24, 16, skipNever, 7},
+	{10, 16, 24, 64, skipNever, 8},
 	{32, 258, 258, 4096, skipNever, 9},
 }
 

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -61,13 +61,13 @@ type compressionLevel struct {
 // See https://blog.klauspost.com/rebalancing-deflate-compression-levels/
 var levels = []compressionLevel{
 	{}, // 0
-	// Level 1-3 uses specialized algorithm - values not used
+	// Level 1-4 uses specialized algorithm - values not used
 	{0, 0, 0, 0, 0, 1},
 	{0, 0, 0, 0, 0, 2},
 	{0, 0, 0, 0, 0, 3},
-	// For levels 4-6 we don't bother trying with lazy matches.
+	{0, 0, 0, 0, 0, 4},
+	// For levels 5-6 we don't bother trying with lazy matches.
 	// Lazy matching is at least 30% slower, with 1.5% increase.
-	{4, 0, 6, 6, 8, 4},
 	{6, 0, 12, 8, 12, 5},
 	{8, 0, 24, 16, 16, 6},
 	// Levels 7-9 use increasingly more lazy matching
@@ -1164,7 +1164,7 @@ func (d *compressor) init(w io.Writer, level int) (err error) {
 		d.window = make([]byte, maxStoreBlockSize)
 		d.fill = (*compressor).fillBlock
 		d.step = (*compressor).storeHuff
-	case level >= 1 && level <= 3:
+	case level >= 1 && level <= 4:
 		d.snap = newSnappy(level)
 		d.window = make([]byte, maxStoreBlockSize)
 		d.fill = (*compressor).fillBlock
@@ -1172,7 +1172,7 @@ func (d *compressor) init(w io.Writer, level int) (err error) {
 	case level == DefaultCompression:
 		level = 5
 		fallthrough
-	case 4 <= level && level <= 9:
+	case 5 <= level && level <= 9:
 		d.compressionLevel = levels[level]
 		d.initDeflate()
 		d.fill = (*compressor).fillDeflate

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -67,7 +67,7 @@ var levels = []compressionLevel{
 	{0, 0, 0, 0, 0, 3},
 	// For levels 4-6 we don't bother trying with lazy matches.
 	// Lazy matching is at least 30% slower, with 1.5% increase.
-	{4, 0, 6, 6, 12, 4},
+	{4, 0, 6, 6, 8, 4},
 	{6, 0, 12, 8, 12, 5},
 	{8, 0, 24, 16, 16, 6},
 	// Levels 7-9 use increasingly more lazy matching
@@ -696,7 +696,7 @@ func (d *compressor) deflateLazy() {
 				// If we have a long run of no matches, skip additional bytes
 				// Resets when d.ii overflows after 64KB.
 				if d.ii > 31 {
-					n := int(d.ii >> 6)
+					n := int(d.ii >> 5)
 					for j := 0; j < n; j++ {
 						if d.index >= d.windowEnd-1 {
 							break
@@ -853,7 +853,7 @@ func (d *compressor) deflateSSE() {
 			}
 		} else {
 			d.ii++
-			end := d.index + int(d.ii>>uint(d.fastSkipHashing)) + 1
+			end := d.index + int(d.ii>>5) + 1
 			if end > d.windowEnd {
 				end = d.windowEnd
 			}

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -69,11 +69,11 @@ var levels = []compressionLevel{
 	// Lazy matching is at least 30% slower, with 1.5% increase.
 	{4, 0, 8, 4, 4, 4},
 	{4, 0, 12, 6, 5, 5},
-	{6, 0, 24, 16, 6, 6},
+	{8, 0, 32, 32, 6, 6},
 	// Levels 7-9 use increasingly more lazy matching
 	// and increasingly stringent conditions for "good enough".
-	{4, 8, 16, 16, skipNever, 7},
-	{6, 16, 32, 64, skipNever, 8},
+	{4, 6, 8, 8, skipNever, 7},
+	{6, 16, 16, 32, skipNever, 8},
 	{32, 258, 258, 4096, skipNever, 9},
 }
 

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -1099,6 +1099,7 @@ func (d *compressor) storeSnappy() {
 			}
 			d.tokens.n = 0
 			d.windowEnd = 0
+			d.snap.Reset()
 			return
 		}
 	}

--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -61,15 +61,15 @@ type compressionLevel struct {
 // See https://blog.klauspost.com/rebalancing-deflate-compression-levels/
 var levels = []compressionLevel{
 	{}, // 0
-	// Level 1+2 uses snappy algorithm - values not used
+	// Level 1-3 uses specialized algorithm - values not used
 	{0, 0, 0, 0, 0, 1},
 	{0, 0, 0, 0, 0, 2},
-	// For levels 3-6 we don't bother trying with lazy matches.
+	{0, 0, 0, 0, 0, 3},
+	// For levels 4-6 we don't bother trying with lazy matches.
 	// Lazy matching is at least 30% slower, with 1.5% increase.
-	{4, 0, 8, 4, 4, 3},
-	{4, 0, 12, 6, 5, 4},
-	{6, 0, 24, 16, 6, 5},
-	{8, 0, 32, 32, 7, 6},
+	{4, 0, 8, 4, 4, 4},
+	{4, 0, 12, 6, 5, 5},
+	{6, 0, 24, 16, 6, 6},
 	// Levels 7-9 use increasingly more lazy matching
 	// and increasingly stringent conditions for "good enough".
 	{4, 8, 16, 16, skipNever, 7},

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -372,7 +372,7 @@ var deflateInflateStringTests = []deflateInflateStringTest{
 	{
 		"../testdata/Mark.Twain-Tom.Sawyer.txt",
 		"Mark.Twain-Tom.Sawyer",
-		[...]int{407330, 195000, 185361, 180974, 169160, 164476, 162936, 160506, 160295, 160295, 233460 + 100},
+		[...]int{407330, 195000, 185361, 180974, 173886, 168819, 164609, 160506, 160295, 160295, 233460 + 100},
 	},
 }
 

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -372,7 +372,7 @@ var deflateInflateStringTests = []deflateInflateStringTest{
 	{
 		"../testdata/Mark.Twain-Tom.Sawyer.txt",
 		"Mark.Twain-Tom.Sawyer",
-		[...]int{387999, 185000, 182361, 179974, 169160, 168819, 162936, 160506, 160295, 160295, 233460 + 100},
+		[...]int{387999, 185000, 182361, 179974, 174124, 168819, 162936, 160506, 160295, 160295, 233460 + 100},
 	},
 }
 

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -372,7 +372,7 @@ var deflateInflateStringTests = []deflateInflateStringTest{
 	{
 		"../testdata/Mark.Twain-Tom.Sawyer.txt",
 		"Mark.Twain-Tom.Sawyer",
-		[...]int{407330, 195000, 185361, 180974, 173886, 168819, 164609, 160506, 160295, 160295, 233460 + 100},
+		[...]int{387999, 185000, 182361, 179974, 169160, 168819, 162936, 160506, 160295, 160295, 233460 + 100},
 	},
 }
 

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -566,3 +566,83 @@ func testResetOutput(t *testing.T, newWriter func(w io.Writer) (*Writer, error))
 	}
 	t.Logf("got %d bytes", len(out1))
 }
+
+// TestBestSpeed tests that round-tripping through deflate and then inflate
+// recovers the original input. The Write sizes are near the thresholds in the
+// compressor.encSpeed method (0, 16, 128), as well as near maxStoreBlockSize
+// (65535).
+func TestBestSpeed(t *testing.T) {
+	abc := make([]byte, 128)
+	for i := range abc {
+		abc[i] = byte(i)
+	}
+	abcabc := bytes.Repeat(abc, 131072/len(abc))
+	var want []byte
+
+	testCases := [][]int{
+		{65536, 0},
+		{65536, 1},
+		{65536, 1, 256},
+		{65536, 1, 65536},
+		{65536, 14},
+		{65536, 15},
+		{65536, 16},
+		{65536, 16, 256},
+		{65536, 16, 65536},
+		{65536, 127},
+		{65536, 128},
+		{65536, 128, 256},
+		{65536, 128, 65536},
+		{65536, 129},
+		{65536, 65536, 256},
+		{65536, 65536, 65536},
+	}
+
+	for i, tc := range testCases {
+		for _, firstN := range []int{1, 65534, 65535, 65536, 65537, 131072} {
+			tc[0] = firstN
+		outer:
+			for _, flush := range []bool{false, true} {
+				buf := new(bytes.Buffer)
+				want = want[:0]
+
+				w, err := NewWriter(buf, BestSpeed)
+				if err != nil {
+					t.Errorf("i=%d, firstN=%d, flush=%t: NewWriter: %v", i, firstN, flush, err)
+					continue
+				}
+				for _, n := range tc {
+					want = append(want, abcabc[:n]...)
+					if _, err := w.Write(abcabc[:n]); err != nil {
+						t.Errorf("i=%d, firstN=%d, flush=%t: Write: %v", i, firstN, flush, err)
+						continue outer
+					}
+					if !flush {
+						continue
+					}
+					if err := w.Flush(); err != nil {
+						t.Errorf("i=%d, firstN=%d, flush=%t: Flush: %v", i, firstN, flush, err)
+						continue outer
+					}
+				}
+				if err := w.Close(); err != nil {
+					t.Errorf("i=%d, firstN=%d, flush=%t: Close: %v", i, firstN, flush, err)
+					continue
+				}
+
+				r := NewReader(buf)
+				got, err := ioutil.ReadAll(r)
+				if err != nil {
+					t.Errorf("i=%d, firstN=%d, flush=%t: ReadAll: %v", i, firstN, flush, err)
+					continue
+				}
+				r.Close()
+
+				if !bytes.Equal(got, want) {
+					t.Errorf("i=%d, firstN=%d, flush=%t: corruption during deflate-then-inflate", i, firstN, flush)
+					continue
+				}
+			}
+		}
+	}
+}

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -29,7 +29,7 @@ type snappyEnc interface {
 }
 
 func newSnappy(level int) snappyEnc {
-	if useSSE42 {
+	if false && useSSE42 {
 		e := &snappySSE4{snappyGen: snappyGen{cur: 1}}
 		switch level {
 		case 3:
@@ -45,7 +45,7 @@ func newSnappy(level int) snappyEnc {
 	case 2:
 		e.enc = e.encodeL2
 	case 3:
-		e.enc = e.encodeL3
+		e.enc = e.encodeL2
 	default:
 		panic("invalid level specified")
 	}
@@ -219,14 +219,30 @@ emitRemainder:
 	}
 }
 
+type tableEntry struct {
+	val    uint32
+	offset int32
+}
+
+func load3232(b []byte, i int32) uint32 {
+	b = b[i : i+4 : len(b)] // Help the compiler eliminate bounds checks on the next line.
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}
+
+func load6432(b []byte, i int32) uint64 {
+	b = b[i : i+8 : len(b)] // Help the compiler eliminate bounds checks on the next line.
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}
+
 // snappyGen maintains the table for matches,
 // and the previous byte block for level 2.
 // This is the generic implementation.
 type snappyGen struct {
-	table [tableSize]int64
+	table [tableSize]tableEntry
 	block [maxStoreBlockSize]byte
 	prev  []byte
-	cur   int
+	cur   int32
 	enc   func(dst *tokens, src []byte)
 }
 
@@ -237,13 +253,18 @@ func (e *snappyGen) Encode(dst *tokens, src []byte) {
 // EncodeL2 uses a similar algorithm to level 1, but is capable
 // of matching across blocks giving better compression at a small slowdown.
 func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
-	// Return early if src is short.
-	if len(src) <= 4 {
-		if len(src) != 0 {
-			emitLiteral(dst, src)
-		}
-		e.prev = nil
-		e.cur += len(src)
+	const (
+		inputMargin            = 16 - 1
+		minNonLiteralBlockSize = 1 + 1 + inputMargin
+	)
+
+	// This check isn't in the Snappy implementation, but there, the caller
+	// instead of the callee handles this case.
+	if len(src) < minNonLiteralBlockSize {
+		// We do not fill the token table.
+		// This will be picked up by caller.
+		dst.n = uint16(len(src))
+		e.cur += int32(len(src)) + maxStoreBlockSize
 		return
 	}
 
@@ -252,254 +273,273 @@ func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
 		e.cur = 1
 	}
 
-	// Iterate over the source bytes.
-	var (
-		s   int // The iterator position.
-		t   int // The last position with the same hash as s.
-		lit int // The start position of any pending literal bytes.
-	)
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := int32(len(src) - inputMargin)
 
-	for s+3 < len(src) {
-		// Update the hash table.
-		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
-		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
-		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-		// We need to to store values in [-1, inf) in table.
-		// To save some initialization time, we make sure that
-		// e.cur is never zero.
-		t, *p = int(*p)-e.cur, int64(s+e.cur)
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := int32(0)
 
-		// If t is positive, the match starts in the current block
-		if t >= 0 {
+	// The encoded form must start with a literal, as there are no previous
+	// bytes to copy, so we start looking for hash matches at s == 1.
+	s := int32(1)
+	cv := load3232(src, s)
+	nextHash := hash(cv)
 
-			offset := uint(s - t - 1)
-			// Check that the offset is valid and that we match at least 4 bytes
-			if offset >= (maxOffset-1) || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
-				// Skip 1 byte for 32 consecutive missed.
-				s += 1 + ((s - lit) >> 5)
-				continue
+	for {
+		// Copied from the C++ snappy implementation:
+		//
+		// Heuristic match skipping: If 32 bytes are scanned with no matches
+		// found, start looking only at every other byte. If 32 more bytes are
+		// scanned (or skipped), look at every third byte, etc.. When a match
+		// is found, immediately go back to looking at every byte. This is a
+		// small loss (~5% performance, ~0.1% density) for compressible data
+		// due to more bookkeeping, but for non-compressible data (such as
+		// JPEG) it's a huge win since the compressor quickly "realizes" the
+		// data is incompressible and doesn't bother looking for matches
+		// everywhere.
+		//
+		// The "skip" variable keeps track of how many bytes there are since
+		// the last match; dividing it by 32 (ie. right-shifting by five) gives
+		// the number of bytes to move ahead for each iteration.
+		skip := int32(32)
+
+		nextS := s
+		var candidate tableEntry
+		for {
+			s = nextS
+			bytesBetweenHashLookups := skip >> 5
+			nextS = s + bytesBetweenHashLookups
+			skip += bytesBetweenHashLookups
+			if nextS > sLimit {
+				goto emitRemainder
 			}
-			// Otherwise, we have a match. First, emit any pending literal bytes.
-			if lit != s {
-				emitLiteral(dst, src[lit:s])
+			candidate = e.table[nextHash&tableMask]
+			now := load3232(src, nextS)
+			e.table[nextHash&tableMask] = tableEntry{offset: s + e.cur, val: cv}
+			nextHash = hash(now)
+			// TODO: < should be <=, and add a test for that.
+			if cv == candidate.val && uint(s-(candidate.offset-e.cur)) < maxMatchOffset {
+				break
 			}
-			// Extend the match to be as long as possible.
-			s0 := s
-			s1 := s + maxMatchLength
-			if s1 > len(src) {
-				s1 = len(src)
+			cv = now
+		}
+
+		// A 4-byte match has been found. We'll later see if more than 4 bytes
+		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+		// them as literal bytes.
+		emitLiteral(dst, src[nextEmit:s])
+
+		// Call emitCopy, and then see if another emitCopy could be our next
+		// move. Repeat until we find no match for the input immediately after
+		// what was consumed by the last emitCopy call.
+		//
+		// If we exit this loop normally then we need to call emitLiteral next,
+		// though we don't yet know how big the literal will be. We handle that
+		// by proceeding to the next iteration of the main loop. We also can
+		// exit this loop via goto if we get close to exhausting the input.
+		for {
+			// Invariant: we have a 4-byte match at s, and no need to emit any
+			// literal bytes prior to s.
+			base := s
+
+			// Extend the 4-byte match as long as possible.
+			//
+			// This is an inlined version of Snappy's:
+			//	s = extendMatch(src, candidate+4, s+4)
+			s += 4
+			s1 := base + maxMatchLength
+			if s1 > int32(len(src)) {
+				s1 = int32(len(src))
 			}
-			s, t = s+4, t+4
-			for s < s1 && src[s] == src[t] {
-				s++
-				t++
+			pos := int(candidate.offset - e.cur)
+			for i := pos + 4; s < s1 && src[i] == src[s]; i, s = i+1, s+1 {
 			}
-			// Emit the copied bytes.
-			// inlined: emitCopy(dst, s-t, s-s0)
-			dst.tokens[dst.n] = matchToken(uint32(s-s0-3), uint32(s-t-minOffsetSize))
+
+			// matchToken is flate's equivalent of Snappy's emitCopy.
+			dst.tokens[dst.n] = matchToken(uint32(s-base-baseMatchLength), uint32(int(base)-pos-baseMatchOffset))
 			dst.n++
-			lit = s
-			continue
-		}
-		// We found a match in the previous block.
-		tp := len(e.prev) + t
-		if tp < 0 || t > -5 || s-t >= maxOffset || b0 != e.prev[tp] || b1 != e.prev[tp+1] || b2 != e.prev[tp+2] || b3 != e.prev[tp+3] {
-			// Skip 1 byte for 32 consecutive missed.
-			s += 1 + ((s - lit) >> 5)
-			continue
-		}
-		// Otherwise, we have a match. First, emit any pending literal bytes.
-		if lit != s {
-			emitLiteral(dst, src[lit:s])
-		}
-		// Extend the match to be as long as possible.
-		s0 := s
-		s1 := s + maxMatchLength
-		if s1 > len(src) {
-			s1 = len(src)
-		}
-		s, tp = s+4, tp+4
-		for s < s1 && src[s] == e.prev[tp] {
-			s++
-			tp++
-			if tp == len(e.prev) {
-				t = 0
-				// continue in current buffer
-				for s < s1 && src[s] == src[t] {
-					s++
-					t++
-				}
-				goto l
+			nextEmit = s
+			if s >= sLimit {
+				goto emitRemainder
+			}
+
+			// We could immediately start working at s now, but to improve
+			// compression we first update the hash table at s-1 and at s. If
+			// another emitCopy is not our next move, also calculate nextHash
+			// at s+1. At least on GOARCH=amd64, these three hash calculations
+			// are faster as one load64 call (with some shifts) instead of
+			// three load32 calls.
+			x := load6432(src, s-1)
+			prevHash := hash(uint32(x))
+			e.table[prevHash&tableMask] = tableEntry{offset: e.cur + s - 1, val: uint32(x)}
+			x >>= 8
+			currHash := hash(uint32(x))
+			candidate = e.table[currHash&tableMask]
+			e.table[currHash&tableMask] = tableEntry{offset: e.cur + s, val: uint32(x)}
+			// TODO: >= should be >, and add a test for that.
+			if uint32(x) != candidate.val || uint(s-(candidate.offset-e.cur)) >= maxMatchOffset {
+				cv = uint32(x >> 8)
+				nextHash = hash(cv)
+				s++
+				break
 			}
 		}
-	l:
-		// Emit the copied bytes.
-		if t < 0 {
-			t = tp - len(e.prev)
-		}
-		dst.tokens[dst.n] = matchToken(uint32(s-s0-3), uint32(s-t-minOffsetSize))
-		dst.n++
-		lit = s
-
 	}
 
-	// Emit any final pending literal bytes and return.
-	if lit != len(src) {
-		emitLiteral(dst, src[lit:])
+emitRemainder:
+	if int(nextEmit) < len(src) {
+		emitLiteral(dst, src[nextEmit:])
 	}
-	e.cur += len(src)
-	// Store this block, if it was full length.
-	if len(src) == maxStoreBlockSize {
-		copy(e.block[:], src)
-		e.prev = e.block[:len(src)]
-	} else {
-		e.prev = nil
-	}
+	e.cur += int32(len(src)) + maxStoreBlockSize
 }
 
 // EncodeL3 uses a similar algorithm to level 2, but is capable
 // will keep two matches per hash.
 // Both hashes are checked if the first isn't ok, and the longest is selected.
 func (e *snappyGen) encodeL3(dst *tokens, src []byte) {
-	// Return early if src is short.
-	if len(src) <= 4 {
-		if len(src) != 0 {
-			emitLiteral(dst, src)
-		}
-		e.prev = nil
-		e.cur += len(src)
-		return
-	}
+	/*
+			// Return early if src is short.
+			if len(src) <= 4 {
+				if len(src) != 0 {
+					emitLiteral(dst, src)
+				}
+				e.prev = nil
+				e.cur += len(src)
+				return
+			}
 
-	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
-	if e.cur > 1<<30 {
-		e.cur = 1
-	}
+			// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+			if e.cur > 1<<30 {
+				e.cur = 1
+			}
 
-	// Iterate over the source bytes.
-	var (
-		s   int // The iterator position.
-		lit int // The start position of any pending literal bytes.
-	)
+			// Iterate over the source bytes.
+			var (
+				s   int // The iterator position.
+				lit int // The start position of any pending literal bytes.
+			)
 
-	for s+3 < len(src) {
-		// Update the hash table.
-		h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
-		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-		tmp := *p
-		p1 := int(tmp & 0xffffffff) // Closest match position
-		p2 := int(tmp >> 32)        // Furthest match position
+			for s+3 < len(src) {
+				// Update the hash table.
+				h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
+				p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
+				tmp := *p
+				p1 := int(tmp & 0xffffffff) // Closest match position
+				p2 := int(tmp >> 32)        // Furthest match position
 
-		// We need to to store values in [-1, inf) in table.
-		// To save some initialization time, we make sure that
-		// e.cur is never zero.
-		t1 := p1 - e.cur
+				// We need to to store values in [-1, inf) in table.
+				// To save some initialization time, we make sure that
+				// e.cur is never zero.
+				t1 := p1 - e.cur
 
-		var l2 int
-		var t2 int
-		l1 := e.matchlen(s, t1, src)
-		// If fist match was ok, don't do the second.
-		if l1 < 16 {
-			t2 = p2 - e.cur
-			l2 = e.matchlen(s, t2, src)
+				var l2 int
+				var t2 int
+				l1 := e.matchlen(s, t1, src)
+				// If fist match was ok, don't do the second.
+				if l1 < 16 {
+					t2 = p2 - e.cur
+					l2 = e.matchlen(s, t2, src)
 
-			// If both are short, continue
-			if l1 < 4 && l2 < 4 {
+					// If both are short, continue
+					if l1 < 4 && l2 < 4 {
+						// Update hash table
+						*p = int64(s+e.cur) | (int64(p1) << 32)
+						// Skip 1 byte for 32 consecutive missed.
+						s += 1 + ((s - lit) >> 5)
+						continue
+					}
+				}
+
+				// Otherwise, we have a match. First, emit any pending literal bytes.
+				if lit != s {
+					emitLiteral(dst, src[lit:s])
+				}
 				// Update hash table
 				*p = int64(s+e.cur) | (int64(p1) << 32)
-				// Skip 1 byte for 32 consecutive missed.
-				s += 1 + ((s - lit) >> 5)
-				continue
+
+				// Store the longest match l1 will be closest, so we prefer that if equal length
+				if l1 >= l2 {
+					dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
+					s += l1
+				} else {
+					dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
+					s += l2
+				}
+				dst.n++
+				lit = s
+			}
+
+			// Emit any final pending literal bytes and return.
+			if lit != len(src) {
+				emitLiteral(dst, src[lit:])
+			}
+			e.cur += len(src)
+			// Store this block, if it was full length.
+			if len(src) == maxStoreBlockSize {
+				copy(e.block[:], src)
+				e.prev = e.block[:len(src)]
+			} else {
+				e.prev = nil
 			}
 		}
 
-		// Otherwise, we have a match. First, emit any pending literal bytes.
-		if lit != s {
-			emitLiteral(dst, src[lit:s])
-		}
-		// Update hash table
-		*p = int64(s+e.cur) | (int64(p1) << 32)
+		func (e *snappyGen) matchlen(s, t int, src []byte) int {
+			// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
+			offset := uint(s - t - 1)
 
-		// Store the longest match l1 will be closest, so we prefer that if equal length
-		if l1 >= l2 {
-			dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
-			s += l1
-		} else {
-			dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
-			s += l2
-		}
-		dst.n++
-		lit = s
-	}
+			// If we are inside the current block
+			if t >= 0 {
+				if offset >= (maxOffset-1) ||
+					src[s] != src[t] || src[s+1] != src[t+1] ||
+					src[s+2] != src[t+2] || src[s+3] != src[t+3] {
+					return 0
+				}
+				// Extend the match to be as long as possible.
+				s0 := s
+				s1 := s + maxMatchLength
+				if s1 > len(src) {
+					s1 = len(src)
+				}
+				s, t = s+4, t+4
+				for s < s1 && src[s] == src[t] {
+					s++
+					t++
+				}
+				return s - s0
+			}
 
-	// Emit any final pending literal bytes and return.
-	if lit != len(src) {
-		emitLiteral(dst, src[lit:])
-	}
-	e.cur += len(src)
-	// Store this block, if it was full length.
-	if len(src) == maxStoreBlockSize {
-		copy(e.block[:], src)
-		e.prev = e.block[:len(src)]
-	} else {
-		e.prev = nil
-	}
-}
+			// We found a match in the previous block.
+			tp := len(e.prev) + t
+			if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
+				src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
+				src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
+				return 0
+			}
 
-func (e *snappyGen) matchlen(s, t int, src []byte) int {
-	// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-	offset := uint(s - t - 1)
-
-	// If we are inside the current block
-	if t >= 0 {
-		if offset >= (maxOffset-1) ||
-			src[s] != src[t] || src[s+1] != src[t+1] ||
-			src[s+2] != src[t+2] || src[s+3] != src[t+3] {
-			return 0
-		}
-		// Extend the match to be as long as possible.
-		s0 := s
-		s1 := s + maxMatchLength
-		if s1 > len(src) {
-			s1 = len(src)
-		}
-		s, t = s+4, t+4
-		for s < s1 && src[s] == src[t] {
-			s++
-			t++
-		}
-		return s - s0
-	}
-
-	// We found a match in the previous block.
-	tp := len(e.prev) + t
-	if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
-		src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
-		src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
-		return 0
-	}
-
-	// Extend the match to be as long as possible.
-	s0 := s
-	s1 := s + maxMatchLength
-	if s1 > len(src) {
-		s1 = len(src)
-	}
-	s, tp = s+4, tp+4
-	for s < s1 && src[s] == e.prev[tp] {
-		s++
-		tp++
-		if tp == len(e.prev) {
-			t = 0
-			// continue in current buffer
-			for s < s1 && src[s] == src[t] {
+			// Extend the match to be as long as possible.
+			s0 := s
+			s1 := s + maxMatchLength
+			if s1 > len(src) {
+				s1 = len(src)
+			}
+			s, tp = s+4, tp+4
+			for s < s1 && src[s] == e.prev[tp] {
 				s++
-				t++
+				tp++
+				if tp == len(e.prev) {
+					t = 0
+					// continue in current buffer
+					for s < s1 && src[s] == src[t] {
+						s++
+						t++
+					}
+					return s - s0
+				}
 			}
 			return s - s0
-		}
-	}
-	return s - s0
+	*/
 }
 
 // Reset the encoding table.
@@ -517,135 +557,137 @@ type snappySSE4 struct {
 // but will keep two matches per hash.
 // Both hashes are checked if the first isn't ok, and the longest is selected.
 func (e *snappySSE4) encodeL3(dst *tokens, src []byte) {
-	// Return early if src is short.
-	if len(src) <= 4 {
-		if len(src) != 0 {
-			emitLiteral(dst, src)
-		}
-		e.prev = nil
-		e.cur += len(src)
-		return
-	}
+	/*
+			// Return early if src is short.
+			if len(src) <= 4 {
+				if len(src) != 0 {
+					emitLiteral(dst, src)
+				}
+				e.prev = nil
+				e.cur += len(src)
+				return
+			}
 
-	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
-	if e.cur > 1<<30 {
-		e.cur = 1
-	}
+			// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+			if e.cur > 1<<30 {
+				e.cur = 1
+			}
 
-	// Iterate over the source bytes.
-	var (
-		s   int // The iterator position.
-		lit int // The start position of any pending literal bytes.
-	)
+			// Iterate over the source bytes.
+			var (
+				s   int // The iterator position.
+				lit int // The start position of any pending literal bytes.
+			)
 
-	for s+3 < len(src) {
-		// Load potential matches from hash table.
-		h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
-		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-		tmp := *p
-		p1 := int(tmp & 0xffffffff) // Closest match position
-		p2 := int(tmp >> 32)        // Furthest match position
+			for s+3 < len(src) {
+				// Load potential matches from hash table.
+				h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
+				p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
+				tmp := *p
+				p1 := int(tmp & 0xffffffff) // Closest match position
+				p2 := int(tmp >> 32)        // Furthest match position
 
-		// We need to to store values in [-1, inf) in table.
-		// To save some initialization time, we make sure that
-		// e.cur is never zero.
-		t1 := int(p1) - e.cur
+				// We need to to store values in [-1, inf) in table.
+				// To save some initialization time, we make sure that
+				// e.cur is never zero.
+				t1 := int(p1) - e.cur
 
-		var l2 int
-		var t2 int
-		l1 := e.matchlen(s, t1, src)
-		// If fist match was ok, don't do the second.
-		if l1 < 16 {
-			t2 = int(p2) - e.cur
-			l2 = e.matchlen(s, t2, src)
+				var l2 int
+				var t2 int
+				l1 := e.matchlen(s, t1, src)
+				// If fist match was ok, don't do the second.
+				if l1 < 16 {
+					t2 = int(p2) - e.cur
+					l2 = e.matchlen(s, t2, src)
 
-			// If both are short, continue
-			if l1 < 4 && l2 < 4 {
+					// If both are short, continue
+					if l1 < 4 && l2 < 4 {
+						// Update hash table
+						*p = int64(s+e.cur) | (int64(p1) << 32)
+						// Skip 1 byte for 32 consecutive missed.
+						s += 1 + ((s - lit) >> 5)
+						continue
+					}
+				}
+
+				// Otherwise, we have a match. First, emit any pending literal bytes.
+				if lit != s {
+					emitLiteral(dst, src[lit:s])
+				}
 				// Update hash table
 				*p = int64(s+e.cur) | (int64(p1) << 32)
-				// Skip 1 byte for 32 consecutive missed.
-				s += 1 + ((s - lit) >> 5)
-				continue
+
+				// Store the longest match l1 will be closest, so we prefer that if equal length
+				if l1 >= l2 {
+					dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
+					s += l1
+				} else {
+					dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
+					s += l2
+				}
+				dst.n++
+				lit = s
+			}
+
+			// Emit any final pending literal bytes and return.
+			if lit != len(src) {
+				emitLiteral(dst, src[lit:])
+			}
+			e.cur += len(src)
+			// Store this block, if it was full length.
+			if len(src) == maxStoreBlockSize {
+				copy(e.block[:], src)
+				e.prev = e.block[:len(src)]
+			} else {
+				e.prev = nil
 			}
 		}
 
-		// Otherwise, we have a match. First, emit any pending literal bytes.
-		if lit != s {
-			emitLiteral(dst, src[lit:s])
-		}
-		// Update hash table
-		*p = int64(s+e.cur) | (int64(p1) << 32)
+		func (e *snappySSE4) matchlen(s, t int, src []byte) int {
+			// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
+			offset := uint(s - t - 1)
 
-		// Store the longest match l1 will be closest, so we prefer that if equal length
-		if l1 >= l2 {
-			dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
-			s += l1
-		} else {
-			dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
-			s += l2
-		}
-		dst.n++
-		lit = s
-	}
+			// If we are inside the current block
+			if t >= 0 {
+				if offset >= (maxOffset - 1) {
+					return 0
+				}
+				length := len(src) - s
+				if length > maxMatchLength {
+					length = maxMatchLength
+				}
+				// Extend the match to be as long as possible.
+				return matchLenSSE4(src[t:], src[s:], length)
+			}
 
-	// Emit any final pending literal bytes and return.
-	if lit != len(src) {
-		emitLiteral(dst, src[lit:])
-	}
-	e.cur += len(src)
-	// Store this block, if it was full length.
-	if len(src) == maxStoreBlockSize {
-		copy(e.block[:], src)
-		e.prev = e.block[:len(src)]
-	} else {
-		e.prev = nil
-	}
-}
+			// We found a match in the previous block.
+			tp := len(e.prev) + t
+			if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
+				src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
+				src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
+				return 0
+			}
 
-func (e *snappySSE4) matchlen(s, t int, src []byte) int {
-	// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-	offset := uint(s - t - 1)
-
-	// If we are inside the current block
-	if t >= 0 {
-		if offset >= (maxOffset - 1) {
-			return 0
-		}
-		length := len(src) - s
-		if length > maxMatchLength {
-			length = maxMatchLength
-		}
-		// Extend the match to be as long as possible.
-		return matchLenSSE4(src[t:], src[s:], length)
-	}
-
-	// We found a match in the previous block.
-	tp := len(e.prev) + t
-	if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
-		src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
-		src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
-		return 0
-	}
-
-	// Extend the match to be as long as possible.
-	s0 := s
-	s1 := s + maxMatchLength
-	if s1 > len(src) {
-		s1 = len(src)
-	}
-	s, tp = s+4, tp+4
-	for s < s1 && src[s] == e.prev[tp] {
-		s++
-		tp++
-		if tp == len(e.prev) {
-			t = 0
-			// continue in current buffer
-			for s < s1 && src[s] == src[t] {
+			// Extend the match to be as long as possible.
+			s0 := s
+			s1 := s + maxMatchLength
+			if s1 > len(src) {
+				s1 = len(src)
+			}
+			s, tp = s+4, tp+4
+			for s < s1 && src[s] == e.prev[tp] {
 				s++
-				t++
+				tp++
+				if tp == len(e.prev) {
+					t = 0
+					// continue in current buffer
+					for s < s1 && src[s] == src[t] {
+						s++
+						t++
+					}
+					return s - s0
+				}
 			}
 			return s - s0
-		}
-	}
-	return s - s0
+	*/
 }

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -30,9 +30,9 @@ func newSnappy(level int) snappyEnc {
 	case 1:
 		return &snappyL1{}
 	case 2:
-		return &snappyL2{snappyGen: snappyGen{cur: 1, prev: make([]byte, 0, maxStoreBlockSize)}}
+		return &snappyL2{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}
 	case 3:
-		return &snappyL3{snappyGen: snappyGen{cur: 1, prev: make([]byte, 0, maxStoreBlockSize)}}
+		return &snappyL3{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}
 	default:
 		panic("invalid level specified")
 	}
@@ -249,7 +249,7 @@ func (e *snappyL2) Encode(dst *tokens, src []byte) {
 		for i := range e.table {
 			e.table[i] = tableEntry{}
 		}
-		e.cur = 1
+		e.cur = maxStoreBlockSize
 	}
 
 	// This check isn't in the Snappy implementation, but there, the caller
@@ -308,8 +308,7 @@ func (e *snappyL2) Encode(dst *tokens, src []byte) {
 			nextHash = hash(now)
 
 			offset := s - (candidate.offset - e.cur)
-			if offset >= maxMatchOffset ||
-				cv != candidate.val {
+			if offset >= maxMatchOffset || cv != candidate.val {
 				// Out of range or not matched.
 				cv = now
 				continue
@@ -364,8 +363,7 @@ func (e *snappyL2) Encode(dst *tokens, src []byte) {
 			e.table[currHash&tableMask] = tableEntry{offset: e.cur + s, val: uint32(x)}
 
 			offset := s - (candidate.offset - e.cur)
-			if offset >= maxMatchOffset ||
-				uint32(x) != candidate.val {
+			if offset >= maxMatchOffset || uint32(x) != candidate.val {
 				cv = uint32(x >> 8)
 				nextHash = hash(cv)
 				s++
@@ -406,7 +404,7 @@ func (e *snappyL3) Encode(dst *tokens, src []byte) {
 		for i := range e.table {
 			e.table[i] = tableEntryPrev{}
 		}
-		e.cur = 1
+		e.cur = maxStoreBlockSize
 	}
 
 	// This check isn't in the Snappy implementation, but there, the caller

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -5,9 +5,6 @@
 
 package flate
 
-// We limit how far copy back-references can go, the same as the C++ code.
-const maxOffset = 1 << 15
-
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 func emitLiteral(dst *tokens, lit []byte) {
 	ol := int(dst.n)
@@ -29,27 +26,16 @@ type snappyEnc interface {
 }
 
 func newSnappy(level int) snappyEnc {
-	if false && useSSE42 {
-		e := &snappySSE4{snappyGen: snappyGen{cur: 1}}
-		switch level {
-		case 3:
-			e.enc = e.encodeL3
-			return e
-		}
-	}
-	if level == 1 {
-		return &snappyL1{}
-	}
-	e := &snappyGen{cur: 1}
 	switch level {
+	case 1:
+		return &snappyL1{}
 	case 2:
-		e.enc = e.encodeL2
+		return &snappyL2{snappyGen: snappyGen{cur: 1, prev: make([]byte, 0, maxStoreBlockSize)}}
 	case 3:
-		e.enc = e.encodeL2
+		return &snappyL3{snappyGen: snappyGen{cur: 1, prev: make([]byte, 0, maxStoreBlockSize)}}
 	default:
 		panic("invalid level specified")
 	}
-	return e
 }
 
 const (
@@ -60,7 +46,6 @@ const (
 	baseMatchOffset = 1              // The smallest match offset
 	baseMatchLength = 3              // The smallest match length per the RFC section 3.2.5
 	maxMatchOffset  = 1 << 15        // The largest match offset
-	inputMargin     = 16 - 1
 )
 
 func load32(b []byte, i int) uint32 {
@@ -239,24 +224,31 @@ func load6432(b []byte, i int32) uint64 {
 // and the previous byte block for level 2.
 // This is the generic implementation.
 type snappyGen struct {
-	table [tableSize]tableEntry
-	block [maxStoreBlockSize]byte
-	prev  []byte
-	cur   int32
-	enc   func(dst *tokens, src []byte)
+	prev []byte
+	cur  int32
+	enc  func(dst *tokens, src []byte)
 }
 
-func (e *snappyGen) Encode(dst *tokens, src []byte) {
-	e.enc(dst, src)
+// snappyGen maintains the table for matches,
+// and the previous byte block for level 2.
+// This is the generic implementation.
+type snappyL2 struct {
+	snappyGen
+	table [tableSize]tableEntry
 }
 
 // EncodeL2 uses a similar algorithm to level 1, but is capable
 // of matching across blocks giving better compression at a small slowdown.
-func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
+func (e *snappyL2) Encode(dst *tokens, src []byte) {
 	const (
 		inputMargin            = 16 - 1
 		minNonLiteralBlockSize = 1 + 1 + inputMargin
 	)
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 1
+	}
 
 	// This check isn't in the Snappy implementation, but there, the caller
 	// instead of the callee handles this case.
@@ -265,12 +257,8 @@ func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
 		// This will be picked up by caller.
 		dst.n = uint16(len(src))
 		e.cur += int32(len(src)) + maxStoreBlockSize
+		e.prev = e.prev[:0]
 		return
-	}
-
-	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
-	if e.cur > 1<<30 {
-		e.cur = 1
 	}
 
 	// sLimit is when to stop looking for offset/length copies. The inputMargin
@@ -304,6 +292,7 @@ func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
 		// the last match; dividing it by 32 (ie. right-shifting by five) gives
 		// the number of bytes to move ahead for each iteration.
 		skip := int32(32)
+		var nPrevLen = int32(-len(e.prev))
 
 		nextS := s
 		var candidate tableEntry
@@ -319,9 +308,183 @@ func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
 			now := load3232(src, nextS)
 			e.table[nextHash&tableMask] = tableEntry{offset: s + e.cur, val: cv}
 			nextHash = hash(now)
-			// TODO: < should be <=, and add a test for that.
-			if cv == candidate.val && uint(s-(candidate.offset-e.cur)) < maxMatchOffset {
+
+			offset := s - (candidate.offset - e.cur)
+			if offset > maxMatchOffset ||
+				cv != candidate.val ||
+				offset <= nPrevLen {
+				// Out of range or not matched.
+				cv = now
+				continue
+			}
+			break
+		}
+
+		// A 4-byte match has been found. We'll later see if more than 4 bytes
+		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+		// them as literal bytes.
+		emitLiteral(dst, src[nextEmit:s])
+
+		// Call emitCopy, and then see if another emitCopy could be our next
+		// move. Repeat until we find no match for the input immediately after
+		// what was consumed by the last emitCopy call.
+		//
+		// If we exit this loop normally then we need to call emitLiteral next,
+		// though we don't yet know how big the literal will be. We handle that
+		// by proceeding to the next iteration of the main loop. We also can
+		// exit this loop via goto if we get close to exhausting the input.
+		for {
+			// Invariant: we have a 4-byte match at s, and no need to emit any
+			// literal bytes prior to s.
+
+			// Extend the 4-byte match as long as possible.
+			//
+			s += 4
+			t := candidate.offset - e.cur + 4
+			l := e.matchlen(s, t, src)
+
+			// matchToken is flate's equivalent of Snappy's emitCopy. (length,offset)
+			dst.tokens[dst.n] = matchToken(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
+			dst.n++
+			s += l
+			nextEmit = s
+			if s >= sLimit {
+				goto emitRemainder
+			}
+
+			// We could immediately start working at s now, but to improve
+			// compression we first update the hash table at s-1 and at s. If
+			// another emitCopy is not our next move, also calculate nextHash
+			// at s+1. At least on GOARCH=amd64, these three hash calculations
+			// are faster as one load64 call (with some shifts) instead of
+			// three load32 calls.
+			x := load6432(src, s-1)
+			prevHash := hash(uint32(x))
+			e.table[prevHash&tableMask] = tableEntry{offset: e.cur + s - 1, val: uint32(x)}
+			x >>= 8
+			currHash := hash(uint32(x))
+			candidate = e.table[currHash&tableMask]
+			e.table[currHash&tableMask] = tableEntry{offset: e.cur + s, val: uint32(x)}
+
+			offset := s - (candidate.offset - e.cur)
+			if offset > maxMatchOffset ||
+				uint32(x) != candidate.val ||
+				offset <= nPrevLen {
+				cv = uint32(x >> 8)
+				nextHash = hash(cv)
+				s++
 				break
+			}
+		}
+	}
+
+emitRemainder:
+	if int(nextEmit) < len(src) {
+		emitLiteral(dst, src[nextEmit:])
+	}
+	e.cur += int32(len(src))
+	e.prev = e.prev[:len(src)]
+	copy(e.prev, src)
+}
+
+type tableEntryPrev struct {
+	Cur  tableEntry
+	Prev tableEntry
+}
+
+// snappyL3
+type snappyL3 struct {
+	snappyGen
+	table [tableSize]tableEntryPrev
+}
+
+// Encode uses a similar algorithm to level 2, will check up to two candidates.
+func (e *snappyL3) Encode(dst *tokens, src []byte) {
+	const (
+		inputMargin            = 16 - 1
+		minNonLiteralBlockSize = 1 + 1 + inputMargin
+	)
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		e.cur = 1
+	}
+
+	// This check isn't in the Snappy implementation, but there, the caller
+	// instead of the callee handles this case.
+	if len(src) < minNonLiteralBlockSize {
+		// We do not fill the token table.
+		// This will be picked up by caller.
+		dst.n = uint16(len(src))
+		e.cur += int32(len(src)) + maxStoreBlockSize
+		e.prev = e.prev[:0]
+		return
+	}
+
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := int32(len(src) - inputMargin)
+
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := int32(0)
+
+	// The encoded form must start with a literal, as there are no previous
+	// bytes to copy, so we start looking for hash matches at s == 1.
+	s := int32(1)
+	cv := load3232(src, s)
+	nextHash := hash(cv)
+	var nPrevLen = int32(-len(e.prev))
+
+	for {
+		// Copied from the C++ snappy implementation:
+		//
+		// Heuristic match skipping: If 32 bytes are scanned with no matches
+		// found, start looking only at every other byte. If 32 more bytes are
+		// scanned (or skipped), look at every third byte, etc.. When a match
+		// is found, immediately go back to looking at every byte. This is a
+		// small loss (~5% performance, ~0.1% density) for compressible data
+		// due to more bookkeeping, but for non-compressible data (such as
+		// JPEG) it's a huge win since the compressor quickly "realizes" the
+		// data is incompressible and doesn't bother looking for matches
+		// everywhere.
+		//
+		// The "skip" variable keeps track of how many bytes there are since
+		// the last match; dividing it by 32 (ie. right-shifting by five) gives
+		// the number of bytes to move ahead for each iteration.
+		skip := int32(32)
+
+		nextS := s
+		var candidate tableEntry
+		for {
+			s = nextS
+			bytesBetweenHashLookups := skip >> 5
+			nextS = s + bytesBetweenHashLookups
+			skip += bytesBetweenHashLookups
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			candidates := e.table[nextHash&tableMask]
+			now := load3232(src, nextS)
+			e.table[nextHash&tableMask] = tableEntryPrev{Prev: candidates.Cur, Cur: tableEntry{offset: s + e.cur, val: cv}}
+			nextHash = hash(now)
+
+			// Check both candidates
+			candidate = candidates.Cur
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset &&
+					offset > nPrevLen {
+					break
+				}
+			}
+			candidate = candidates.Prev
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset &&
+					offset > nPrevLen {
+					break
+				}
 			}
 			cv = now
 		}
@@ -342,24 +505,17 @@ func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
 		for {
 			// Invariant: we have a 4-byte match at s, and no need to emit any
 			// literal bytes prior to s.
-			base := s
 
 			// Extend the 4-byte match as long as possible.
 			//
-			// This is an inlined version of Snappy's:
-			//	s = extendMatch(src, candidate+4, s+4)
 			s += 4
-			s1 := base + maxMatchLength
-			if s1 > int32(len(src)) {
-				s1 = int32(len(src))
-			}
-			pos := int(candidate.offset - e.cur)
-			for i := pos + 4; s < s1 && src[i] == src[s]; i, s = i+1, s+1 {
-			}
+			t := candidate.offset - e.cur + 4
+			l := e.matchlen(s, t, src)
 
-			// matchToken is flate's equivalent of Snappy's emitCopy.
-			dst.tokens[dst.n] = matchToken(uint32(s-base-baseMatchLength), uint32(int(base)-pos-baseMatchOffset))
+			// matchToken is flate's equivalent of Snappy's emitCopy. (length,offset)
+			dst.tokens[dst.n] = matchTokend(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
 			dst.n++
+			s += l
 			nextEmit = s
 			if s >= sLimit {
 				goto emitRemainder
@@ -373,18 +529,41 @@ func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
 			// three load32 calls.
 			x := load6432(src, s-1)
 			prevHash := hash(uint32(x))
-			e.table[prevHash&tableMask] = tableEntry{offset: e.cur + s - 1, val: uint32(x)}
+
+			e.table[prevHash&tableMask] = tableEntryPrev{
+				Prev: e.table[prevHash&tableMask].Cur,
+				Cur:  tableEntry{offset: e.cur + s - 1, val: uint32(x)},
+			}
 			x >>= 8
 			currHash := hash(uint32(x))
-			candidate = e.table[currHash&tableMask]
-			e.table[currHash&tableMask] = tableEntry{offset: e.cur + s, val: uint32(x)}
-			// TODO: >= should be >, and add a test for that.
-			if uint32(x) != candidate.val || uint(s-(candidate.offset-e.cur)) >= maxMatchOffset {
-				cv = uint32(x >> 8)
-				nextHash = hash(cv)
-				s++
-				break
+			candidates := e.table[currHash&tableMask]
+			cv = uint32(x)
+			e.table[currHash&tableMask] = tableEntryPrev{
+				Prev: candidates.Cur,
+				Cur:  tableEntry{offset: s + e.cur, val: cv},
 			}
+
+			// Check both candidates
+			candidate = candidates.Cur
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset &&
+					offset > nPrevLen {
+					continue
+				}
+			}
+			candidate = candidates.Prev
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset &&
+					offset > nPrevLen {
+					continue
+				}
+			}
+			cv = uint32(x >> 8)
+			nextHash = hash(cv)
+			s++
+			break
 		}
 	}
 
@@ -392,302 +571,47 @@ emitRemainder:
 	if int(nextEmit) < len(src) {
 		emitLiteral(dst, src[nextEmit:])
 	}
-	e.cur += int32(len(src)) + maxStoreBlockSize
+	e.cur += int32(len(src))
+	e.prev = e.prev[:len(src)]
+	copy(e.prev, src)
 }
 
-// EncodeL3 uses a similar algorithm to level 2, but is capable
-// will keep two matches per hash.
-// Both hashes are checked if the first isn't ok, and the longest is selected.
-func (e *snappyGen) encodeL3(dst *tokens, src []byte) {
-	/*
-			// Return early if src is short.
-			if len(src) <= 4 {
-				if len(src) != 0 {
-					emitLiteral(dst, src)
-				}
-				e.prev = nil
-				e.cur += len(src)
-				return
-			}
+func (e *snappyGen) matchlen(s, t int32, src []byte) int32 {
+	s0 := s
+	s1 := s + maxMatchLength - 4
+	if s1 > int32(len(src)) {
+		s1 = int32(len(src))
+	}
 
-			// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
-			if e.cur > 1<<30 {
-				e.cur = 1
-			}
-
-			// Iterate over the source bytes.
-			var (
-				s   int // The iterator position.
-				lit int // The start position of any pending literal bytes.
-			)
-
-			for s+3 < len(src) {
-				// Update the hash table.
-				h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
-				p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-				tmp := *p
-				p1 := int(tmp & 0xffffffff) // Closest match position
-				p2 := int(tmp >> 32)        // Furthest match position
-
-				// We need to to store values in [-1, inf) in table.
-				// To save some initialization time, we make sure that
-				// e.cur is never zero.
-				t1 := p1 - e.cur
-
-				var l2 int
-				var t2 int
-				l1 := e.matchlen(s, t1, src)
-				// If fist match was ok, don't do the second.
-				if l1 < 16 {
-					t2 = p2 - e.cur
-					l2 = e.matchlen(s, t2, src)
-
-					// If both are short, continue
-					if l1 < 4 && l2 < 4 {
-						// Update hash table
-						*p = int64(s+e.cur) | (int64(p1) << 32)
-						// Skip 1 byte for 32 consecutive missed.
-						s += 1 + ((s - lit) >> 5)
-						continue
-					}
-				}
-
-				// Otherwise, we have a match. First, emit any pending literal bytes.
-				if lit != s {
-					emitLiteral(dst, src[lit:s])
-				}
-				// Update hash table
-				*p = int64(s+e.cur) | (int64(p1) << 32)
-
-				// Store the longest match l1 will be closest, so we prefer that if equal length
-				if l1 >= l2 {
-					dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
-					s += l1
-				} else {
-					dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
-					s += l2
-				}
-				dst.n++
-				lit = s
-			}
-
-			// Emit any final pending literal bytes and return.
-			if lit != len(src) {
-				emitLiteral(dst, src[lit:])
-			}
-			e.cur += len(src)
-			// Store this block, if it was full length.
-			if len(src) == maxStoreBlockSize {
-				copy(e.block[:], src)
-				e.prev = e.block[:len(src)]
-			} else {
-				e.prev = nil
-			}
+	// If we are inside the current block
+	if t >= 0 {
+		// Extend the match to be as long as possible.
+		for s < s1 && src[s] == src[t] {
+			s, t = s+1, t+1
 		}
+		return s - s0
+	}
 
-		func (e *snappyGen) matchlen(s, t int, src []byte) int {
-			// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-			offset := uint(s - t - 1)
+	// We found a match in the previous block.
+	tp := int32(len(e.prev)) + t
 
-			// If we are inside the current block
-			if t >= 0 {
-				if offset >= (maxOffset-1) ||
-					src[s] != src[t] || src[s+1] != src[t+1] ||
-					src[s+2] != src[t+2] || src[s+3] != src[t+3] {
-					return 0
-				}
-				// Extend the match to be as long as possible.
-				s0 := s
-				s1 := s + maxMatchLength
-				if s1 > len(src) {
-					s1 = len(src)
-				}
-				s, t = s+4, t+4
-				for s < s1 && src[s] == src[t] {
-					s++
-					t++
-				}
-				return s - s0
-			}
-
-			// We found a match in the previous block.
-			tp := len(e.prev) + t
-			if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
-				src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
-				src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
-				return 0
-			}
-
-			// Extend the match to be as long as possible.
-			s0 := s
-			s1 := s + maxMatchLength
-			if s1 > len(src) {
-				s1 = len(src)
-			}
-			s, tp = s+4, tp+4
-			for s < s1 && src[s] == e.prev[tp] {
-				s++
-				tp++
-				if tp == len(e.prev) {
-					t = 0
-					// continue in current buffer
-					for s < s1 && src[s] == src[t] {
-						s++
-						t++
-					}
-					return s - s0
-				}
+	// Extend the match to be as long as possible.
+	for s < s1 && src[s] == e.prev[tp] {
+		s, tp = s+1, tp+1
+		if tp == int32(len(e.prev)) {
+			// continue in current buffer
+			t = 0
+			for s < s1 && src[s] == src[t] {
+				s, t = s+1, t+1
 			}
 			return s - s0
-	*/
+		}
+	}
+	return s - s0
 }
 
 // Reset the encoding table.
 func (e *snappyGen) Reset() {
-	e.prev = nil
-}
-
-// snappySSE4 extends snappyGen.
-// This implementation can use SSE 4.2 for length matching.
-type snappySSE4 struct {
-	snappyGen
-}
-
-// EncodeL3 uses a similar algorithm to level 2,
-// but will keep two matches per hash.
-// Both hashes are checked if the first isn't ok, and the longest is selected.
-func (e *snappySSE4) encodeL3(dst *tokens, src []byte) {
-	/*
-			// Return early if src is short.
-			if len(src) <= 4 {
-				if len(src) != 0 {
-					emitLiteral(dst, src)
-				}
-				e.prev = nil
-				e.cur += len(src)
-				return
-			}
-
-			// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
-			if e.cur > 1<<30 {
-				e.cur = 1
-			}
-
-			// Iterate over the source bytes.
-			var (
-				s   int // The iterator position.
-				lit int // The start position of any pending literal bytes.
-			)
-
-			for s+3 < len(src) {
-				// Load potential matches from hash table.
-				h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
-				p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-				tmp := *p
-				p1 := int(tmp & 0xffffffff) // Closest match position
-				p2 := int(tmp >> 32)        // Furthest match position
-
-				// We need to to store values in [-1, inf) in table.
-				// To save some initialization time, we make sure that
-				// e.cur is never zero.
-				t1 := int(p1) - e.cur
-
-				var l2 int
-				var t2 int
-				l1 := e.matchlen(s, t1, src)
-				// If fist match was ok, don't do the second.
-				if l1 < 16 {
-					t2 = int(p2) - e.cur
-					l2 = e.matchlen(s, t2, src)
-
-					// If both are short, continue
-					if l1 < 4 && l2 < 4 {
-						// Update hash table
-						*p = int64(s+e.cur) | (int64(p1) << 32)
-						// Skip 1 byte for 32 consecutive missed.
-						s += 1 + ((s - lit) >> 5)
-						continue
-					}
-				}
-
-				// Otherwise, we have a match. First, emit any pending literal bytes.
-				if lit != s {
-					emitLiteral(dst, src[lit:s])
-				}
-				// Update hash table
-				*p = int64(s+e.cur) | (int64(p1) << 32)
-
-				// Store the longest match l1 will be closest, so we prefer that if equal length
-				if l1 >= l2 {
-					dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
-					s += l1
-				} else {
-					dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
-					s += l2
-				}
-				dst.n++
-				lit = s
-			}
-
-			// Emit any final pending literal bytes and return.
-			if lit != len(src) {
-				emitLiteral(dst, src[lit:])
-			}
-			e.cur += len(src)
-			// Store this block, if it was full length.
-			if len(src) == maxStoreBlockSize {
-				copy(e.block[:], src)
-				e.prev = e.block[:len(src)]
-			} else {
-				e.prev = nil
-			}
-		}
-
-		func (e *snappySSE4) matchlen(s, t int, src []byte) int {
-			// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-			offset := uint(s - t - 1)
-
-			// If we are inside the current block
-			if t >= 0 {
-				if offset >= (maxOffset - 1) {
-					return 0
-				}
-				length := len(src) - s
-				if length > maxMatchLength {
-					length = maxMatchLength
-				}
-				// Extend the match to be as long as possible.
-				return matchLenSSE4(src[t:], src[s:], length)
-			}
-
-			// We found a match in the previous block.
-			tp := len(e.prev) + t
-			if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
-				src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
-				src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
-				return 0
-			}
-
-			// Extend the match to be as long as possible.
-			s0 := s
-			s1 := s + maxMatchLength
-			if s1 > len(src) {
-				s1 = len(src)
-			}
-			s, tp = s+4, tp+4
-			for s < s1 && src[s] == e.prev[tp] {
-				s++
-				tp++
-				if tp == len(e.prev) {
-					t = 0
-					// continue in current buffer
-					for s < s1 && src[s] == src[t] {
-						s++
-						t++
-					}
-					return s - s0
-				}
-			}
-			return s - s0
-	*/
+	e.prev = e.prev[:0]
+	e.cur += maxMatchOffset + 1
 }

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -226,7 +226,6 @@ func load6432(b []byte, i int32) uint64 {
 type snappyGen struct {
 	prev []byte
 	cur  int32
-	enc  func(dst *tokens, src []byte)
 }
 
 // snappyGen maintains the table for matches,
@@ -256,7 +255,7 @@ func (e *snappyL2) Encode(dst *tokens, src []byte) {
 		// We do not fill the token table.
 		// This will be picked up by caller.
 		dst.n = uint16(len(src))
-		e.cur += int32(len(src)) + maxStoreBlockSize
+		e.cur += maxStoreBlockSize
 		e.prev = e.prev[:0]
 		return
 	}
@@ -416,7 +415,7 @@ func (e *snappyL3) Encode(dst *tokens, src []byte) {
 		// We do not fill the token table.
 		// This will be picked up by caller.
 		dst.n = uint16(len(src))
-		e.cur += int32(len(src)) + maxStoreBlockSize
+		e.cur += maxStoreBlockSize
 		e.prev = e.prev[:0]
 		return
 	}

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -33,6 +33,8 @@ func newSnappy(level int) snappyEnc {
 		return &snappyL2{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}
 	case 3:
 		return &snappyL3{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}
+	case 4:
+		return &snappyL4{snappyL3{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}}
 	default:
 		panic("invalid level specified")
 	}
@@ -507,7 +509,7 @@ func (e *snappyL3) Encode(dst *tokens, src []byte) {
 			l := e.matchlen(s, t, src)
 
 			// matchToken is flate's equivalent of Snappy's emitCopy. (length,offset)
-			dst.tokens[dst.n] = matchTokend(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
+			dst.tokens[dst.n] = matchToken(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
 			dst.n++
 			s += l
 			nextEmit = s
@@ -549,6 +551,217 @@ func (e *snappyL3) Encode(dst *tokens, src []byte) {
 			if cv == candidate.val {
 				offset := s - (candidate.offset - e.cur)
 				if offset < maxMatchOffset {
+					continue
+				}
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset {
+						continue
+					}
+				}
+			}
+			cv = uint32(x >> 8)
+			nextHash = hash(cv)
+			s++
+			break
+		}
+	}
+
+emitRemainder:
+	if int(nextEmit) < len(src) {
+		emitLiteral(dst, src[nextEmit:])
+	}
+	e.cur += int32(len(src))
+	e.prev = e.prev[:len(src)]
+	copy(e.prev, src)
+}
+
+// snappyL4
+type snappyL4 struct {
+	snappyL3
+}
+
+// Encode uses a similar algorithm to level 3,
+// but will check up to two candidates if first isn't long enough.
+func (e *snappyL4) Encode(dst *tokens, src []byte) {
+	const (
+		inputMargin            = 16 - 1
+		minNonLiteralBlockSize = 1 + 1 + inputMargin
+		matchLenGood           = 12
+	)
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		for i := range e.table {
+			e.table[i] = tableEntryPrev{}
+		}
+		e.cur = maxStoreBlockSize
+	}
+
+	// This check isn't in the Snappy implementation, but there, the caller
+	// instead of the callee handles this case.
+	if len(src) < minNonLiteralBlockSize {
+		// We do not fill the token table.
+		// This will be picked up by caller.
+		dst.n = uint16(len(src))
+		e.cur += maxStoreBlockSize
+		e.prev = e.prev[:0]
+		return
+	}
+
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := int32(len(src) - inputMargin)
+
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := int32(0)
+	s := int32(0)
+	cv := load3232(src, s)
+	nextHash := hash(cv)
+
+	for {
+		// Copied from the C++ snappy implementation:
+		//
+		// Heuristic match skipping: If 32 bytes are scanned with no matches
+		// found, start looking only at every other byte. If 32 more bytes are
+		// scanned (or skipped), look at every third byte, etc.. When a match
+		// is found, immediately go back to looking at every byte. This is a
+		// small loss (~5% performance, ~0.1% density) for compressible data
+		// due to more bookkeeping, but for non-compressible data (such as
+		// JPEG) it's a huge win since the compressor quickly "realizes" the
+		// data is incompressible and doesn't bother looking for matches
+		// everywhere.
+		//
+		// The "skip" variable keeps track of how many bytes there are since
+		// the last match; dividing it by 32 (ie. right-shifting by five) gives
+		// the number of bytes to move ahead for each iteration.
+		skip := int32(32)
+
+		nextS := s
+		var candidate tableEntry
+		var candidateAlt tableEntry
+		for {
+			s = nextS
+			bytesBetweenHashLookups := skip >> 5
+			nextS = s + bytesBetweenHashLookups
+			skip += bytesBetweenHashLookups
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			candidates := e.table[nextHash&tableMask]
+			now := load3232(src, nextS)
+			e.table[nextHash&tableMask] = tableEntryPrev{Prev: candidates.Cur, Cur: tableEntry{offset: s + e.cur, val: cv}}
+			nextHash = hash(now)
+
+			// Check both candidates
+			candidate = candidates.Cur
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset {
+					offset = s - (candidates.Prev.offset - e.cur)
+					if cv == candidates.Prev.val && offset < maxMatchOffset {
+						candidateAlt = candidates.Prev
+					}
+					break
+				}
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset {
+						break
+					}
+				}
+			}
+			cv = now
+		}
+
+		// A 4-byte match has been found. We'll later see if more than 4 bytes
+		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+		// them as literal bytes.
+		emitLiteral(dst, src[nextEmit:s])
+
+		// Call emitCopy, and then see if another emitCopy could be our next
+		// move. Repeat until we find no match for the input immediately after
+		// what was consumed by the last emitCopy call.
+		//
+		// If we exit this loop normally then we need to call emitLiteral next,
+		// though we don't yet know how big the literal will be. We handle that
+		// by proceeding to the next iteration of the main loop. We also can
+		// exit this loop via goto if we get close to exhausting the input.
+		for {
+			// Invariant: we have a 4-byte match at s, and no need to emit any
+			// literal bytes prior to s.
+
+			// Extend the 4-byte match as long as possible.
+			//
+			s += 4
+			t := candidate.offset - e.cur + 4
+			l := e.matchlen(s, t, src)
+			// Try alternative candidate if match length < matchLenGood.
+			if l < matchLenGood-4 && candidateAlt.offset != 0 {
+				t2 := candidateAlt.offset - e.cur + 4
+				l2 := e.matchlen(s, t2, src)
+				if l2 > l {
+					l = l2
+					t = t2
+				}
+			}
+			// matchToken is flate's equivalent of Snappy's emitCopy. (length,offset)
+			dst.tokens[dst.n] = matchToken(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
+			dst.n++
+			s += l
+			nextEmit = s
+			if s >= sLimit {
+				goto emitRemainder
+			}
+
+			// We could immediately start working at s now, but to improve
+			// compression we first update the hash table at s-2, s-1 and at s. If
+			// another emitCopy is not our next move, also calculate nextHash
+			// at s+1. At least on GOARCH=amd64, these three hash calculations
+			// are faster as one load64 call (with some shifts) instead of
+			// three load32 calls.
+			x := load6432(src, s-2)
+			prevHash := hash(uint32(x))
+
+			e.table[prevHash&tableMask] = tableEntryPrev{
+				Prev: e.table[prevHash&tableMask].Cur,
+				Cur:  tableEntry{offset: e.cur + s - 2, val: uint32(x)},
+			}
+			x >>= 8
+			prevHash = hash(uint32(x))
+
+			e.table[prevHash&tableMask] = tableEntryPrev{
+				Prev: e.table[prevHash&tableMask].Cur,
+				Cur:  tableEntry{offset: e.cur + s - 1, val: uint32(x)},
+			}
+			x >>= 8
+			currHash := hash(uint32(x))
+			candidates := e.table[currHash&tableMask]
+			cv = uint32(x)
+			e.table[currHash&tableMask] = tableEntryPrev{
+				Prev: candidates.Cur,
+				Cur:  tableEntry{offset: s + e.cur, val: cv},
+			}
+
+			// Check both candidates
+			candidate = candidates.Cur
+			candidateAlt = tableEntry{}
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset {
+					offset = s - (candidates.Prev.offset - e.cur)
+					if cv == candidates.Prev.val && offset < maxMatchOffset {
+						candidateAlt = candidates.Prev
+					}
 					continue
 				}
 			} else {

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -270,10 +270,7 @@ func (e *snappyL2) Encode(dst *tokens, src []byte) {
 
 	// nextEmit is where in src the next emitLiteral should start from.
 	nextEmit := int32(0)
-
-	// The encoded form must start with a literal, as there are no previous
-	// bytes to copy, so we start looking for hash matches at s == 1.
-	s := int32(1)
+	s := int32(0)
 	cv := load3232(src, s)
 	nextHash := hash(cv)
 
@@ -430,10 +427,7 @@ func (e *snappyL3) Encode(dst *tokens, src []byte) {
 
 	// nextEmit is where in src the next emitLiteral should start from.
 	nextEmit := int32(0)
-
-	// The encoded form must start with a literal, as there are no previous
-	// bytes to copy, so we start looking for hash matches at s == 1.
-	s := int32(1)
+	s := int32(0)
 	cv := load3232(src, s)
 	nextHash := hash(cv)
 

--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -477,13 +477,16 @@ func (e *snappyL3) Encode(dst *tokens, src []byte) {
 					offset > nPrevLen {
 					break
 				}
-			}
-			candidate = candidates.Prev
-			if cv == candidate.val {
-				offset := s - (candidate.offset - e.cur)
-				if offset < maxMatchOffset &&
-					offset > nPrevLen {
-					break
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset &&
+						offset > nPrevLen {
+						break
+					}
 				}
 			}
 			cv = now
@@ -551,13 +554,16 @@ func (e *snappyL3) Encode(dst *tokens, src []byte) {
 					offset > nPrevLen {
 					continue
 				}
-			}
-			candidate = candidates.Prev
-			if cv == candidate.val {
-				offset := s - (candidate.offset - e.cur)
-				if offset < maxMatchOffset &&
-					offset > nPrevLen {
-					continue
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset &&
+						offset > nPrevLen {
+						continue
+					}
 				}
 			}
 			cv = uint32(x >> 8)

--- a/flate/token.go
+++ b/flate/token.go
@@ -4,6 +4,8 @@
 
 package flate
 
+import "fmt"
+
 const (
 	// 2 bits:   type   0 = literal  1=EOF  2=Match   3=Unused
 	// 8 bits:   xlength = length - MIN_MATCH_LENGTH
@@ -77,6 +79,14 @@ func literalToken(literal uint32) token { return token(literalType + literal) }
 
 // Convert a < xlength, xoffset > pair into a match token.
 func matchToken(xlength uint32, xoffset uint32) token {
+	return token(matchType + xlength<<lengthShift + xoffset)
+}
+
+func matchTokend(xlength uint32, xoffset uint32) token {
+	if xlength > maxMatchLength || xoffset > maxMatchOffset {
+		fmt.Printf("Invalid match: len: %d, offset: %d\n", xlength, xoffset)
+		return token(matchType)
+	}
 	return token(matchType + xlength<<lengthShift + xoffset)
 }
 

--- a/flate/token.go
+++ b/flate/token.go
@@ -84,7 +84,7 @@ func matchToken(xlength uint32, xoffset uint32) token {
 
 func matchTokend(xlength uint32, xoffset uint32) token {
 	if xlength > maxMatchLength || xoffset > maxMatchOffset {
-		fmt.Printf("Invalid match: len: %d, offset: %d\n", xlength, xoffset)
+		panic(fmt.Sprintf("Invalid match: len: %d, offset: %d\n", xlength, xoffset))
 		return token(matchType)
 	}
 	return token(matchType + xlength<<lengthShift + xoffset)


### PR DESCRIPTION
Rewrite level 1 to a new level 2, that can do cross-block matching.

This provides a speedup to level 2+3 and rebalances level 4-7 accordingly.

AMD64, 1 core used.

"Level", "Gzipped size", "Throughput". 

Web content (sites, 481601400 bytes):
```
1, 165556800 bytes, 71.96MB/s
2, 163167700 bytes, 70.18MB/s
3, 162457100 bytes, 66.70MB/s 
```

enwik9 (1000000000 bytes):
```
1,  391052014 bytes, 78.36 MB/s
2,  382585541 bytes, 73.99 MB/s
3,  373035681 bytes, 68.46 MB/s
```

Highly compressible JSON (adresser.001, 1073741824 bytes):
```
1,  58161197 bytes, 288.94 MB/s
2,  48010017 bytes, 301.03 MB/s
3,  44563592 bytes, 357.03 MB/s
```

VM Image (rawstudio-mint14.tar, 8558382592 bytes):
```
1, 4030083076, 105.52 MB/s
2, 3956375446, 98.82 MB/s
3, 3924833672, 96.13 MB/s
```
