### PR TITLE
zstd: Add function to get decoder as io.ReadCloser

### DIFF
--- a/zstd/decoder.go
+++ b/zstd/decoder.go
@@ -391,6 +391,7 @@ func (d *Decoder) Close() {
 // IOReadCloser returns the decoder as an io.ReadCloser for convenience.
 // Any changes to the decoder will be reflected, so the returned ReadCloser
 // can be reused along with the decoder.
+// io.WriterTo is also supported by the returned ReadCloser.
 func (d *Decoder) IOReadCloser() io.ReadCloser {
 	return closeWrapper{d: d}
 }
@@ -398,6 +399,11 @@ func (d *Decoder) IOReadCloser() io.ReadCloser {
 // closeWrapper wraps a function call as a closer.
 type closeWrapper struct {
 	d *Decoder
+}
+
+// WriteTo forwards WriteTo calls to the decoder.
+func (c closeWrapper) WriteTo(w io.Writer) (n int64, err error) {
+	return c.d.WriteTo(w)
 }
 
 // Read forwards read calls to the decoder.

--- a/zstd/decoder.go
+++ b/zstd/decoder.go
@@ -388,6 +388,29 @@ func (d *Decoder) Close() {
 	d.current.err = ErrDecoderClosed
 }
 
+// IOReadCloser returns the decoder as an io.ReadCloser for convenience.
+// Any changes to the decoder will be reflected, so the returned ReadCloser
+// can be reused along with the decoder.
+func (d *Decoder) IOReadCloser() io.ReadCloser {
+	return closeWrapper{d: d}
+}
+
+// closeWrapper wraps a function call as a closer.
+type closeWrapper struct {
+	d *Decoder
+}
+
+// Read forwards read calls to the decoder.
+func (c closeWrapper) Read(p []byte) (n int, err error) {
+	return c.d.Read(p)
+}
+
+// Close closes the decoder.
+func (c closeWrapper) Close() error {
+	c.d.Close()
+	return nil
+}
+
 type decodeOutput struct {
 	d   *blockDec
 	b   []byte


### PR DESCRIPTION
This is mostly for convenience.