### PR TITLE
zstd: Tweak singlesegment default

### DIFF
--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -433,7 +433,8 @@ func (e *Encoder) EncodeAll(src, dst []byte) []byte {
 	}()
 	enc.Reset()
 	blk := enc.Block()
-	single := len(src) > 1<<20
+	// Use single segments when above minimum window and below 1MB.
+	single := len(src) < 1<<20 && len(src) > MinWindowSize
 	if e.o.single != nil {
 		single = *e.o.single
 	}


### PR DESCRIPTION
Default single segment wasn't as intended. Tweak it to be enabled between Minimum Window and 1MB.

For small sizes it adds 1-2 bytes of overhead, so we only add it above minimum window.