### PR TITLE
Clean up test decoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ This package provides various compression algorithms.
 [![fuzzit](https://app.fuzzit.dev/badge?org_id=klauspost)](https://fuzzit.dev)
 
 # changelog
-* Nov 28, 2018 (v1.9.3) Less allocations in stateless deflate.
-* Nov 28, 2018: 5-20% Faster huff0 decode. Impacts zstd as well. [#184](https://github.com/klauspost/compress/pull/184)
+
+* Dec 3, 2019: (v1.9.4) S2: limit max repeat length. [#188](https://github.com/klauspost/compress/pull/188)
+* Dec 3, 2019: Add [WithNoEntropyCompression](https://godoc.org/github.com/klauspost/compress/zstd#WithNoEntropyCompression) to zstd [#187](https://github.com/klauspost/compress/pull/187)
+* Dec 3, 2019: Reduce memory use for tests. Check for leaked goroutines.
+* Nov 28, 2019 (v1.9.3) Less allocations in stateless deflate.
+* Nov 28, 2019: 5-20% Faster huff0 decode. Impacts zstd as well. [#184](https://github.com/klauspost/compress/pull/184)
 * Nov 12, 2019 (v1.9.2) Added [Stateless Compression](#stateless-compression) for gzip/deflate.
 * Nov 12, 2019: Fixed zstd decompression of large single blocks. [#180](https://github.com/klauspost/compress/pull/180)
 * Nov 11, 2019: Set default  [s2c](https://github.com/klauspost/compress/tree/master/s2#commandline-tools) block size to 4MB.

--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -106,6 +106,7 @@ func newBlockDec(lowMem bool) *blockDec {
 		input:   make(chan struct{}, 1),
 		history: make(chan *history, 1),
 	}
+	b.decWG.Add(1)
 	go b.startDecoder()
 	return &b
 }
@@ -190,7 +191,6 @@ func (b *blockDec) Close() {
 // decodeAsync will prepare decoding the block when it receives input.
 // This will separate output and history.
 func (b *blockDec) startDecoder() {
-	b.decWG.Add(1)
 	defer b.decWG.Done()
 	for range b.input {
 		//println("blockDec: Got block input")

--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -89,6 +89,7 @@ type blockDec struct {
 	sequenceBuf []seq
 	tmp         [4]byte
 	err         error
+	decWG       sync.WaitGroup
 }
 
 func (b *blockDec) String() string {
@@ -183,11 +184,14 @@ func (b *blockDec) Close() {
 	close(b.input)
 	close(b.history)
 	close(b.result)
+	b.decWG.Wait()
 }
 
 // decodeAsync will prepare decoding the block when it receives input.
 // This will separate output and history.
 func (b *blockDec) startDecoder() {
+	b.decWG.Add(1)
+	defer b.decWG.Done()
 	for range b.input {
 		//println("blockDec: Got block input")
 		switch b.Type {

--- a/zstd/snappy_test.go
+++ b/zstd/snappy_test.go
@@ -42,6 +42,7 @@ func TestSnappy_ConvertSimple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer dec.Close()
 	decoded, err := dec.DecodeAll(dst.Bytes(), nil)
 	if err != nil {
 		t.Error(err, len(decoded))
@@ -62,6 +63,7 @@ func TestSnappy_ConvertXML(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer dec.Close()
 	in, err := ioutil.ReadAll(dec)
 	if err != nil {
 		t.Fatal(err)
@@ -138,6 +140,7 @@ func TestSnappy_ConvertSilesia(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer dec.Close()
 	decoded, err := dec.DecodeAll(dst.Bytes(), nil)
 	if err != nil {
 		t.Error(err, len(decoded))

--- a/zstd/zstd_test.go
+++ b/zstd/zstd_test.go
@@ -1,0 +1,28 @@
+package zstd
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	ec := m.Run()
+	if ec == 0 && runtime.NumGoroutine() > 1 {
+		n := 0
+		for n < 60 {
+			n++
+			time.Sleep(time.Second)
+			if runtime.NumGoroutine() == 1 {
+				os.Exit(0)
+			}
+		}
+		fmt.Println("goroutines:", runtime.NumGoroutine())
+		pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+		os.Exit(1)
+	}
+	os.Exit(ec)
+}


### PR DESCRIPTION
Adds gorouine leak detection. Only tests themselves were leaking.

Fixes #189  (as much as possible)