### PR TITLE
Add WithNoEntropyCompression to zstd

### DIFF
--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -262,7 +262,7 @@ func (e *Encoder) nextBlock(final bool) error {
 			// If we got the exact same number of literals as input,
 			// assume the literals cannot be compressed.
 			if len(src) != len(blk.literals) || len(src) != e.o.blockSize {
-				err = blk.encode()
+				err = blk.encode(e.o.noEntropy)
 			}
 			switch err {
 			case errIncompressible:
@@ -473,7 +473,7 @@ func (e *Encoder) EncodeAll(src, dst []byte) []byte {
 		// If we got the exact same number of literals as input,
 		// assume the literals cannot be compressed.
 		if len(blk.literals) != len(todo) || len(todo) != e.o.blockSize {
-			err = blk.encode()
+			err = blk.encode(e.o.noEntropy)
 		}
 
 		switch err {

--- a/zstd/encoder_options.go
+++ b/zstd/encoder_options.go
@@ -20,6 +20,7 @@ type encoderOptions struct {
 	windowSize int
 	level      EncoderLevel
 	fullZero   bool
+	noEntropy  bool
 }
 
 func (o *encoderOptions) setDefault() {
@@ -198,6 +199,16 @@ func WithEncoderLevel(l EncoderLevel) EOption {
 func WithZeroFrames(b bool) EOption {
 	return func(o *encoderOptions) error {
 		o.fullZero = b
+		return nil
+	}
+}
+
+// WithNoEntropyCompression will always skip entropy compression of literals.
+// This can be useful if content has matches, but unlikely to benefit from entropy
+// compression. Usually the slight speed improvement is not worth enabling this.
+func WithNoEntropyCompression(b bool) EOption {
+	return func(o *encoderOptions) error {
+		o.noEntropy = b
 		return nil
 	}
 }

--- a/zstd/snappy.go
+++ b/zstd/snappy.go
@@ -111,7 +111,7 @@ func (r *SnappyConverter) Convert(in io.Reader, w io.Writer) (int64, error) {
 			// Add empty last block
 			r.block.reset(nil)
 			r.block.last = true
-			err := r.block.encodeLits()
+			err := r.block.encodeLits(false)
 			if err != nil {
 				return written, err
 			}
@@ -178,7 +178,7 @@ func (r *SnappyConverter) Convert(in io.Reader, w io.Writer) (int64, error) {
 				r.err = ErrSnappyCorrupt
 				return written, r.err
 			}
-			err = r.block.encode()
+			err = r.block.encode(false)
 			switch err {
 			case errIncompressible:
 				r.block.popOffsets()
@@ -188,7 +188,7 @@ func (r *SnappyConverter) Convert(in io.Reader, w io.Writer) (int64, error) {
 					println("snappy.Decode:", err)
 					return written, err
 				}
-				err = r.block.encodeLits()
+				err = r.block.encodeLits(false)
 				if err != nil {
 					return written, err
 				}
@@ -235,7 +235,7 @@ func (r *SnappyConverter) Convert(in io.Reader, w io.Writer) (int64, error) {
 				r.err = ErrSnappyCorrupt
 				return written, r.err
 			}
-			err := r.block.encodeLits()
+			err := r.block.encodeLits(false)
 			if err != nil {
 				return written, err
 			}


### PR DESCRIPTION
WithNoEntropyCompression will always skip entropy compression of literals.
This can be useful if content has matches, but unlikely to benefit from entropy compression.
Usually the slight speed improvement is not worth enabling this.