### PR TITLE
zstd split sequence decode/execute

### DIFF
--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -653,13 +653,18 @@ func (b *blockDec) decodeCompressed(hist *history) error {
 		println("initializing sequences:", err)
 		return err
 	}
-
-	err = seqs.decode(nSeqs, br, hist.b)
+	s := b.sequenceBuf[:nSeqs]
+	err = seqs.decode(s, br)
 	if err != nil {
 		return err
 	}
 	if !br.finished() {
 		return fmt.Errorf("%d extra bits on block, should be 0", br.remain())
+	}
+	// We need output history here.
+	err = seqs.execute(s, hist.b)
+	if err != nil {
+		return err
 	}
 
 	err = br.close()


### PR DESCRIPTION
The basic idea is that we don't need the stream history to decode the sequences.

So we do history in two parts:

1) Decode as much as we can without any history.
2) Receive decoder history.
3) Decode sequences.
4) Send decoder history to next block. Next block goto 2)
5) Wait for stream history
6) Execute decoded sequences.
7) Send stream history to next block. Next block goto 6)

This should allow more concurrency for stream decoding.

We probably should keep the combined code for buffer decoding.

So this would require each decoder to have a channel on which it can receive the decoder history, if it is interested.

Estimated speed boost would be in the area of 1.5x