### PR TITLE
Don't use flate asm code when building for gccgo.

### DIFF
--- a/flate/crc32_amd64.go
+++ b/flate/crc32_amd64.go
@@ -1,5 +1,6 @@
 //+build !noasm
 //+build !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 

--- a/flate/crc32_amd64.s
+++ b/flate/crc32_amd64.s
@@ -1,5 +1,6 @@
 //+build !noasm
 //+build !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 

--- a/flate/crc32_noasm.go
+++ b/flate/crc32_noasm.go
@@ -1,4 +1,4 @@
-//+build !amd64 noasm appengine
+//+build !amd64 noasm appengine gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 


### PR DESCRIPTION
Updates golang/go#28670