### PR TITLE
Return length from StatelessDeflate

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This package provides various compression algorithms.
 
 # changelog
 
+* Feb 14, 2020: Return a length from [stateless deflate](https://pkg.go.dev/github.com/klauspost/compress/flate?tab=doc#StatelessDeflate) to indicate the bytes written. Breaking change.
 * Feb 4, 2020: (v1.10.0) Add optional dictionary to [stateless deflate](https://pkg.go.dev/github.com/klauspost/compress/flate?tab=doc#StatelessDeflate). Breaking change, send `nil` for previous behaviour. [#216](https://github.com/klauspost/compress/pull/216)
 * Feb 3, 2020: Fix buffer overflow on repeated small block deflate.  [#218](https://github.com/klauspost/compress/pull/218)
 * Jan 31, 2020: Allow copying content from an existing ZIP file without decompressing+compressing. [#214](https://github.com/klauspost/compress/pull/214)

--- a/flate/flate_test.go
+++ b/flate/flate_test.go
@@ -141,14 +141,14 @@ func TestRegressions(t *testing.T) {
 		t.Run(tt.Name+"stateless", func(t *testing.T) {
 			// Split into two and use history...
 			buf := new(bytes.Buffer)
-			err = StatelessDeflate(buf, data1[:len(data1)/2], false, nil)
+			_, err = StatelessDeflate(buf, data1[:len(data1)/2], false, nil)
 			if err != nil {
 				t.Error(err)
 			}
 
 			// Use top half as dictionary...
 			dict := data1[:len(data1)/2]
-			err = StatelessDeflate(buf, data1[len(data1)/2:], true, dict)
+			_, err = StatelessDeflate(buf, data1[len(data1)/2:], true, dict)
 			if err != nil {
 				t.Error(err)
 			}

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -207,7 +207,7 @@ func (z *Writer) Write(p []byte) (int, error) {
 	z.size += uint32(len(p))
 	z.digest = crc32.Update(z.digest, crc32.IEEETable, p)
 	if z.level == StatelessCompression {
-		return len(p), flate.StatelessDeflate(z.w, p, false, nil)
+		return flate.StatelessDeflate(z.w, p, false, nil)
 	}
 	n, z.err = z.compressor.Write(p)
 	return n, z.err
@@ -255,7 +255,7 @@ func (z *Writer) Close() error {
 		}
 	}
 	if z.level == StatelessCompression {
-		z.err = flate.StatelessDeflate(z.w, nil, true, nil)
+		_, z.err = flate.StatelessDeflate(z.w, nil, true, nil)
 	} else {
 		z.err = z.compressor.Close()
 	}


### PR DESCRIPTION
Means users who use it in a io.Writer over StatelessWriter
for adjusting the dictionary do not need to think about
the length.

Also fixes a bug in gzip.Writer where because
stateless writer wasn't returning n, len(p) was always returned
even when an error occured.

See https://github.com/klauspost/compress/pull/216#issuecomment-586015867