### PR TITLE
Fix wrong decoder output

### DIFF
--- a/zstd/bitreader.go
+++ b/zstd/bitreader.go
@@ -76,7 +76,7 @@ func (b *bitReader) fill() {
 	if b.bitsRead < 32 {
 		return
 	}
-	if b.off > 4 {
+	if b.off >= 4 {
 		v := b.in[b.off-4 : b.off]
 		low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
 		b.value = (b.value << 32) | uint64(low)

--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -517,7 +517,9 @@ func (b *blockDec) decodeCompressed(hist *history) error {
 		}
 		for i := uint(0); i < 3; i++ {
 			mode := seqCompMode((compMode >> (6 - i*2)) & 3)
-			//println("Table", tableIndex(i), "is", mode)
+			if debug {
+				println("Table", tableIndex(i), "is", mode)
+			}
 			var seq *sequenceDec
 			switch tableIndex(i) {
 			case tableLiteralLengths:
@@ -659,6 +661,7 @@ func (b *blockDec) decodeCompressed(hist *history) error {
 	// TODO: Investigate if sending history without decoders are faster.
 	//   This would allow the sequences to be decoded async and only have to construct stream history.
 	//   If only recent offsets were not transferred, this would be an obvious win.
+	// 	 Also, if first 3 sequences don't reference recent offsets, all sequences can be decoded.
 
 	if err := seqs.initialize(br, hist, literals, b.dst); err != nil {
 		println("initializing sequences:", err)
@@ -670,9 +673,7 @@ func (b *blockDec) decodeCompressed(hist *history) error {
 		return err
 	}
 	if !br.finished() {
-		// Disabled until this is resolved:
-		// https://github.com/facebook/zstd/issues/1597
-		// return fmt.Errorf("%d extra bits on block, should be 0", br.remain())
+		return fmt.Errorf("%d extra bits on block, should be 0", br.remain())
 	}
 
 	err = br.close()
@@ -699,5 +700,9 @@ func (b *blockDec) decodeCompressed(hist *history) error {
 	}
 	hist.append(b.dst)
 	hist.recentOffsets = seqs.prevOffset
+	if debug {
+		println("Finished block with literals:", len(literals), "and", nSeqs, "sequences.")
+	}
+
 	return nil
 }

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -77,7 +77,7 @@ func TestNewReaderMismatch(t *testing.T) {
 		return
 	}
 	defer f.Close()
-	dec, err := NewReader(f)
+	dec, err := NewReader(f, WithDecoderConcurrency(1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -19,6 +19,7 @@ type frameDec struct {
 	o         decoderOptions
 	crc       hash.Hash64
 	frameDone sync.WaitGroup
+	offset    int64
 
 	WindowSize       uint64
 	DictionaryID     uint32
@@ -368,14 +369,15 @@ func (d *frameDec) startDecoder(output chan decodeOutput) {
 			return
 		}
 		if debug {
-			println("got result")
+			println("got result, from ", d.offset, "to", d.offset+int64(len(r.b)))
+			d.offset += int64(len(r.b))
 		}
 		if !block.Last {
 			// Send history to next block
 			select {
 			case next = <-d.decoding:
 				if debug {
-					println("Sending ", len(d.history.b), " bytes as history")
+					println("Sending ", len(d.history.b), "bytes as history")
 				}
 				next.history <- &d.history
 			default:

--- a/zstd/fse_decoder.go
+++ b/zstd/fse_decoder.go
@@ -206,7 +206,7 @@ func decSymbolValue(symb uint8, t []baseOffset) (decSymbol, error) {
 // setRLE will set the decoder til RLE mode.
 func (s *fseDecoder) setRLE(symbol decSymbol) {
 	s.actualTableLog = 0
-	s.maxBits = 0
+	s.maxBits = symbol.addBits
 	s.dt[0] = symbol
 }
 

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -73,7 +73,7 @@ func (s *sequenceDecs) initialize(br *bitReader, hist *history, literals, out []
 		return errors.New("litLengths:" + err.Error())
 	}
 	if err := s.offsets.init(br); err != nil {
-		return errors.New("litLengths:" + err.Error())
+		return errors.New("offsets:" + err.Error())
 	}
 	if err := s.matchLengths.init(br); err != nil {
 		return errors.New("matchLengths:" + err.Error())


### PR DESCRIPTION
Add test to help identify where mismatches occur by hashing big files and compare output.

Should eventually fix #124 

Actual block, match length mismatch (`43974` vs `43973`)
```
zstd_decompress.c: neededInSize = 3 
zstd_decompress.c: ZSTD_decompressContinue (srcSize:3) 
zstd_decompress.c: stage zdss_read 
zstd_decompress.c: neededInSize = 22 
zstd_decompress.c: ZSTD_decompressStream 
zstd_decompress.c: input size : 25 
zstd_decompress.c: stage zdss_read 
zstd_decompress.c: neededInSize = 22 
zstd_decompress.c: ZSTD_decompressContinue (srcSize:22) 
zstd_decompress.c: ZSTD_decompressContinue: case ZSTDds_decompressBlock 
zstd_decompress.c: ZSTD_decompressContinue: case bt_compressed 
zstd_decompress_block.c: ZSTD_decompressBlock_internal (size : 22) 
zstd_decompress_block.c: ZSTD_decodeLiteralsBlock : 1 
zstd_decompress_block.c: ZSTD_decodeSeqHeaders 
zstd_decompress_block.c: ZSTD_decompressSequences 
zstd_decompress_block.c: ZSTD_decompressSequences_body 
zstd_decompress_block.c: ZSTD_initFseState : val=0 using 0 bits 
zstd_decompress_block.c: ZSTD_initFseState : val=0 using 0 bits 
zstd_decompress_block.c: ZSTD_initFseState : val=52 using 6 bits 
zstd_decompress_block.c: seq: litL=0, matchL=20, offset=763266 
zstd_decompress_block.c: regenerated sequence size : 20 
zstd_decompress_block.c: seq: litL=0, matchL=5, offset=982870 
zstd_decompress_block.c: regenerated sequence size : 5 
zstd_decompress_block.c: seq: litL=0, matchL=43974, offset=982923 
zstd_decompress_block.c: regenerated sequence size : 43974 
zstd_decompress_block.c: seq: litL=0, matchL=21537, offset=982854 
zstd_decompress_block.c: regenerated sequence size : 21537 
zstd_decompress_block.c: ZSTD_decompressSequences_body: after decode loop, remaining nbSeq : 0 
zstd_decompress.c: ZSTD_decompressContinue: decoded size from block : 65536 
```

vs

```
2019/06/17 21:36:04 decoding new block
2019/06/17 21:36:04 Data size on stream: 22
2019/06/17 21:36:04 next block: Steam Size: 22, Type: blockTypeCompressed, Last: false, Window: 4194304
2019/06/17 21:36:04 literals type: literalsBlockRaw litRegenSize: 0 litCompSize 0
2019/06/17 21:36:04 Compression modes: 0b1010000
2019/06/17 21:36:04 Table tableLiteralLengths is compModeRLE
2019/06/17 21:36:04 RLE set to {newState:0 addBits:0 nbBits:0 baseline:0}, code: 0
2019/06/17 21:36:04 Table tableOffsets is compModeRLE
2019/06/17 21:36:04 RLE set to {newState:0 addBits:19 nbBits:0 baseline:524285}, code: 19
2019/06/17 21:36:04 Table tableMatchLengths is compModePredefined
2019/06/17 21:36:04 Final literals: 0 and 4 sequences.
2019/06/17 21:36:04 History merged ok
2019/06/17 21:36:04 Seq 0 Litlen: 0 matchOff: 763266 0 (abs) matchLen: 20
2019/06/17 21:36:04 Seq 1 Litlen: 0 matchOff: 982870 0 (abs) matchLen: 5
2019/06/17 21:36:04 Seq 2 Litlen: 0 matchOff: 982923 0 (abs) matchLen: 43973
2019/06/17 21:36:04 Seq 3 Litlen: 0 matchOff: 982854 0 (abs) matchLen: 21537
2019/06/17 21:36:04 Finished block with literals: 0 and 4 sequences.
2019/06/17 21:36:04 Decompressed to 65535 bytes, error: <nil>
2019/06/17 21:36:04 blockDec: Finished block
```
