### PR TITLE
zstd: Improve match speed of fastest level.

### DIFF
--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -87,6 +87,17 @@ func printf(format string, a ...interface{}) {
 	}
 }
 
+// matchLenFast does matching, but will not match the last up to 7 bytes.
+func matchLenFast(a, b []byte) int {
+	endI := len(a) & (math.MaxInt32 - 7)
+	for i := 0; i < endI; i += 8 {
+		if diff := load64(a, i) ^ load64(b, i); diff != 0 {
+			return i + bits.TrailingZeros64(diff)>>3
+		}
+	}
+	return endI
+}
+
 // matchLen returns the maximum length.
 // a must be the shortest of the two.
 // The function also returns whether all bytes matched.


### PR DESCRIPTION
Inline matchlen code and slightly simplify it. This loses a small amount of compression but gives a big speedup. This seems reasonable at the fastest level.

Before/after, best of 3 runs each:

```
file	out	level	insize	outsize	millis	mb/s
enwik9	zskp	1	1000000000	343831004	4202	226.91
enwik9	zskp	1	1000000000	343848582	3682	258.97

github-june-2days-2019.json	zskp	1	6273951764	698824137	10787	554.67
github-june-2days-2019.json	zskp	1	6273951764	699045015	10474	571.23

github-ranks-backup.bin	zskp	1	1862623243	454018274	4833	367.54
github-ranks-backup.bin	zskp	1	1862623243	454072815	4568	388.82

rawstudio-mint14.tar	zskp	1	8558382592	3667295557	21060	387.55
rawstudio-mint14.tar	zskp	1	8558382592	3667489370	20207	403.90

nyc-taxi-data-10M.csv	zskp	1	3325605752	641244049	10954	289.53
nyc-taxi-data-10M.csv	zskp	1	3325605752	641339945	9668	328.01

gob-stream	zskp	1	1911399616	234947276	3514	518.62
gob-stream	zskp	1	1911399616	235022249	3354	543.36
```
