### PR TITLE
zstd: Decoder: implement io.Closer

### DIFF
--- a/zstd/decoder.go
+++ b/zstd/decoder.go
@@ -382,9 +382,9 @@ func (d *Decoder) nextBlock(blocking bool) (ok bool) {
 
 // Close will release all resources.
 // It is NOT possible to reuse the decoder after this.
-func (d *Decoder) Close() {
+func (d *Decoder) Close() error {
 	if d.current.err == ErrDecoderClosed {
-		return
+		return ErrDecoderClosed
 	}
 	d.drainOutput()
 	if d.stream != nil {
@@ -404,6 +404,7 @@ func (d *Decoder) Close() {
 		d.current.d = nil
 	}
 	d.current.err = ErrDecoderClosed
+	return nil
 }
 
 // IOReadCloser returns the decoder as an io.ReadCloser for convenience.


### PR DESCRIPTION
Permit zstd.Decoder to implement io.Closer without an adapter.