### PR TITLE
zstd: If first block and 'final', encode direct.

### DIFF
--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -39,17 +39,18 @@ type encoder interface {
 }
 
 type encoderState struct {
-	w             io.Writer
-	filling       []byte
-	current       []byte
-	previous      []byte
-	encoder       encoder
-	writing       *blockEnc
-	err           error
-	writeErr      error
-	nWritten      int64
-	headerWritten bool
-	eofWritten    bool
+	w                io.Writer
+	filling          []byte
+	current          []byte
+	previous         []byte
+	encoder          encoder
+	writing          *blockEnc
+	err              error
+	writeErr         error
+	nWritten         int64
+	headerWritten    bool
+	eofWritten       bool
+	fullFrameWritten bool
 
 	// This waitgroup indicates an encode is running.
 	wg sync.WaitGroup
@@ -114,6 +115,7 @@ func (e *Encoder) Reset(w io.Writer) {
 	s.encoder.Reset()
 	s.headerWritten = false
 	s.eofWritten = false
+	s.fullFrameWritten = false
 	s.w = w
 	s.err = nil
 	s.nWritten = 0
@@ -183,6 +185,8 @@ func (e *Encoder) nextBlock(final bool) error {
 			s.nWritten += int64(n2)
 			s.current = s.current[:0]
 			s.filling = s.filling[:0]
+			s.headerWritten = true
+			s.fullFrameWritten = true
 			return nil
 		}
 
@@ -372,6 +376,9 @@ func (e *Encoder) Close() error {
 	err := e.nextBlock(true)
 	if err != nil {
 		return err
+	}
+	if e.state.fullFrameWritten {
+		return s.err
 	}
 	s.wg.Wait()
 	s.wWg.Wait()


### PR DESCRIPTION
If if writing header (ie first block) and it is the final block, use block compression instead of async.

Addition for #248