### PR TITLE
Rewrite level 2+3+4 compression (#61)

### DIFF
--- a/flate/snappy.go
+++ b/flate/snappy.go
@@ -5,9 +5,6 @@
 
 package flate
 
-// We limit how far copy back-references can go, the same as the C++ code.
-const maxOffset = 1 << 15
-
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 func emitLiteral(dst *tokens, lit []byte) {
 	ol := int(dst.n)
@@ -29,27 +26,18 @@ type snappyEnc interface {
 }
 
 func newSnappy(level int) snappyEnc {
-	if useSSE42 {
-		e := &snappySSE4{snappyGen: snappyGen{cur: 1}}
-		switch level {
-		case 3:
-			e.enc = e.encodeL3
-			return e
-		}
-	}
-	if level == 1 {
-		return &snappyL1{}
-	}
-	e := &snappyGen{cur: 1}
 	switch level {
+	case 1:
+		return &snappyL1{}
 	case 2:
-		e.enc = e.encodeL2
+		return &snappyL2{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}
 	case 3:
-		e.enc = e.encodeL3
+		return &snappyL3{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}
+	case 4:
+		return &snappyL4{snappyL3{snappyGen: snappyGen{cur: maxStoreBlockSize, prev: make([]byte, 0, maxStoreBlockSize)}}}
 	default:
 		panic("invalid level specified")
 	}
-	return e
 }
 
 const (
@@ -60,7 +48,6 @@ const (
 	baseMatchOffset = 1              // The smallest match offset
 	baseMatchLength = 3              // The smallest match length per the RFC section 3.2.5
 	maxMatchOffset  = 1 << 15        // The largest match offset
-	inputMargin     = 16 - 1
 )
 
 func load32(b []byte, i int) uint32 {
@@ -181,8 +168,17 @@ func (e *snappyL1) Encode(dst *tokens, src []byte) {
 			if s1 > len(src) {
 				s1 = len(src)
 			}
-			for i := candidate + 4; s < s1 && src[i] == src[s]; i, s = i+1, s+1 {
+			a := src[s:s1]
+			b := src[candidate+4:]
+			b = b[:len(a)]
+			l := len(a)
+			for i := range a {
+				if a[i] != b[i] {
+					l = i
+					break
+				}
 			}
+			s += l
 
 			// matchToken is flate's equivalent of Snappy's emitCopy.
 			dst.tokens[dst.n] = matchToken(uint32(s-base-baseMatchLength), uint32(base-candidate-baseMatchOffset))
@@ -219,433 +215,642 @@ emitRemainder:
 	}
 }
 
+type tableEntry struct {
+	val    uint32
+	offset int32
+}
+
+func load3232(b []byte, i int32) uint32 {
+	b = b[i : i+4 : len(b)] // Help the compiler eliminate bounds checks on the next line.
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}
+
+func load6432(b []byte, i int32) uint64 {
+	b = b[i : i+8 : len(b)] // Help the compiler eliminate bounds checks on the next line.
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}
+
 // snappyGen maintains the table for matches,
 // and the previous byte block for level 2.
 // This is the generic implementation.
 type snappyGen struct {
-	table [tableSize]int64
-	block [maxStoreBlockSize]byte
-	prev  []byte
-	cur   int
-	enc   func(dst *tokens, src []byte)
+	prev []byte
+	cur  int32
 }
 
-func (e *snappyGen) Encode(dst *tokens, src []byte) {
-	e.enc(dst, src)
+// snappyGen maintains the table for matches,
+// and the previous byte block for level 2.
+// This is the generic implementation.
+type snappyL2 struct {
+	snappyGen
+	table [tableSize]tableEntry
 }
 
 // EncodeL2 uses a similar algorithm to level 1, but is capable
 // of matching across blocks giving better compression at a small slowdown.
-func (e *snappyGen) encodeL2(dst *tokens, src []byte) {
-	// Return early if src is short.
-	if len(src) <= 4 {
-		if len(src) != 0 {
-			emitLiteral(dst, src)
-		}
-		e.prev = nil
-		e.cur += len(src)
-		return
-	}
+func (e *snappyL2) Encode(dst *tokens, src []byte) {
+	const (
+		inputMargin            = 16 - 1
+		minNonLiteralBlockSize = 1 + 1 + inputMargin
+	)
 
 	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
 	if e.cur > 1<<30 {
-		e.cur = 1
+		for i := range e.table {
+			e.table[i] = tableEntry{}
+		}
+		e.cur = maxStoreBlockSize
 	}
 
-	// Iterate over the source bytes.
-	var (
-		s   int // The iterator position.
-		t   int // The last position with the same hash as s.
-		lit int // The start position of any pending literal bytes.
-	)
+	// This check isn't in the Snappy implementation, but there, the caller
+	// instead of the callee handles this case.
+	if len(src) < minNonLiteralBlockSize {
+		// We do not fill the token table.
+		// This will be picked up by caller.
+		dst.n = uint16(len(src))
+		e.cur += maxStoreBlockSize
+		e.prev = e.prev[:0]
+		return
+	}
 
-	for s+3 < len(src) {
-		// Update the hash table.
-		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
-		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
-		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-		// We need to to store values in [-1, inf) in table.
-		// To save some initialization time, we make sure that
-		// e.cur is never zero.
-		t, *p = int(*p)-e.cur, int64(s+e.cur)
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := int32(len(src) - inputMargin)
 
-		// If t is positive, the match starts in the current block
-		if t >= 0 {
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := int32(0)
+	s := int32(0)
+	cv := load3232(src, s)
+	nextHash := hash(cv)
 
-			offset := uint(s - t - 1)
-			// Check that the offset is valid and that we match at least 4 bytes
-			if offset >= (maxOffset-1) || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
-				// Skip 1 byte for 32 consecutive missed.
-				s += 1 + ((s - lit) >> 5)
+	for {
+		// Copied from the C++ snappy implementation:
+		//
+		// Heuristic match skipping: If 32 bytes are scanned with no matches
+		// found, start looking only at every other byte. If 32 more bytes are
+		// scanned (or skipped), look at every third byte, etc.. When a match
+		// is found, immediately go back to looking at every byte. This is a
+		// small loss (~5% performance, ~0.1% density) for compressible data
+		// due to more bookkeeping, but for non-compressible data (such as
+		// JPEG) it's a huge win since the compressor quickly "realizes" the
+		// data is incompressible and doesn't bother looking for matches
+		// everywhere.
+		//
+		// The "skip" variable keeps track of how many bytes there are since
+		// the last match; dividing it by 32 (ie. right-shifting by five) gives
+		// the number of bytes to move ahead for each iteration.
+		skip := int32(32)
+
+		nextS := s
+		var candidate tableEntry
+		for {
+			s = nextS
+			bytesBetweenHashLookups := skip >> 5
+			nextS = s + bytesBetweenHashLookups
+			skip += bytesBetweenHashLookups
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			candidate = e.table[nextHash&tableMask]
+			now := load3232(src, nextS)
+			e.table[nextHash&tableMask] = tableEntry{offset: s + e.cur, val: cv}
+			nextHash = hash(now)
+
+			offset := s - (candidate.offset - e.cur)
+			if offset >= maxMatchOffset || cv != candidate.val {
+				// Out of range or not matched.
+				cv = now
 				continue
 			}
-			// Otherwise, we have a match. First, emit any pending literal bytes.
-			if lit != s {
-				emitLiteral(dst, src[lit:s])
-			}
-			// Extend the match to be as long as possible.
-			s0 := s
-			s1 := s + maxMatchLength
-			if s1 > len(src) {
-				s1 = len(src)
-			}
-			s, t = s+4, t+4
-			for s < s1 && src[s] == src[t] {
-				s++
-				t++
-			}
-			// Emit the copied bytes.
-			// inlined: emitCopy(dst, s-t, s-s0)
-			dst.tokens[dst.n] = matchToken(uint32(s-s0-3), uint32(s-t-minOffsetSize))
+			break
+		}
+
+		// A 4-byte match has been found. We'll later see if more than 4 bytes
+		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+		// them as literal bytes.
+		emitLiteral(dst, src[nextEmit:s])
+
+		// Call emitCopy, and then see if another emitCopy could be our next
+		// move. Repeat until we find no match for the input immediately after
+		// what was consumed by the last emitCopy call.
+		//
+		// If we exit this loop normally then we need to call emitLiteral next,
+		// though we don't yet know how big the literal will be. We handle that
+		// by proceeding to the next iteration of the main loop. We also can
+		// exit this loop via goto if we get close to exhausting the input.
+		for {
+			// Invariant: we have a 4-byte match at s, and no need to emit any
+			// literal bytes prior to s.
+
+			// Extend the 4-byte match as long as possible.
+			//
+			s += 4
+			t := candidate.offset - e.cur + 4
+			l := e.matchlen(s, t, src)
+
+			// matchToken is flate's equivalent of Snappy's emitCopy. (length,offset)
+			dst.tokens[dst.n] = matchToken(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
 			dst.n++
-			lit = s
-			continue
-		}
-		// We found a match in the previous block.
-		tp := len(e.prev) + t
-		if tp < 0 || t > -5 || s-t >= maxOffset || b0 != e.prev[tp] || b1 != e.prev[tp+1] || b2 != e.prev[tp+2] || b3 != e.prev[tp+3] {
-			// Skip 1 byte for 32 consecutive missed.
-			s += 1 + ((s - lit) >> 5)
-			continue
-		}
-		// Otherwise, we have a match. First, emit any pending literal bytes.
-		if lit != s {
-			emitLiteral(dst, src[lit:s])
-		}
-		// Extend the match to be as long as possible.
-		s0 := s
-		s1 := s + maxMatchLength
-		if s1 > len(src) {
-			s1 = len(src)
-		}
-		s, tp = s+4, tp+4
-		for s < s1 && src[s] == e.prev[tp] {
-			s++
-			tp++
-			if tp == len(e.prev) {
-				t = 0
-				// continue in current buffer
-				for s < s1 && src[s] == src[t] {
-					s++
-					t++
-				}
-				goto l
+			s += l
+			nextEmit = s
+			if s >= sLimit {
+				goto emitRemainder
+			}
+
+			// We could immediately start working at s now, but to improve
+			// compression we first update the hash table at s-1 and at s. If
+			// another emitCopy is not our next move, also calculate nextHash
+			// at s+1. At least on GOARCH=amd64, these three hash calculations
+			// are faster as one load64 call (with some shifts) instead of
+			// three load32 calls.
+			x := load6432(src, s-1)
+			prevHash := hash(uint32(x))
+			e.table[prevHash&tableMask] = tableEntry{offset: e.cur + s - 1, val: uint32(x)}
+			x >>= 8
+			currHash := hash(uint32(x))
+			candidate = e.table[currHash&tableMask]
+			e.table[currHash&tableMask] = tableEntry{offset: e.cur + s, val: uint32(x)}
+
+			offset := s - (candidate.offset - e.cur)
+			if offset >= maxMatchOffset || uint32(x) != candidate.val {
+				cv = uint32(x >> 8)
+				nextHash = hash(cv)
+				s++
+				break
 			}
 		}
-	l:
-		// Emit the copied bytes.
-		if t < 0 {
-			t = tp - len(e.prev)
-		}
-		dst.tokens[dst.n] = matchToken(uint32(s-s0-3), uint32(s-t-minOffsetSize))
-		dst.n++
-		lit = s
-
 	}
 
-	// Emit any final pending literal bytes and return.
-	if lit != len(src) {
-		emitLiteral(dst, src[lit:])
+emitRemainder:
+	if int(nextEmit) < len(src) {
+		emitLiteral(dst, src[nextEmit:])
 	}
-	e.cur += len(src)
-	// Store this block, if it was full length.
-	if len(src) == maxStoreBlockSize {
-		copy(e.block[:], src)
-		e.prev = e.block[:len(src)]
-	} else {
-		e.prev = nil
-	}
+	e.cur += int32(len(src))
+	e.prev = e.prev[:len(src)]
+	copy(e.prev, src)
 }
 
-// EncodeL3 uses a similar algorithm to level 2, but is capable
-// will keep two matches per hash.
-// Both hashes are checked if the first isn't ok, and the longest is selected.
-func (e *snappyGen) encodeL3(dst *tokens, src []byte) {
-	// Return early if src is short.
-	if len(src) <= 4 {
-		if len(src) != 0 {
-			emitLiteral(dst, src)
-		}
-		e.prev = nil
-		e.cur += len(src)
-		return
-	}
+type tableEntryPrev struct {
+	Cur  tableEntry
+	Prev tableEntry
+}
+
+// snappyL3
+type snappyL3 struct {
+	snappyGen
+	table [tableSize]tableEntryPrev
+}
+
+// Encode uses a similar algorithm to level 2, will check up to two candidates.
+func (e *snappyL3) Encode(dst *tokens, src []byte) {
+	const (
+		inputMargin            = 16 - 1
+		minNonLiteralBlockSize = 1 + 1 + inputMargin
+	)
 
 	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
 	if e.cur > 1<<30 {
-		e.cur = 1
+		for i := range e.table {
+			e.table[i] = tableEntryPrev{}
+		}
+		e.cur = maxStoreBlockSize
 	}
 
-	// Iterate over the source bytes.
-	var (
-		s   int // The iterator position.
-		lit int // The start position of any pending literal bytes.
-	)
+	// This check isn't in the Snappy implementation, but there, the caller
+	// instead of the callee handles this case.
+	if len(src) < minNonLiteralBlockSize {
+		// We do not fill the token table.
+		// This will be picked up by caller.
+		dst.n = uint16(len(src))
+		e.cur += maxStoreBlockSize
+		e.prev = e.prev[:0]
+		return
+	}
 
-	for s+3 < len(src) {
-		// Update the hash table.
-		h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
-		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-		tmp := *p
-		p1 := int(tmp & 0xffffffff) // Closest match position
-		p2 := int(tmp >> 32)        // Furthest match position
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := int32(len(src) - inputMargin)
 
-		// We need to to store values in [-1, inf) in table.
-		// To save some initialization time, we make sure that
-		// e.cur is never zero.
-		t1 := p1 - e.cur
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := int32(0)
+	s := int32(0)
+	cv := load3232(src, s)
+	nextHash := hash(cv)
 
-		var l2 int
-		var t2 int
-		l1 := e.matchlen(s, t1, src)
-		// If fist match was ok, don't do the second.
-		if l1 < 16 {
-			t2 = p2 - e.cur
-			l2 = e.matchlen(s, t2, src)
+	for {
+		// Copied from the C++ snappy implementation:
+		//
+		// Heuristic match skipping: If 32 bytes are scanned with no matches
+		// found, start looking only at every other byte. If 32 more bytes are
+		// scanned (or skipped), look at every third byte, etc.. When a match
+		// is found, immediately go back to looking at every byte. This is a
+		// small loss (~5% performance, ~0.1% density) for compressible data
+		// due to more bookkeeping, but for non-compressible data (such as
+		// JPEG) it's a huge win since the compressor quickly "realizes" the
+		// data is incompressible and doesn't bother looking for matches
+		// everywhere.
+		//
+		// The "skip" variable keeps track of how many bytes there are since
+		// the last match; dividing it by 32 (ie. right-shifting by five) gives
+		// the number of bytes to move ahead for each iteration.
+		skip := int32(32)
 
-			// If both are short, continue
-			if l1 < 4 && l2 < 4 {
-				// Update hash table
-				*p = int64(s+e.cur) | (int64(p1) << 32)
-				// Skip 1 byte for 32 consecutive missed.
-				s += 1 + ((s - lit) >> 5)
-				continue
+		nextS := s
+		var candidate tableEntry
+		for {
+			s = nextS
+			bytesBetweenHashLookups := skip >> 5
+			nextS = s + bytesBetweenHashLookups
+			skip += bytesBetweenHashLookups
+			if nextS > sLimit {
+				goto emitRemainder
 			}
+			candidates := e.table[nextHash&tableMask]
+			now := load3232(src, nextS)
+			e.table[nextHash&tableMask] = tableEntryPrev{Prev: candidates.Cur, Cur: tableEntry{offset: s + e.cur, val: cv}}
+			nextHash = hash(now)
+
+			// Check both candidates
+			candidate = candidates.Cur
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset {
+					break
+				}
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset {
+						break
+					}
+				}
+			}
+			cv = now
 		}
 
-		// Otherwise, we have a match. First, emit any pending literal bytes.
-		if lit != s {
-			emitLiteral(dst, src[lit:s])
-		}
-		// Update hash table
-		*p = int64(s+e.cur) | (int64(p1) << 32)
+		// A 4-byte match has been found. We'll later see if more than 4 bytes
+		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+		// them as literal bytes.
+		emitLiteral(dst, src[nextEmit:s])
 
-		// Store the longest match l1 will be closest, so we prefer that if equal length
-		if l1 >= l2 {
-			dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
-			s += l1
-		} else {
-			dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
-			s += l2
+		// Call emitCopy, and then see if another emitCopy could be our next
+		// move. Repeat until we find no match for the input immediately after
+		// what was consumed by the last emitCopy call.
+		//
+		// If we exit this loop normally then we need to call emitLiteral next,
+		// though we don't yet know how big the literal will be. We handle that
+		// by proceeding to the next iteration of the main loop. We also can
+		// exit this loop via goto if we get close to exhausting the input.
+		for {
+			// Invariant: we have a 4-byte match at s, and no need to emit any
+			// literal bytes prior to s.
+
+			// Extend the 4-byte match as long as possible.
+			//
+			s += 4
+			t := candidate.offset - e.cur + 4
+			l := e.matchlen(s, t, src)
+
+			// matchToken is flate's equivalent of Snappy's emitCopy. (length,offset)
+			dst.tokens[dst.n] = matchToken(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
+			dst.n++
+			s += l
+			nextEmit = s
+			if s >= sLimit {
+				goto emitRemainder
+			}
+
+			// We could immediately start working at s now, but to improve
+			// compression we first update the hash table at s-2, s-1 and at s. If
+			// another emitCopy is not our next move, also calculate nextHash
+			// at s+1. At least on GOARCH=amd64, these three hash calculations
+			// are faster as one load64 call (with some shifts) instead of
+			// three load32 calls.
+			x := load6432(src, s-2)
+			prevHash := hash(uint32(x))
+
+			e.table[prevHash&tableMask] = tableEntryPrev{
+				Prev: e.table[prevHash&tableMask].Cur,
+				Cur:  tableEntry{offset: e.cur + s - 2, val: uint32(x)},
+			}
+			x >>= 8
+			prevHash = hash(uint32(x))
+
+			e.table[prevHash&tableMask] = tableEntryPrev{
+				Prev: e.table[prevHash&tableMask].Cur,
+				Cur:  tableEntry{offset: e.cur + s - 1, val: uint32(x)},
+			}
+			x >>= 8
+			currHash := hash(uint32(x))
+			candidates := e.table[currHash&tableMask]
+			cv = uint32(x)
+			e.table[currHash&tableMask] = tableEntryPrev{
+				Prev: candidates.Cur,
+				Cur:  tableEntry{offset: s + e.cur, val: cv},
+			}
+
+			// Check both candidates
+			candidate = candidates.Cur
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset {
+					continue
+				}
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset {
+						continue
+					}
+				}
+			}
+			cv = uint32(x >> 8)
+			nextHash = hash(cv)
+			s++
+			break
 		}
-		dst.n++
-		lit = s
 	}
 
-	// Emit any final pending literal bytes and return.
-	if lit != len(src) {
-		emitLiteral(dst, src[lit:])
+emitRemainder:
+	if int(nextEmit) < len(src) {
+		emitLiteral(dst, src[nextEmit:])
 	}
-	e.cur += len(src)
-	// Store this block, if it was full length.
-	if len(src) == maxStoreBlockSize {
-		copy(e.block[:], src)
-		e.prev = e.block[:len(src)]
-	} else {
-		e.prev = nil
-	}
+	e.cur += int32(len(src))
+	e.prev = e.prev[:len(src)]
+	copy(e.prev, src)
 }
 
-func (e *snappyGen) matchlen(s, t int, src []byte) int {
-	// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-	offset := uint(s - t - 1)
+// snappyL4
+type snappyL4 struct {
+	snappyL3
+}
+
+// Encode uses a similar algorithm to level 3,
+// but will check up to two candidates if first isn't long enough.
+func (e *snappyL4) Encode(dst *tokens, src []byte) {
+	const (
+		inputMargin            = 16 - 1
+		minNonLiteralBlockSize = 1 + 1 + inputMargin
+		matchLenGood           = 12
+	)
+
+	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
+	if e.cur > 1<<30 {
+		for i := range e.table {
+			e.table[i] = tableEntryPrev{}
+		}
+		e.cur = maxStoreBlockSize
+	}
+
+	// This check isn't in the Snappy implementation, but there, the caller
+	// instead of the callee handles this case.
+	if len(src) < minNonLiteralBlockSize {
+		// We do not fill the token table.
+		// This will be picked up by caller.
+		dst.n = uint16(len(src))
+		e.cur += maxStoreBlockSize
+		e.prev = e.prev[:0]
+		return
+	}
+
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := int32(len(src) - inputMargin)
+
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := int32(0)
+	s := int32(0)
+	cv := load3232(src, s)
+	nextHash := hash(cv)
+
+	for {
+		// Copied from the C++ snappy implementation:
+		//
+		// Heuristic match skipping: If 32 bytes are scanned with no matches
+		// found, start looking only at every other byte. If 32 more bytes are
+		// scanned (or skipped), look at every third byte, etc.. When a match
+		// is found, immediately go back to looking at every byte. This is a
+		// small loss (~5% performance, ~0.1% density) for compressible data
+		// due to more bookkeeping, but for non-compressible data (such as
+		// JPEG) it's a huge win since the compressor quickly "realizes" the
+		// data is incompressible and doesn't bother looking for matches
+		// everywhere.
+		//
+		// The "skip" variable keeps track of how many bytes there are since
+		// the last match; dividing it by 32 (ie. right-shifting by five) gives
+		// the number of bytes to move ahead for each iteration.
+		skip := int32(32)
+
+		nextS := s
+		var candidate tableEntry
+		var candidateAlt tableEntry
+		for {
+			s = nextS
+			bytesBetweenHashLookups := skip >> 5
+			nextS = s + bytesBetweenHashLookups
+			skip += bytesBetweenHashLookups
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			candidates := e.table[nextHash&tableMask]
+			now := load3232(src, nextS)
+			e.table[nextHash&tableMask] = tableEntryPrev{Prev: candidates.Cur, Cur: tableEntry{offset: s + e.cur, val: cv}}
+			nextHash = hash(now)
+
+			// Check both candidates
+			candidate = candidates.Cur
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset {
+					offset = s - (candidates.Prev.offset - e.cur)
+					if cv == candidates.Prev.val && offset < maxMatchOffset {
+						candidateAlt = candidates.Prev
+					}
+					break
+				}
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset {
+						break
+					}
+				}
+			}
+			cv = now
+		}
+
+		// A 4-byte match has been found. We'll later see if more than 4 bytes
+		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+		// them as literal bytes.
+		emitLiteral(dst, src[nextEmit:s])
+
+		// Call emitCopy, and then see if another emitCopy could be our next
+		// move. Repeat until we find no match for the input immediately after
+		// what was consumed by the last emitCopy call.
+		//
+		// If we exit this loop normally then we need to call emitLiteral next,
+		// though we don't yet know how big the literal will be. We handle that
+		// by proceeding to the next iteration of the main loop. We also can
+		// exit this loop via goto if we get close to exhausting the input.
+		for {
+			// Invariant: we have a 4-byte match at s, and no need to emit any
+			// literal bytes prior to s.
+
+			// Extend the 4-byte match as long as possible.
+			//
+			s += 4
+			t := candidate.offset - e.cur + 4
+			l := e.matchlen(s, t, src)
+			// Try alternative candidate if match length < matchLenGood.
+			if l < matchLenGood-4 && candidateAlt.offset != 0 {
+				t2 := candidateAlt.offset - e.cur + 4
+				l2 := e.matchlen(s, t2, src)
+				if l2 > l {
+					l = l2
+					t = t2
+				}
+			}
+			// matchToken is flate's equivalent of Snappy's emitCopy. (length,offset)
+			dst.tokens[dst.n] = matchToken(uint32(l+4-baseMatchLength), uint32(s-t-baseMatchOffset))
+			dst.n++
+			s += l
+			nextEmit = s
+			if s >= sLimit {
+				goto emitRemainder
+			}
+
+			// We could immediately start working at s now, but to improve
+			// compression we first update the hash table at s-2, s-1 and at s. If
+			// another emitCopy is not our next move, also calculate nextHash
+			// at s+1. At least on GOARCH=amd64, these three hash calculations
+			// are faster as one load64 call (with some shifts) instead of
+			// three load32 calls.
+			x := load6432(src, s-2)
+			prevHash := hash(uint32(x))
+
+			e.table[prevHash&tableMask] = tableEntryPrev{
+				Prev: e.table[prevHash&tableMask].Cur,
+				Cur:  tableEntry{offset: e.cur + s - 2, val: uint32(x)},
+			}
+			x >>= 8
+			prevHash = hash(uint32(x))
+
+			e.table[prevHash&tableMask] = tableEntryPrev{
+				Prev: e.table[prevHash&tableMask].Cur,
+				Cur:  tableEntry{offset: e.cur + s - 1, val: uint32(x)},
+			}
+			x >>= 8
+			currHash := hash(uint32(x))
+			candidates := e.table[currHash&tableMask]
+			cv = uint32(x)
+			e.table[currHash&tableMask] = tableEntryPrev{
+				Prev: candidates.Cur,
+				Cur:  tableEntry{offset: s + e.cur, val: cv},
+			}
+
+			// Check both candidates
+			candidate = candidates.Cur
+			candidateAlt = tableEntry{}
+			if cv == candidate.val {
+				offset := s - (candidate.offset - e.cur)
+				if offset < maxMatchOffset {
+					offset = s - (candidates.Prev.offset - e.cur)
+					if cv == candidates.Prev.val && offset < maxMatchOffset {
+						candidateAlt = candidates.Prev
+					}
+					continue
+				}
+			} else {
+				// We only check if value mismatches.
+				// Offset will always be invalid in other cases.
+				candidate = candidates.Prev
+				if cv == candidate.val {
+					offset := s - (candidate.offset - e.cur)
+					if offset < maxMatchOffset {
+						continue
+					}
+				}
+			}
+			cv = uint32(x >> 8)
+			nextHash = hash(cv)
+			s++
+			break
+		}
+	}
+
+emitRemainder:
+	if int(nextEmit) < len(src) {
+		emitLiteral(dst, src[nextEmit:])
+	}
+	e.cur += int32(len(src))
+	e.prev = e.prev[:len(src)]
+	copy(e.prev, src)
+}
+
+func (e *snappyGen) matchlen(s, t int32, src []byte) int32 {
+	s1 := int(s) + maxMatchLength - 4
+	if s1 > len(src) {
+		s1 = len(src)
+	}
 
 	// If we are inside the current block
 	if t >= 0 {
-		if offset >= (maxOffset-1) ||
-			src[s] != src[t] || src[s+1] != src[t+1] ||
-			src[s+2] != src[t+2] || src[s+3] != src[t+3] {
-			return 0
-		}
+		b := src[t:]
+		a := src[s:s1]
+		b = b[:len(a)]
 		// Extend the match to be as long as possible.
-		s0 := s
-		s1 := s + maxMatchLength
-		if s1 > len(src) {
-			s1 = len(src)
+		for i := range a {
+			if a[i] != b[i] {
+				return int32(i)
+			}
 		}
-		s, t = s+4, t+4
-		for s < s1 && src[s] == src[t] {
-			s++
-			t++
-		}
-		return s - s0
+		return int32(len(a))
 	}
 
 	// We found a match in the previous block.
-	tp := len(e.prev) + t
-	if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
-		src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
-		src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
+	tp := int32(len(e.prev)) + t
+	if tp < 0 {
 		return 0
 	}
 
 	// Extend the match to be as long as possible.
-	s0 := s
-	s1 := s + maxMatchLength
-	if s1 > len(src) {
-		s1 = len(src)
+	a := src[s:s1]
+	b := e.prev[tp:]
+	if len(b) > len(a) {
+		b = b[:len(a)]
 	}
-	s, tp = s+4, tp+4
-	for s < s1 && src[s] == e.prev[tp] {
-		s++
-		tp++
-		if tp == len(e.prev) {
-			t = 0
-			// continue in current buffer
-			for s < s1 && src[s] == src[t] {
-				s++
-				t++
-			}
-			return s - s0
+	a = a[:len(b)]
+	for i := range b {
+		if a[i] != b[i] {
+			return int32(i)
 		}
 	}
-	return s - s0
+	n := int32(len(b))
+	a = src[s+n : s1]
+	b = src[:len(a)]
+	for i := range a {
+		if a[i] != b[i] {
+			return int32(i) + n
+		}
+	}
+	return int32(len(a)) + n
 }
 
 // Reset the encoding table.
 func (e *snappyGen) Reset() {
-	e.prev = nil
-}
-
-// snappySSE4 extends snappyGen.
-// This implementation can use SSE 4.2 for length matching.
-type snappySSE4 struct {
-	snappyGen
-}
-
-// EncodeL3 uses a similar algorithm to level 2,
-// but will keep two matches per hash.
-// Both hashes are checked if the first isn't ok, and the longest is selected.
-func (e *snappySSE4) encodeL3(dst *tokens, src []byte) {
-	// Return early if src is short.
-	if len(src) <= 4 {
-		if len(src) != 0 {
-			emitLiteral(dst, src)
-		}
-		e.prev = nil
-		e.cur += len(src)
-		return
-	}
-
-	// Ensure that e.cur doesn't wrap, mainly an issue on 32 bits.
-	if e.cur > 1<<30 {
-		e.cur = 1
-	}
-
-	// Iterate over the source bytes.
-	var (
-		s   int // The iterator position.
-		lit int // The start position of any pending literal bytes.
-	)
-
-	for s+3 < len(src) {
-		// Load potential matches from hash table.
-		h := uint32(src[s]) | uint32(src[s+1])<<8 | uint32(src[s+2])<<16 | uint32(src[s+3])<<24
-		p := &e.table[(h*0x1e35a7bd)>>(32-tableBits)]
-		tmp := *p
-		p1 := int(tmp & 0xffffffff) // Closest match position
-		p2 := int(tmp >> 32)        // Furthest match position
-
-		// We need to to store values in [-1, inf) in table.
-		// To save some initialization time, we make sure that
-		// e.cur is never zero.
-		t1 := int(p1) - e.cur
-
-		var l2 int
-		var t2 int
-		l1 := e.matchlen(s, t1, src)
-		// If fist match was ok, don't do the second.
-		if l1 < 16 {
-			t2 = int(p2) - e.cur
-			l2 = e.matchlen(s, t2, src)
-
-			// If both are short, continue
-			if l1 < 4 && l2 < 4 {
-				// Update hash table
-				*p = int64(s+e.cur) | (int64(p1) << 32)
-				// Skip 1 byte for 32 consecutive missed.
-				s += 1 + ((s - lit) >> 5)
-				continue
-			}
-		}
-
-		// Otherwise, we have a match. First, emit any pending literal bytes.
-		if lit != s {
-			emitLiteral(dst, src[lit:s])
-		}
-		// Update hash table
-		*p = int64(s+e.cur) | (int64(p1) << 32)
-
-		// Store the longest match l1 will be closest, so we prefer that if equal length
-		if l1 >= l2 {
-			dst.tokens[dst.n] = matchToken(uint32(l1-3), uint32(s-t1-minOffsetSize))
-			s += l1
-		} else {
-			dst.tokens[dst.n] = matchToken(uint32(l2-3), uint32(s-t2-minOffsetSize))
-			s += l2
-		}
-		dst.n++
-		lit = s
-	}
-
-	// Emit any final pending literal bytes and return.
-	if lit != len(src) {
-		emitLiteral(dst, src[lit:])
-	}
-	e.cur += len(src)
-	// Store this block, if it was full length.
-	if len(src) == maxStoreBlockSize {
-		copy(e.block[:], src)
-		e.prev = e.block[:len(src)]
-	} else {
-		e.prev = nil
-	}
-}
-
-func (e *snappySSE4) matchlen(s, t int, src []byte) int {
-	// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-	offset := uint(s - t - 1)
-
-	// If we are inside the current block
-	if t >= 0 {
-		if offset >= (maxOffset - 1) {
-			return 0
-		}
-		length := len(src) - s
-		if length > maxMatchLength {
-			length = maxMatchLength
-		}
-		// Extend the match to be as long as possible.
-		return matchLenSSE4(src[t:], src[s:], length)
-	}
-
-	// We found a match in the previous block.
-	tp := len(e.prev) + t
-	if tp < 0 || offset >= (maxOffset-1) || t > -5 ||
-		src[s] != e.prev[tp] || src[s+1] != e.prev[tp+1] ||
-		src[s+2] != e.prev[tp+2] || src[s+3] != e.prev[tp+3] {
-		return 0
-	}
-
-	// Extend the match to be as long as possible.
-	s0 := s
-	s1 := s + maxMatchLength
-	if s1 > len(src) {
-		s1 = len(src)
-	}
-	s, tp = s+4, tp+4
-	for s < s1 && src[s] == e.prev[tp] {
-		s++
-		tp++
-		if tp == len(e.prev) {
-			t = 0
-			// continue in current buffer
-			for s < s1 && src[s] == src[t] {
-				s++
-				t++
-			}
-			return s - s0
-		}
-	}
-	return s - s0
+	e.prev = e.prev[:0]
+	e.cur += maxMatchOffset + 1
 }

--- a/flate/token.go
+++ b/flate/token.go
@@ -4,6 +4,8 @@
 
 package flate
 
+import "fmt"
+
 const (
 	// 2 bits:   type   0 = literal  1=EOF  2=Match   3=Unused
 	// 8 bits:   xlength = length - MIN_MATCH_LENGTH
@@ -77,6 +79,14 @@ func literalToken(literal uint32) token { return token(literalType + literal) }
 
 // Convert a < xlength, xoffset > pair into a match token.
 func matchToken(xlength uint32, xoffset uint32) token {
+	return token(matchType + xlength<<lengthShift + xoffset)
+}
+
+func matchTokend(xlength uint32, xoffset uint32) token {
+	if xlength > maxMatchLength || xoffset > maxMatchOffset {
+		panic(fmt.Sprintf("Invalid match: len: %d, offset: %d\n", xlength, xoffset))
+		return token(matchType)
+	}
 	return token(matchType + xlength<<lengthShift + xoffset)
 }
 


### PR DESCRIPTION
Rewrite level 1 to a new level 2, that can do cross-block matching.

Currently this is a rewrite of level 1 which allows us to retain the hash table between blocks. It is close to the same speed as level 1, but no previous block matching has been added.

* Implement level 2 (cross-block matches) and level 3 (2 checks per hash).
* Only check second candidate if value mismatches.
* Fine tune compression settings.
* Rebalance to adjust for new compression levels.
* For level 3, add another hash to the table before resuming.
* Adjustments to balance.
* Restore compressed content performance
* Fix flush/reset.
* Simplify offset handling for faster encoding.
* Also attempt to match first byte
* Initialize to maxStoreBlockSize to invalidate zero values.
* Add specialized level 4 which checks length of up to two candidates.
* Adjust level 4 limit.
* Eliminate bounds checks in match length.

Increases speed considerably on well-matching material.