### PR TITLE
keep allocations as small as possible

### DIFF
--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -185,7 +185,12 @@ func (s *sequenceDecs) decode(seqs int, br *bitReader, hist []byte) error {
 			// but could be if destination slice is too small for sync operations.
 			// over-allocating here can create a large amount of GC pressure so we try to keep
 			// it as contained as possible
-			addBytes := 1024 + (size - len(s.out))
+			used := len(s.out) - startSize
+			addBytes := 256 + ll + ml + used>>2
+			// Clamp to max block size.
+			if used+addBytes > maxBlockSize {
+				addBytes = maxBlockSize - used
+			}
 			s.out = append(s.out, make([]byte, addBytes)...)
 			s.out = s.out[:len(s.out)-addBytes]
 		}

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -181,11 +181,13 @@ func (s *sequenceDecs) decode(seqs int, br *bitReader, hist []byte) error {
 			return fmt.Errorf("output (%d) bigger than max block size", size)
 		}
 		if size > cap(s.out) {
-			// Not enough size, will be extremely rarely triggered,
+			// Not enough size, which can happen under high volume block streaming conditions
 			// but could be if destination slice is too small for sync operations.
-			// We add maxBlockSize to the capacity.
-			s.out = append(s.out, make([]byte, maxBlockSize)...)
-			s.out = s.out[:len(s.out)-maxBlockSize]
+			// over-allocating here can create a large amount of GC pressure so we try to keep
+			// it as contained as possible
+			addBytes := size - len(s.out)
+			s.out = append(s.out, make([]byte, addBytes)...)
+			s.out = s.out[:len(s.out)-addBytes]
 		}
 		if ml > maxMatchLen {
 			return fmt.Errorf("match len (%d) bigger than max allowed length", ml)

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -185,7 +185,7 @@ func (s *sequenceDecs) decode(seqs int, br *bitReader, hist []byte) error {
 			// but could be if destination slice is too small for sync operations.
 			// over-allocating here can create a large amount of GC pressure so we try to keep
 			// it as contained as possible
-			addBytes := size - len(s.out)
+			addBytes := 1024 + (size - len(s.out))
 			s.out = append(s.out, make([]byte, addBytes)...)
 			s.out = s.out[:len(s.out)-addBytes]
 		}


### PR DESCRIPTION
Under some large streaming volume conditions (kafka consumption) this allocation can create tremendous GC pressure, where setting GOGC <= 10 still is not enough.  Since this condition does not happen "very often" (but seems to happen more often in this streaming case then originally advertised by the original comment) we only allocate as much as we need not an extra 2Mb slab.

Conditions:
- 2000 zstd encoded blocks second over 64 different streams byte blocks were in 1Mb chunks

Before this change:
- with in several seconds Ram consumption would jump from 200Mb to over 30Gb
- pprof indicated this allocation as the issue, however only ~500Mb inuse indicating GC had not cleaned up the other allocs
- turning on GOGC=5, stemmed the speed of OOM, but still eventually OOMed

After this change:
- ram usage is steady at around 200Mb and message rate seems same as before.