### PR TITLE
huff0: Faster 4x decompression

### DIFF
--- a/huff0/decompress.go
+++ b/huff0/decompress.go
@@ -247,9 +247,13 @@ func (s *Scratch) Decompress4X(in []byte, dstSize int) (out []byte, err error) {
 	dstOut := s.Out
 	dstEvery := (dstSize + 3) / 4
 
+	const tlSize = 1 << tableLogMax
+	const tlMask = tlSize - 1
+	single := s.dt.single[:tlSize]
+
 	decode := func(br *bitReader) byte {
 		val := br.peekBitsFast(s.actualTableLog) /* note : actualTableLog >= 1 */
-		v := s.dt.single[val]
+		v := single[val&tlMask]
 		br.bitsRead += v.nBits
 		return v.byte
 	}


### PR DESCRIPTION
Avoid bounds check when reading bits:

```
e:\gopath\src\github.com\klauspost\compress\huff0>benchstat old.txt new.txt
name                                     old time/op    new time/op    delta
Decompress4XNoTable/digits-12               245µs ± 1%     224µs ± 1%   -8.62%         (p=0.000 n=10+9)
Decompress4XNoTable/gettysburg-12          3.39µs ± 1%    3.16µs ± 1%   -7.03%        (p=0.000 n=10+10)
Decompress4XNoTable/twain-12                741µs ± 1%     674µs ± 1%   -9.12%         (p=0.000 n=9+10)
Decompress4XNoTable/low-ent.10k-12         75.4µs ± 1%    68.2µs ± 0%   -9.57%        (p=0.000 n=10+10)
Decompress4XNoTable/superlow-ent-10k-12    20.2µs ± 1%    18.8µs ± 1%   -7.21%        (p=0.000 n=10+10)
Decompress4XNoTable/case1-12                321ns ± 1%     322ns ± 1%     ~            (p=0.389 n=9+10)
Decompress4XNoTable/case2-12                267ns ± 1%     267ns ± 1%     ~           (p=1.000 n=10+10)
Decompress4XNoTable/case3-12                274ns ± 0%     273ns ± 0%   -0.36%          (p=0.009 n=8+8)
Decompress4XNoTable/pngdata.001-12          100µs ± 2%      91µs ± 1%   -9.25%         (p=0.000 n=10+9)
Decompress4XNoTable/normcount2-12           458ns ± 1%     459ns ± 1%     ~           (p=0.309 n=10+10)

name                                     old speed      new speed      delta
Decompress4XNoTable/digits-12             409MB/s ± 1%   447MB/s ± 1%   +9.42%         (p=0.000 n=10+9)
Decompress4XNoTable/gettysburg-12         456MB/s ± 1%   490MB/s ± 1%   +7.56%        (p=0.000 n=10+10)
Decompress4XNoTable/twain-12              354MB/s ± 1%   389MB/s ± 1%  +10.03%         (p=0.000 n=9+10)
Decompress4XNoTable/low-ent.10k-12        531MB/s ± 1%   587MB/s ± 0%  +10.58%        (p=0.000 n=10+10)
Decompress4XNoTable/superlow-ent-10k-12   519MB/s ± 1%   560MB/s ± 1%   +7.77%        (p=0.000 n=10+10)
Decompress4XNoTable/case1-12              171MB/s ± 1%   170MB/s ± 1%     ~            (p=0.159 n=9+10)
Decompress4XNoTable/case2-12              168MB/s ± 1%   168MB/s ± 1%     ~           (p=0.808 n=10+10)
Decompress4XNoTable/case3-12              175MB/s ± 0%   175MB/s ± 0%   +0.37%          (p=0.002 n=8+8)
Decompress4XNoTable/pngdata.001-12        512MB/s ± 2%   565MB/s ± 1%  +10.20%         (p=0.000 n=10+9)
Decompress4XNoTable/normcount2-12         190MB/s ± 0%   189MB/s ± 1%     ~            (p=0.149 n=9+10)
```