### PR TITLE
inflate: Read more bits when decoding

### DIFF
--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -33,24 +33,24 @@ type reverseBitsTest struct {
 }
 
 var deflateTests = []*deflateTest{
-	{[]byte{}, 0, []byte{1, 0, 0, 255, 255}},
-	{[]byte{0x11}, BestCompression, []byte{18, 4, 4, 0, 0, 255, 255}},
-	{[]byte{0x11}, BestCompression, []byte{18, 4, 4, 0, 0, 255, 255}},
-	{[]byte{0x11}, BestCompression, []byte{18, 4, 4, 0, 0, 255, 255}},
+	{[]byte{}, 0, []byte{0x3, 0x0}},
+	{[]byte{0x11}, BestCompression, []byte{0x12, 0x4, 0xc, 0x0}},
+	{[]byte{0x11}, BestCompression, []byte{0x12, 0x4, 0xc, 0x0}},
+	{[]byte{0x11}, BestCompression, []byte{0x12, 0x4, 0xc, 0x0}},
 
-	{[]byte{0x11}, 0, []byte{0, 1, 0, 254, 255, 17, 1, 0, 0, 255, 255}},
-	{[]byte{0x11, 0x12}, 0, []byte{0, 2, 0, 253, 255, 17, 18, 1, 0, 0, 255, 255}},
+	{[]byte{0x11}, 0, []byte{0x0, 0x1, 0x0, 0xfe, 0xff, 0x11, 0x3, 0x0}},
+	{[]byte{0x11, 0x12}, 0, []byte{0x0, 0x2, 0x0, 0xfd, 0xff, 0x11, 0x12, 0x3, 0x0}},
 	{[]byte{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, 0,
-		[]byte{0, 8, 0, 247, 255, 17, 17, 17, 17, 17, 17, 17, 17, 1, 0, 0, 255, 255},
+		[]byte{0x0, 0x8, 0x0, 0xf7, 0xff, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x3, 0x0},
 	},
-	{[]byte{}, 1, []byte{1, 0, 0, 255, 255}},
-	{[]byte{0x11}, BestCompression, []byte{18, 4, 4, 0, 0, 255, 255}},
-	{[]byte{0x11, 0x12}, BestCompression, []byte{18, 20, 2, 4, 0, 0, 255, 255}},
-	{[]byte{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, BestCompression, []byte{18, 132, 2, 64, 0, 0, 0, 255, 255}},
-	{[]byte{}, 9, []byte{1, 0, 0, 255, 255}},
-	{[]byte{0x11}, 9, []byte{18, 4, 4, 0, 0, 255, 255}},
-	{[]byte{0x11, 0x12}, 9, []byte{18, 20, 2, 4, 0, 0, 255, 255}},
-	{[]byte{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, 9, []byte{18, 132, 2, 64, 0, 0, 0, 255, 255}},
+	{[]byte{}, 1, []byte{0x3, 0x0}},
+	{[]byte{0x11}, BestCompression, []byte{0x12, 0x4, 0xc, 0x0}},
+	{[]byte{0x11, 0x12}, BestCompression, []byte{0x12, 0x14, 0x2, 0xc, 0x0}},
+	{[]byte{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, BestCompression, []byte{0x12, 0x84, 0x2, 0xc0, 0x0}},
+	{[]byte{}, 9, []byte{0x3, 0x0}},
+	{[]byte{0x11}, 9, []byte{0x12, 0x4, 0xc, 0x0}},
+	{[]byte{0x11, 0x12}, 9, []byte{0x12, 0x14, 0x2, 0xc, 0x0}},
+	{[]byte{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, 9, []byte{0x12, 0x84, 0x2, 0xc0, 0x0}},
 }
 
 var deflateInflateTests = []*deflateInflateTest{
@@ -110,7 +110,7 @@ func TestBulkHash4(t *testing.T) {
 }
 
 func TestDeflate(t *testing.T) {
-	for _, h := range deflateTests {
+	for i, h := range deflateTests {
 		var buf bytes.Buffer
 		w, err := NewWriter(&buf, h.level)
 		if err != nil {
@@ -120,7 +120,7 @@ func TestDeflate(t *testing.T) {
 		w.Write(h.in)
 		w.Close()
 		if !bytes.Equal(buf.Bytes(), h.out) {
-			t.Errorf("Deflate(%d, %x) = \n%#v, want \n%#v", h.level, h.in, buf.Bytes(), h.out)
+			t.Errorf("%d: Deflate(%d, %x) = \n%#v, want \n%#v", i, h.level, h.in, buf.Bytes(), h.out)
 		}
 	}
 }

--- a/flate/huffman_bit_writer.go
+++ b/flate/huffman_bit_writer.go
@@ -484,6 +484,9 @@ func (w *huffmanBitWriter) writeDynamicHeader(numLiterals int, numOffsets int, n
 	}
 }
 
+// writeStoredHeader will write a stored header.
+// If the stored block is only used for EOF,
+// it is replaced with a fixed huffman block.
 func (w *huffmanBitWriter) writeStoredHeader(length int, isEof bool) {
 	if w.err != nil {
 		return
@@ -493,6 +496,16 @@ func (w *huffmanBitWriter) writeStoredHeader(length int, isEof bool) {
 		w.writeCode(w.literalEncoding.codes[endBlockMarker])
 		w.lastHeader = 0
 	}
+
+	// To write EOF, use a fixed encoding block. 10 bits instead of 5 bytes.
+	if length == 0 && isEof {
+		w.writeFixedHeader(isEof)
+		// EOB: 7 bits, value: 0
+		w.writeBits(0, 7)
+		w.flush()
+		return
+	}
+
 	var flag int32
 	if isEof {
 		flag = 1

--- a/flate/huffman_code.go
+++ b/flate/huffman_code.go
@@ -109,8 +109,8 @@ func generateFixedOffsetEncoding() *huffmanEncoder {
 	return h
 }
 
-var fixedLiteralEncoding *huffmanEncoder = generateFixedLiteralEncoding()
-var fixedOffsetEncoding *huffmanEncoder = generateFixedOffsetEncoding()
+var fixedLiteralEncoding = generateFixedLiteralEncoding()
+var fixedOffsetEncoding = generateFixedOffsetEncoding()
 
 func (h *huffmanEncoder) bitLength(freq []uint16) int {
 	var total int

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -551,9 +551,9 @@ func (f *decompressor) readHuffman() error {
 		f.h1.min = f.bits[endBlockMarker]
 		if !f.final {
 			// If not the final block, the smallest block possible is
-			// a predefined table with a single EOB marker.
+			// a predefined table, BTYPE=01, with a single EOB marker.
 			// This will take up 3 + 7 bits.
-			f.h1.min += 10
+			//f.h1.min += 10
 		}
 	}
 

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -106,7 +106,7 @@ const (
 )
 
 type huffmanDecoder struct {
-	maxRead  int                       // the minimum code length
+	maxRead  int                       // the maximum number of bits we can read and not overread
 	chunks   *[huffmanNumChunks]uint16 // chunks as described above
 	links    [][]uint16                // overflow links
 	linkMask uint32                    // mask the width of the link table

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -549,6 +549,12 @@ func (f *decompressor) readHuffman() error {
 	// we never read any extra bytes after the end of the DEFLATE stream.
 	if f.h1.min < f.bits[endBlockMarker] {
 		f.h1.min = f.bits[endBlockMarker]
+		if !f.final {
+			// If not the final block, the smallest block possible is
+			// a predefined table with a single EOB marker.
+			// This will take up 3 + 7 bits.
+			f.h1.min += 10
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When a block is not marked as the final block it should be possible to read 10 further bits ahead without breaking the promise of not overreading.

Fixes #231

Also write blocks with only EOF as TYPE 01 (predefined tables) with only an EOB literal. This saves 3-4 bytes at no cost.

The smallest block seems to be a predefined block with a single EOB, which would be 10 bits + EOB from current block (current limit).

This should make it possible to fill more bits at the time when decoding.

```
λ benchcmp old.txt new.txt
benchmark                       old ns/op     new ns/op     delta
BenchmarkGunzipCopy-12          27830317      26617762      -4.36%
BenchmarkGunzipNoWriteTo-12     27878505      26705660      -4.21%

benchmark                       old MB/s     new MB/s     speedup
BenchmarkGunzipCopy-12          171.50       179.31       1.05x
BenchmarkGunzipNoWriteTo-12     171.20       178.72       1.04x
```