### PR TITLE
all: Smaller struct sizes

### DIFF
--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -80,9 +80,7 @@ type advancedState struct {
 	// deflate state
 	length         int
 	offset         int
-	hash           uint32
 	maxInsertIndex int
-	ii             uint16 // position of last match, intended to overflow to reset.
 
 	// Input hash chains
 	// hashHead[hashValue] contains the largest inputIndex with the specified hash value
@@ -97,6 +95,9 @@ type advancedState struct {
 	// input window: unprocessed data is window[index:windowEnd]
 	index     int
 	hashMatch [maxMatchLength + minMatchLength]uint32
+
+	hash uint32
+	ii   uint16 // position of last match, intended to overflow to reset.
 }
 
 type compressor struct {
@@ -107,18 +108,19 @@ type compressor struct {
 	// compression algorithm
 	fill func(*compressor, []byte) int // copy data to window
 	step func(*compressor)             // process window
-	sync bool                          // requesting flush
 
-	window        []byte
-	windowEnd     int
-	blockStart    int  // window index where current tokens start
-	byteAvailable bool // if true, still need to process window[index-1].
-	err           error
+	window     []byte
+	windowEnd  int
+	blockStart int // window index where current tokens start
+	err        error
 
 	// queued output tokens
 	tokens tokens
 	fast   fastEnc
 	state  *advancedState
+
+	sync          bool // requesting flush
+	byteAvailable bool // if true, still need to process window[index-1].
 }
 
 func (d *compressor) fillDeflate(b []byte) int {

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -295,10 +295,6 @@ type decompressor struct {
 	r       Reader
 	roffset int64
 
-	// Input bits, in top of b.
-	b  uint32
-	nb uint
-
 	// Huffman decoders for literal/length, distance.
 	h1, h2 huffmanDecoder
 
@@ -309,19 +305,24 @@ type decompressor struct {
 	// Output history, buffer.
 	dict dictDecoder
 
-	// Temporary buffer (avoids repeated allocation).
-	buf [4]byte
-
 	// Next step in the decompression,
 	// and decompression state.
 	step      func(*decompressor)
 	stepState int
-	final     bool
 	err       error
 	toRead    []byte
 	hl, hd    *huffmanDecoder
 	copyLen   int
 	copyDist  int
+
+	// Temporary buffer (avoids repeated allocation).
+	buf [4]byte
+
+	// Input bits, in top of b.
+	b uint32
+
+	nb    uint
+	final bool
 }
 
 func (f *decompressor) nextBlock() {

--- a/fse/fse.go
+++ b/fse/fse.go
@@ -44,18 +44,14 @@ var (
 // Scratch provides temporary storage for compression and decompression.
 type Scratch struct {
 	// Private
-	count          [maxSymbolValue + 1]uint32
-	norm           [maxSymbolValue + 1]int16
-	symbolLen      uint16 // Length of active part of the symbol table.
-	actualTableLog uint8  // Selected tablelog.
-	br             byteReader
-	bits           bitReader
-	bw             bitWriter
-	ct             cTable      // Compression tables.
-	decTable       []decSymbol // Decompression table.
-	zeroBits       bool        // no bits has prob > 50%.
-	clearCount     bool        // clear count
-	maxCount       int         // count of the most probable symbol
+	count    [maxSymbolValue + 1]uint32
+	norm     [maxSymbolValue + 1]int16
+	br       byteReader
+	bits     bitReader
+	bw       bitWriter
+	ct       cTable      // Compression tables.
+	decTable []decSymbol // Decompression table.
+	maxCount int         // count of the most probable symbol
 
 	// Per block parameters.
 	// These can be used to override compression parameters of the block.
@@ -68,17 +64,22 @@ type Scratch struct {
 	// and allocation will be avoided.
 	Out []byte
 
-	// MaxSymbolValue will override the maximum symbol value of the next block.
-	MaxSymbolValue uint8
-
-	// TableLog will attempt to override the tablelog for the next block.
-	TableLog uint8
-
 	// DecompressLimit limits the maximum decoded size acceptable.
 	// If > 0 decompression will stop when approximately this many bytes
 	// has been decoded.
 	// If 0, maximum size will be 2GB.
 	DecompressLimit int
+
+	symbolLen      uint16 // Length of active part of the symbol table.
+	actualTableLog uint8  // Selected tablelog.
+	zeroBits       bool   // no bits has prob > 50%.
+	clearCount     bool   // clear count
+
+	// MaxSymbolValue will override the maximum symbol value of the next block.
+	MaxSymbolValue uint8
+
+	// TableLog will attempt to override the tablelog for the next block.
+	TableLog uint8
 }
 
 // Histogram allows to populate the histogram and skip that step in the compression,

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -37,13 +37,13 @@ type Writer struct {
 	Header      // written at first call to Write, Flush, or Close
 	w           io.Writer
 	level       int
-	wroteHeader bool
+	err         error
 	compressor  *flate.Writer
 	digest      uint32 // CRC-32, IEEE polynomial (section 8)
 	size        uint32 // Uncompressed size (section 2.3.1)
+	wroteHeader bool
 	closed      bool
 	buf         [10]byte
-	err         error
 }
 
 // NewWriter returns a new Writer.

--- a/huff0/huff0.go
+++ b/huff0/huff0.go
@@ -79,6 +79,13 @@ type Scratch struct {
 	// Slice of the returned data.
 	OutData []byte
 
+	// MaxDecodedSize will set the maximum allowed output size.
+	// This value will automatically be set to BlockSizeMax if not set.
+	// Decoders will return ErrMaxDecodedSizeExceeded is this limit is exceeded.
+	MaxDecodedSize int
+
+	br byteReader
+
 	// MaxSymbolValue will override the maximum symbol value of the next block.
 	MaxSymbolValue uint8
 
@@ -95,12 +102,6 @@ type Scratch struct {
 	// If WantLogLess == 0 any improvement will do.
 	WantLogLess uint8
 
-	// MaxDecodedSize will set the maximum allowed output size.
-	// This value will automatically be set to BlockSizeMax if not set.
-	// Decoders will return ErrMaxDecodedSizeExceeded is this limit is exceeded.
-	MaxDecodedSize int
-
-	br             byteReader
 	symbolLen      uint16 // Length of active part of the symbol table.
 	maxCount       int    // count of the most probable symbol
 	clearCount     bool   // clear count

--- a/s2/encode.go
+++ b/s2/encode.go
@@ -263,20 +263,21 @@ type Writer struct {
 	// ibuf is a buffer for the incoming (uncompressed) bytes.
 	ibuf []byte
 
-	// wroteStreamHeader is whether we have written the stream header.
-	wroteStreamHeader bool
-	paramsOK          bool
-	better            bool
-
 	blockSize   int
 	obufLen     int
 	concurrency int
 	written     int64
 	output      chan chan result
 	buffers     sync.Pool
-	writerWg    sync.WaitGroup
-	writer      io.Writer
 	pad         int
+
+	writer   io.Writer
+	writerWg sync.WaitGroup
+
+	// wroteStreamHeader is whether we have written the stream header.
+	wroteStreamHeader bool
+	paramsOK          bool
+	better            bool
 }
 
 type result []byte

--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -75,21 +75,25 @@ type blockDec struct {
 
 	// Window size of the block.
 	WindowSize uint64
-	Type       blockType
-	RLESize    uint32
+
+	history     chan *history
+	input       chan struct{}
+	result      chan decodeOutput
+	sequenceBuf []seq
+	err         error
+	decWG       sync.WaitGroup
+
+	// Block is RLE, this is the size.
+	RLESize uint32
+	tmp     [4]byte
+
+	Type blockType
 
 	// Is this the last block of a frame?
 	Last bool
 
 	// Use less memory
-	lowMem      bool
-	history     chan *history
-	input       chan struct{}
-	result      chan decodeOutput
-	sequenceBuf []seq
-	tmp         [4]byte
-	err         error
-	decWG       sync.WaitGroup
+	lowMem bool
 }
 
 func (b *blockDec) String() string {

--- a/zstd/enc_better.go
+++ b/zstd/enc_better.go
@@ -104,10 +104,7 @@ func (e *betterFastEncoder) Encode(blk *blockEnc, src []byte) {
 	sLimit := int32(len(src)) - inputMargin
 	// stepSize is the number of bytes to skip on every main loop iteration.
 	// It should be >= 1.
-	stepSize := int32(e.o.targetLength)
-	if stepSize == 0 {
-		stepSize++
-	}
+	const stepSize = 1
 
 	const kSearchStrength = 9
 

--- a/zstd/enc_dfast.go
+++ b/zstd/enc_dfast.go
@@ -80,10 +80,7 @@ func (e *doubleFastEncoder) Encode(blk *blockEnc, src []byte) {
 	sLimit := int32(len(src)) - inputMargin
 	// stepSize is the number of bytes to skip on every main loop iteration.
 	// It should be >= 1.
-	stepSize := int32(e.o.targetLength)
-	if stepSize == 0 {
-		stepSize++
-	}
+	const stepSize = 1
 
 	const kSearchStrength = 8
 
@@ -401,10 +398,7 @@ func (e *doubleFastEncoder) EncodeNoHist(blk *blockEnc, src []byte) {
 	sLimit := int32(len(src)) - inputMargin
 	// stepSize is the number of bytes to skip on every main loop iteration.
 	// It should be >= 1.
-	stepSize := int32(e.o.targetLength)
-	if stepSize == 0 {
-		stepSize++
-	}
+	const stepSize = 1
 
 	const kSearchStrength = 8
 

--- a/zstd/enc_fast.go
+++ b/zstd/enc_fast.go
@@ -25,7 +25,6 @@ type tableEntry struct {
 }
 
 type fastBase struct {
-	o encParams
 	// cur is the offset at the start of hist
 	cur int32
 	// maximum offset. Should be at least 2x block size.
@@ -117,11 +116,7 @@ func (e *fastEncoder) Encode(blk *blockEnc, src []byte) {
 	sLimit := int32(len(src)) - inputMargin
 	// stepSize is the number of bytes to skip on every main loop iteration.
 	// It should be >= 2.
-	stepSize := int32(e.o.targetLength)
-	if stepSize == 0 {
-		stepSize++
-	}
-	stepSize++
+	const stepSize = 2
 
 	// TEMPLATE
 	const hashLog = tableBits

--- a/zstd/enc_params.go
+++ b/zstd/enc_params.go
@@ -4,6 +4,8 @@
 
 package zstd
 
+/*
+// encParams are not really used, just here for reference.
 type encParams struct {
 	// largest match distance : larger == more compression, more memory needed during decompression
 	windowLog uint8
@@ -152,3 +154,4 @@ var defEncParams = [4][]encParams{
 		{14, 15, 15, 10, 3, 999, strategyBtultra2}, // level 22.
 	},
 }
+*/

--- a/zstd/encoder_options.go
+++ b/zstd/encoder_options.go
@@ -13,12 +13,12 @@ type EOption func(*encoderOptions) error
 // options retains accumulated state of multiple options.
 type encoderOptions struct {
 	concurrent int
-	crc        bool
+	level      EncoderLevel
 	single     *bool
 	pad        int
 	blockSize  int
 	windowSize int
-	level      EncoderLevel
+	crc        bool
 	fullZero   bool
 	noEntropy  bool
 }

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -16,16 +16,11 @@ import (
 )
 
 type frameDec struct {
-	o         decoderOptions
-	crc       hash.Hash64
-	frameDone sync.WaitGroup
-	offset    int64
+	o      decoderOptions
+	crc    hash.Hash64
+	offset int64
 
-	WindowSize       uint64
-	DictionaryID     uint32
-	FrameContentSize uint64
-	HasCheckSum      bool
-	SingleSegment    bool
+	WindowSize uint64
 
 	// maxWindowSize is the maximum windows size to support.
 	// should never be bigger than max-int.
@@ -42,9 +37,16 @@ type frameDec struct {
 	// Byte buffer that can be reused for small input blocks.
 	bBuf byteBuf
 
+	FrameContentSize uint64
+	frameDone        sync.WaitGroup
+
+	DictionaryID  uint32
+	HasCheckSum   bool
+	SingleSegment bool
+
 	// asyncRunning indicates whether the async routine processes input on 'decoding'.
-	asyncRunning   bool
 	asyncRunningMu sync.Mutex
+	asyncRunning   bool
 }
 
 const (


### PR DESCRIPTION
Align elements in structs to avoid padding.