### PR TITLE
Skip creating encoders when not needed

### DIFF
--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -76,6 +76,9 @@ func NewWriter(w io.Writer, opts ...EOption) (*Encoder, error) {
 }
 
 func (e *Encoder) initialize() {
+	if e.o.concurrent == 0 {
+		e.o.setDefault()
+	}
 	e.encoders = make(chan encoder, e.o.concurrent)
 	for i := 0; i < e.o.concurrent; i++ {
 		e.encoders <- e.o.encoder()
@@ -415,9 +418,7 @@ func (e *Encoder) EncodeAll(src, dst []byte) []byte {
 		}
 		return dst
 	}
-	e.init.Do(func() {
-		e.initialize()
-	})
+	e.init.Do(e.initialize)
 	enc := <-e.encoders
 	defer func() {
 		// Release encoder reference to last block.

--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -71,10 +71,6 @@ func NewWriter(w io.Writer, opts ...EOption) (*Encoder, error) {
 	}
 	if w != nil {
 		e.Reset(w)
-	} else {
-		e.init.Do(func() {
-			e.initialize()
-		})
 	}
 	return &e, nil
 }
@@ -89,9 +85,6 @@ func (e *Encoder) initialize() {
 // Reset will re-initialize the writer and new writes will encode to the supplied writer
 // as a new, independent stream.
 func (e *Encoder) Reset(w io.Writer) {
-	e.init.Do(func() {
-		e.initialize()
-	})
 	s := &e.state
 	s.wg.Wait()
 	s.wWg.Wait()
@@ -423,7 +416,6 @@ func (e *Encoder) EncodeAll(src, dst []byte) []byte {
 		return dst
 	}
 	e.init.Do(func() {
-		e.o.setDefault()
 		e.initialize()
 	})
 	enc := <-e.encoders


### PR DESCRIPTION
Only EncodeAll uses the channel of encoders, so only allocate it when needed there.

Fixes #235

Reported by @jpchen-lightstep