### PR TITLE
add WithWindowSize for configurable window size

### DIFF
--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -404,7 +404,7 @@ func (e *Encoder) EncodeAll(src, dst []byte) []byte {
 			// Add frame header.
 			fh := frameHeader{
 				ContentSize:   0,
-				WindowSize:    minWindowSize,
+				WindowSize:    MinWindowSize,
 				SingleSegment: true,
 				// Adding a checksum would be a waste of space.
 				Checksum: false,

--- a/zstd/encoder_options.go
+++ b/zstd/encoder_options.go
@@ -1,6 +1,7 @@
 package zstd
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -60,6 +61,30 @@ func WithEncoderConcurrency(n int) EOption {
 			return fmt.Errorf("concurrency must be at least 1")
 		}
 		o.concurrent = n
+		return nil
+	}
+}
+
+// WithWindowSize will set the maximum allowed back-reference distance.
+// The value must be a power of two between WindowSizeMin and WindowSizeMax.
+// A larger value will enable better compression but allocate more memory and,
+// for above-default values, take considerably longer.
+// By default this is set to 4MB.
+func WithWindowSize(n int) EOption {
+	return func(o *encoderOptions) error {
+		switch {
+		case n < MinWindowSize:
+			return fmt.Errorf("window size must be at least %d", MinWindowSize)
+		case n > MaxWindowSize:
+			return fmt.Errorf("window size must be at most %d", MaxWindowSize)
+		case (n & (n - 1)) != 0:
+			return errors.New("window size must be a power of 2")
+		}
+
+		o.windowSize = n
+		if o.blockSize > o.windowSize {
+			o.blockSize = o.windowSize
+		}
 		return nil
 	}
 }

--- a/zstd/encoder_options.go
+++ b/zstd/encoder_options.go
@@ -69,7 +69,7 @@ func WithEncoderConcurrency(n int) EOption {
 // The value must be a power of two between WindowSizeMin and WindowSizeMax.
 // A larger value will enable better compression but allocate more memory and,
 // for above-default values, take considerably longer.
-// By default this is set to 4MB.
+// The default value is determined by the compression level.
 func WithWindowSize(n int) EOption {
 	return func(o *encoderOptions) error {
 		switch {

--- a/zstd/encoder_options_test.go
+++ b/zstd/encoder_options_test.go
@@ -1,6 +1,7 @@
 package zstd
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -116,6 +117,38 @@ func TestEncoderLevelFromZstd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := EncoderLevelFromZstd(tt.args.level); got != tt.want {
 				t.Errorf("EncoderLevelFromZstd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWindowSize(t *testing.T) {
+	tests := []struct {
+		windowSize int
+		err        bool
+	}{
+		{1 << 9, true},
+		{1 << 10, false},
+		{(1 << 10) + 1, true},
+		{(1 << 10) * 3, true},
+		{1 << 30, false},
+		{1 << 31, true},
+	}
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.windowSize), func(t *testing.T) {
+			var options encoderOptions
+			err := WithWindowSize(tt.windowSize)(&options)
+			if tt.err {
+				if err == nil {
+					t.Error("did not get error for invalid window size")
+				}
+			} else {
+				if err != nil {
+					t.Error("got error for valid window size")
+				}
+				if options.windowSize != tt.windowSize {
+					t.Error("failed to set window size")
+				}
 			}
 		})
 	}

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -49,7 +49,8 @@ type frameDec struct {
 
 const (
 	// The minimum Window_Size is 1 KB.
-	minWindowSize = 1 << 10
+	MinWindowSize = 1 << 10
+	MaxWindowSize = 1 << 30
 )
 
 var (
@@ -60,7 +61,7 @@ var (
 func newFrameDec(o decoderOptions) *frameDec {
 	d := frameDec{
 		o:             o,
-		maxWindowSize: 1 << 30,
+		maxWindowSize: MaxWindowSize,
 	}
 	if d.maxWindowSize > o.maxDecodedSize {
 		d.maxWindowSize = o.maxDecodedSize
@@ -215,8 +216,8 @@ func (d *frameDec) reset(br byteBuffer) error {
 	if d.WindowSize == 0 && d.SingleSegment {
 		// We may not need window in this case.
 		d.WindowSize = d.FrameContentSize
-		if d.WindowSize < minWindowSize {
-			d.WindowSize = minWindowSize
+		if d.WindowSize < MinWindowSize {
+			d.WindowSize = MinWindowSize
 		}
 	}
 
@@ -225,7 +226,7 @@ func (d *frameDec) reset(br byteBuffer) error {
 		return ErrWindowSizeExceeded
 	}
 	// The minimum Window_Size is 1 KB.
-	if d.WindowSize < minWindowSize {
+	if d.WindowSize < MinWindowSize {
 		println("got window size: ", d.WindowSize)
 		return ErrWindowSizeTooSmall
 	}


### PR DESCRIPTION
Enabling smaller window sizes will save memory when working exclusively with smaller payloads. In addition, in some cases it offers faster compression with very similar results. Large window sizes are supported but are probably inadvisable in most situations.