### PR TITLE
zstd: Always reset literal dict encoder

### DIFF
--- a/zstd/blockenc.go
+++ b/zstd/blockenc.go
@@ -76,6 +76,7 @@ func (b *blockEnc) reset(prev *blockEnc) {
 	if prev != nil {
 		b.recentOffsets = prev.prevRecentOffsets
 	}
+	b.dictLitEnc = nil
 }
 
 // reset will reset the block for a new encode, but in the same stream,


### PR DESCRIPTION
Currently the literal encoder can be carried over.

Not currently needed, but could give unexpected results in the future.