### PR TITLE
Combine loads

### DIFF
--- a/fse/bitreader.go
+++ b/fse/bitreader.go
@@ -65,9 +65,8 @@ func (b *bitReader) fillFast() {
 	}
 	// Do single re-slice to avoid bounds checks.
 	v := b.in[b.off-4 : b.off]
-	// Split to load words.
-	high := (uint64(v[3]) << 8) | (uint64(v[2]))
-	b.value = (b.value << 32) | ((uint64(v[1]) << 8) | uint64(v[0])) | high<<16
+	low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
+	b.value = (b.value << 32) | uint64(low)
 	b.bitsRead -= 32
 	b.off -= 4
 }
@@ -79,9 +78,8 @@ func (b *bitReader) fill() {
 	}
 	if b.off > 4 {
 		v := b.in[b.off-4 : b.off]
-		// Split to load words.
-		high := (uint64(v[3]) << 8) | (uint64(v[2]))
-		b.value = (b.value << 32) | ((uint64(v[1]) << 8) | uint64(v[0])) | high<<16
+		low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
+		b.value = (b.value << 32) | uint64(low)
 		b.bitsRead -= 32
 		b.off -= 4
 		return

--- a/fse/bitreader.go
+++ b/fse/bitreader.go
@@ -65,7 +65,9 @@ func (b *bitReader) fillFast() {
 	}
 	// Do single re-slice to avoid bounds checks.
 	v := b.in[b.off-4 : b.off]
-	b.value = (b.value << 32) | (uint64(v[3]) << 24) | (uint64(v[2]) << 16) | (uint64(v[1]) << 8) | uint64(v[0])
+	// Split to load words.
+	high := (uint64(v[3]) << 8) | (uint64(v[2]))
+	b.value = (b.value << 32) | ((uint64(v[1]) << 8) | uint64(v[0])) | high<<16
 	b.bitsRead -= 32
 	b.off -= 4
 }
