### PR TITLE
Add pool for bitwriters

### DIFF
--- a/flate/huffman_bit_writer.go
+++ b/flate/huffman_bit_writer.go
@@ -135,7 +135,6 @@ func newHuffmanBitWriter(w io.Writer) *huffmanBitWriter {
 func (w *huffmanBitWriter) reset(writer io.Writer) {
 	w.writer = writer
 	w.bits, w.nbits, w.nbytes, w.err = 0, 0, 0, nil
-	w.bytes = [256]byte{}
 	w.lastHeader = 0
 	w.lastHuffMan = false
 }


### PR DESCRIPTION
Remove stateless allocations with a sync.Pool.
Remove unneeded zeroing.

```
λ benchstat old.txt new.txt
name                  old time/op    new time/op    delta
EncodeDigitsSL1e4-12     128µs ± 1%     130µs ± 5%     ~     (p=0.690 n=5+5)
EncodeDigitsSL1e5-12     847µs ± 0%     853µs ± 1%   +0.71%  (p=0.016 n=5+5)
EncodeDigitsSL1e6-12    7.77ms ± 1%    7.76ms ± 1%     ~     (p=0.841 n=5+5)
EncodeTwainSL1e4-12      140µs ± 0%     139µs ± 2%     ~     (p=0.151 n=5+5)
EncodeTwainSL1e5-12      873µs ± 0%     865µs ± 0%   -0.94%  (p=0.008 n=5+5)
EncodeTwainSL1e6-12     7.95ms ± 0%    7.91ms ± 0%   -0.54%  (p=0.032 n=5+5)

name                  old speed      new speed      delta
EncodeDigitsSL1e4-12  78.2MB/s ± 1%  77.1MB/s ± 5%     ~     (p=0.690 n=5+5)
EncodeDigitsSL1e5-12   118MB/s ± 0%   117MB/s ± 1%   -0.71%  (p=0.016 n=5+5)
EncodeDigitsSL1e6-12   129MB/s ± 1%   129MB/s ± 1%     ~     (p=0.841 n=5+5)
EncodeTwainSL1e4-12   71.3MB/s ± 0%  72.2MB/s ± 2%     ~     (p=0.151 n=5+5)
EncodeTwainSL1e5-12    115MB/s ± 0%   116MB/s ± 0%   +0.95%  (p=0.008 n=5+5)
EncodeTwainSL1e6-12    126MB/s ± 0%   126MB/s ± 0%   +0.54%  (p=0.032 n=5+5)

name                  old alloc/op   new alloc/op   delta
EncodeDigitsSL1e4-12    12.0kB ± 0%     0.0kB ± 0%  -99.72%  (p=0.008 n=5+5)
EncodeDigitsSL1e5-12    12.0kB ± 0%     0.0kB ± 0%  -99.68%  (p=0.008 n=5+5)
EncodeDigitsSL1e6-12    12.0kB ± 0%     0.1kB ± 0%  -99.23%  (p=0.008 n=5+5)
EncodeTwainSL1e4-12     12.0kB ± 0%     0.0kB ± 0%  -99.72%  (p=0.008 n=5+5)
EncodeTwainSL1e5-12     12.0kB ± 0%     0.0kB ± 0%  -99.68%  (p=0.008 n=5+5)
EncodeTwainSL1e6-12     12.0kB ± 0%     0.1kB ± 0%  -99.22%  (p=0.008 n=5+5)

name                  old allocs/op  new allocs/op  delta
EncodeDigitsSL1e4-12      18.0 ± 0%       1.0 ± 0%  -94.44%  (p=0.008 n=5+5)
EncodeDigitsSL1e5-12      18.0 ± 0%       1.0 ± 0%  -94.44%  (p=0.008 n=5+5)
EncodeDigitsSL1e6-12      18.0 ± 0%       1.0 ± 0%  -94.44%  (p=0.008 n=5+5)
EncodeTwainSL1e4-12       18.0 ± 0%       1.0 ± 0%  -94.44%  (p=0.008 n=5+5)
EncodeTwainSL1e5-12       18.0 ± 0%       1.0 ± 0%  -94.44%  (p=0.008 n=5+5)
EncodeTwainSL1e6-12       18.0 ± 0%       1.0 ± 0%  -94.44%  (p=0.008 n=5+5)
```

 The benchmark does one write/op, so the real-world impact is bigger than indicated by what is indicated above.