### PR TITLE
zstd: Stricter size checks on single segments

### DIFF
--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -49,6 +49,10 @@ var (
 	// For the time being dictionaries are not supported.
 	ErrUnknownDictionary = errors.New("unknown dictionary")
 
+	// ErrFrameSizeExceeded is returned if the stated frame size is exceeded.
+	// This is only returned if SingleSegment is specified on the frame.
+	ErrFrameSizeExceeded = errors.New("frame size exceeded")
+
 	// ErrCRCMismatch is returned if CRC mismatches.
 	ErrCRCMismatch = errors.New("CRC check failed")
 


### PR DESCRIPTION
Refuse decoding single segment frames if they exceed the promised size.

Also, if a bytes.Buffer is passed, check the size and do single threaded decoding if less than 1MB.