@@ -76,7 +78,10 @@ func (b *bitReader) fill() {
 		return
 	}
 	if b.off > 4 {
-		b.value = (b.value << 32) | (uint64(b.in[b.off-1]) << 24) | (uint64(b.in[b.off-2]) << 16) | (uint64(b.in[b.off-3]) << 8) | uint64(b.in[b.off-4])
+		v := b.in[b.off-4 : b.off]
+		// Split to load words.
+		high := (uint64(v[3]) << 8) | (uint64(v[2]))
+		b.value = (b.value << 32) | ((uint64(v[1]) << 8) | uint64(v[0])) | high<<16
 		b.bitsRead -= 32
 		b.off -= 4
 		return

--- a/fse/bytereader.go
+++ b/fse/bytereader.go
@@ -28,19 +28,21 @@ func (b *byteReader) advance(n uint) {
 // Int32 returns a little endian int32 starting at current offset.
 func (b byteReader) Int32() int32 {
 	b2 := b.b[b.off : b.off+4 : b.off+4]
-	v3 := (int32(b2[3]) << 8) | int32(b2[2])
+	v3 := int32(b2[3])
+	v2 := int32(b2[2])
 	v1 := int32(b2[1])
 	v0 := int32(b2[0])
-	return (v3 << 16) | ((v1 << 8) | v0)
+	return v0 | (v1 << 8) | (v2 << 16) | (v3 << 24)
 }
 
 // Uint32 returns a little endian uint32 starting at current offset.
 func (b byteReader) Uint32() uint32 {
 	b2 := b.b[b.off : b.off+4 : b.off+4]
-	v3 := (uint32(b2[3]) << 8) | uint32(b2[2])
+	v3 := uint32(b2[3])
+	v2 := uint32(b2[2])
 	v1 := uint32(b2[1])
 	v0 := uint32(b2[0])
-	return (v3 << 16) | ((v1 << 8) | v0)
+	return v0 | (v1 << 8) | (v2 << 16) | (v3 << 24)
 }
 
 // unread returns the unread portion of the input.

--- a/fse/bytereader.go
+++ b/fse/bytereader.go
@@ -27,20 +27,21 @@ func (b *byteReader) advance(n uint) {
 
 // Int32 returns a little endian int32 starting at current offset.
 func (b byteReader) Int32() int32 {
-	v3 := int32(b.b[b.off+3])
-	v2 := int32(b.b[b.off+2])
-	v1 := int32(b.b[b.off+1])
-	v0 := int32(b.b[b.off])
-	return (v3 << 24) | (v2 << 16) | (v1 << 8) | v0
+	b2 := b.b[b.off : b.off+4 : b.off+4]
+	v3 := (int32(b2[3]) << 8) | int32(b2[2])
+	v1 := int32(b2[1])
+	v0 := int32(b2[0])
+	return (v3 << 16) | ((v1 << 8) | v0)
 }
 
 // Uint32 returns a little endian uint32 starting at current offset.
 func (b byteReader) Uint32() uint32 {
-	v3 := uint32(b.b[b.off+3])
-	v2 := uint32(b.b[b.off+2])
-	v1 := uint32(b.b[b.off+1])
-	v0 := uint32(b.b[b.off])
-	return (v3 << 24) | (v2 << 16) | (v1 << 8) | v0
+	b2 := b.b[b.off : b.off+4 : b.off+4]
+	v3 := (uint32(b2[3]) << 8) | uint32(b2[2])
+	v1 := uint32(b2[1])
+	v0 := uint32(b2[0])
+	return (v3 << 16) | ((v1 << 8) | v0)
+
 }
 
 // unread returns the unread portion of the input.

--- a/fse/bytereader.go
+++ b/fse/bytereader.go
@@ -41,7 +41,6 @@ func (b byteReader) Uint32() uint32 {
 	v1 := uint32(b2[1])
 	v0 := uint32(b2[0])
 	return (v3 << 16) | ((v1 << 8) | v0)
-
 }
 
 // unread returns the unread portion of the input.

--- a/fse/compress.go
+++ b/fse/compress.go
@@ -179,7 +179,7 @@ func (s *Scratch) writeCount() error {
 		nbBits    = uint(tableLog + 1)
 	)
 	if cap(s.Out) < maxHeaderSize {
-		s.Out = make([]byte, 0, s.length+maxHeaderSize)
+		s.Out = make([]byte, 0, s.br.remain()+maxHeaderSize)
 	}
 	outP := uint(0)
 	out := s.Out[:maxHeaderSize]
@@ -422,7 +422,7 @@ func (s *Scratch) countSimple(in []byte) (max int) {
 
 // minTableLog provides the minimum logSize to safely represent a distribution.
 func (s *Scratch) minTableLog() uint8 {
-	minBitsSrc := highBits(uint32(s.length-1)) + 1
+	minBitsSrc := highBits(uint32(s.br.remain()-1)) + 1
 	minBitsSymbols := highBits(uint32(s.symbolLen-1)) + 2
 	if minBitsSrc < minBitsSymbols {
 		return uint8(minBitsSrc)
@@ -434,7 +434,7 @@ func (s *Scratch) minTableLog() uint8 {
 func (s *Scratch) optimalTableLog() {
 	tableLog := s.TableLog
 	minBits := s.minTableLog()
-	maxBitsSrc := uint8(highBits(uint32(s.length-1))) - 2
+	maxBitsSrc := uint8(highBits(uint32(s.br.remain()-1))) - 2
 	if maxBitsSrc < tableLog {
 		// Accuracy can be reduced
 		tableLog = maxBitsSrc
@@ -460,12 +460,12 @@ func (s *Scratch) normalizeCount() error {
 	var (
 		tableLog          = s.actualTableLog
 		scale             = 62 - uint64(tableLog)
-		step              = (1 << 62) / uint64(s.length)
+		step              = (1 << 62) / uint64(s.br.remain())
 		vStep             = uint64(1) << (scale - 20)
 		stillToDistribute = int16(1 << tableLog)
 		largest           int
 		largestP          int16
-		lowThreshold      = (uint32)(s.length >> tableLog)
+		lowThreshold      = (uint32)(s.br.remain() >> tableLog)
 	)
 
 	for i, cnt := range s.count[:s.symbolLen] {
@@ -511,7 +511,7 @@ func (s *Scratch) normalizeCount2() error {
 	const notYetAssigned = -2
 	var (
 		distributed  uint32
-		total        = uint32(s.length)
+		total        = uint32(s.br.remain())
 		tableLog     = s.actualTableLog
 		lowThreshold = uint32(total >> tableLog)
 		lowOne       = uint32((total * 3) >> (tableLog + 1))

--- a/fse/fse.go
+++ b/fse/fse.go
@@ -45,7 +45,6 @@ type Scratch struct {
 	// Private
 	count          [maxSymbolValue + 1]uint32
 	norm           [maxSymbolValue + 1]int16
-	length         int    // input length
 	symbolLen      uint16 // Length of active part of the symbol table.
 	actualTableLog uint8  // Selected tablelog.
 	br             byteReader
@@ -101,7 +100,6 @@ func (s *Scratch) prepare(in []byte) (*Scratch, error) {
 	if s == nil {
 		s = &Scratch{}
 	}
-	s.length = len(in)
 	if s.MaxSymbolValue == 0 {
 		s.MaxSymbolValue = 255
 	}

--- a/fse/fse_test.go
+++ b/fse/fse_test.go
@@ -113,8 +113,8 @@ func TestDecompress(t *testing.T) {
 				t.Fatal(err)
 			}
 			b, err := Decompress(buf0, &s)
-			if err.Error() != test.err {
-				t.Errorf("want error %q (%T), got %q (%T)", test.err, test.err, err, err)
+			if fmt.Sprint(err) != test.err {
+				t.Errorf("want error %q, got %q (%T)", test.err, err, err)
 				return
 			}
 			if err != nil {

--- a/fse/fuzz/run-compress.cmd
+++ b/fse/fuzz/run-compress.cmd
@@ -1,4 +1,4 @@
 cd ..
 go-fuzz-build -tags=compress github.com/klauspost/compress/fse
 cd fuzz
-go-fuzz -bin=../fse-fuzz.zip -workdir=compress -procs=8
+go-fuzz -bin=../fse-fuzz.zip -workdir=compress -procs=4

--- a/fse/fuzz/run-decompress.cmd
+++ b/fse/fuzz/run-decompress.cmd
@@ -1,4 +1,4 @@
 cd ..
 go-fuzz-build -tags=decompress github.com/klauspost/compress/fse
 cd fuzz
-go-fuzz -bin=../fse-fuzz.zip -workdir=decompress -procs=8
+go-fuzz -bin=../fse-fuzz.zip -workdir=decompress -procs=4


### PR DESCRIPTION
It seems like Go SSA has code for combining two byte loads into a word load. Use that:

```
name                       old time/op    new time/op    delta
Decompress/gettysburg-8      7.48µs ± 3%    7.11µs ± 3%  -4.92%        (p=0.000 n=10+10)
Decompress/digits-8           331µs ± 2%     328µs ± 3%    ~            (p=0.156 n=9+10)
Decompress/twain-8           1.49ms ± 4%    1.50ms ± 5%    ~           (p=0.436 n=10+10)
Decompress/low-ent-8          130µs ± 3%     127µs ± 4%  -2.36%         (p=0.043 n=9+10)
Decompress/superlow-ent-8    32.8µs ± 3%    32.3µs ± 2%  -1.77%        (p=0.011 n=10+10)
Decompress/endzerobits-8      268ns ± 3%     269ns ± 2%    ~           (p=0.444 n=10+10)
Decompress/pngdata.001-8      147µs ± 2%     142µs ± 3%  -4.02%         (p=0.000 n=9+10)
Decompress/normcount2-8      1.92µs ± 2%    1.75µs ± 3%  -8.77%         (p=0.000 n=9+10)

name                       old speed      new speed      delta
Decompress/gettysburg-8     207MB/s ± 3%   218MB/s ± 3%  +5.19%        (p=0.000 n=10+10)
Decompress/digits-8         302MB/s ± 2%   305MB/s ± 3%    ~            (p=0.156 n=9+10)
Decompress/twain-8          261MB/s ± 4%   258MB/s ± 5%    ~           (p=0.436 n=10+10)
Decompress/low-ent-8        308MB/s ± 3%   315MB/s ± 4%  +2.44%         (p=0.043 n=9+10)
Decompress/superlow-ent-8   320MB/s ± 3%   326MB/s ± 2%  +1.80%        (p=0.011 n=10+10)
Decompress/endzerobits-8   18.6MB/s ± 3%  18.5MB/s ± 2%    ~           (p=0.271 n=10+10)
Decompress/pngdata.001-8    347MB/s ± 2%   362MB/s ± 3%  +4.22%         (p=0.000 n=9+10)
Decompress/normcount2-8    45.3MB/s ± 2%  49.7MB/s ± 3%  +9.66%         (p=0.000 n=9+10)
```