### PR TITLE
Reduce raw block allocs

### DIFF
--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -156,8 +156,12 @@ func (b *blockDec) reset(br byteBuffer, windowSize uint64) error {
 			}
 			return ErrCompressedSizeTooBig
 		}
-	default:
+	case blockTypeRaw:
 		b.RLESize = 0
+		// We do not need a destination for raw blocks.
+		maxSize = 0
+	default:
+		panic("Invalid block type")
 	}
 
 	// Read block data.

--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -159,7 +159,7 @@ func (b *blockDec) reset(br byteBuffer, windowSize uint64) error {
 	case blockTypeRaw:
 		b.RLESize = 0
 		// We do not need a destination for raw blocks.
-		maxSize = 0
+		maxSize = -1
 	default:
 		panic("Invalid block type")
 	}


### PR DESCRIPTION
Raw blocks don't need a destination since it is always forwarded directly.

The panic should be unreachable. Adding it for sanity check since it is harmless.