### PR TITLE
Fix "Println arg list ends with redundant newline"

### DIFF
--- a/gzip/example_test.go
+++ b/gzip/example_test.go
@@ -98,7 +98,7 @@ func ExampleReader_Multistream() {
 			log.Fatal(err)
 		}
 
-		fmt.Println("\n")
+		fmt.Print("\n\n")
 
 		err = zr.Reset(&buf)
 		if err == io.EOF {


### PR DESCRIPTION
Even though this is still being debated in https://github.com/golang/go/issues/18085 we might as well change it.