### PR TITLE
s2: Add 'best' compression option

### DIFF
--- a/s2/README.md
+++ b/s2/README.md
@@ -456,20 +456,33 @@ This will compress as much as possible with little regard to CPU usage.
 Mainly for offline compression, but where decompression speed should still
 be high and compatible with other S2 compressed data.
 
-Some examples compared to 'better' mode on 16 core CPU:
+Some examples compared on 16 core CPU:
 
 ```
-github-june-2days-2019.json; 6273951764 -> 950079555 [15.14%]; 3541.4MB/s
-github-june-2days-2019.json; 6273951764 -> 846260870 [13.49%]; 661.5MB/s
+* enwik10
+Default... 10000000000 -> 4761467548 [47.61%]; 1.098s, 8685.6MB/s
+Better... 10000000000 -> 4225922984 [42.26%]; 2.817s, 3385.4MB/s
+Best... 10000000000 -> 3667646858 [36.68%]; 35.995s, 264.9MB/s
 
-nyc-taxi-data-10M.csv; 3325605752 -> 960330423 [28.88%]; 3249.5MB/s
-nyc-taxi-data-10M.csv; 3325605752 -> 794873295 [23.90%]; 437.5MB/s
+* github-june-2days-2019.json
+Default... 6273951764 -> 1043196283 [16.63%]; 431ms, 13882.3MB/s
+Better... 6273951764 -> 950079555 [15.14%]; 736ms, 8129.5MB/s
+Best... 6273951764 -> 846260870 [13.49%]; 8.125s, 736.4MB/s
 
-10gb.tar; 10065157632 -> 5650133605 [56.14%]; 3137.9MB/s
-10gb.tar; 10065157632 -> 5250102961 [52.16%]; 390.1MB/s
+* nyc-taxi-data-10M.csv
+Default... 3325605752 -> 1095998837 [32.96%]; 324ms, 9788.7MB/s
+Better... 3325605752 -> 960330423 [28.88%]; 602ms, 5268.4MB/s
+Best... 3325605752 -> 794873295 [23.90%]; 6.619s, 479.1MB/s
 
-consensus.db.10gb; 10737418240 -> 4542443833 [42.30%]; 3008.2MB/s
-consensus.db.10gb; 10737418240 -> 4272335541 [39.79%]; 248.8MB/s
+* 10gb.tar
+Default... 10065157632 -> 5916578242 [58.78%]; 1.028s, 9337.4MB/s
+Better... 10065157632 -> 5650133605 [56.14%]; 2.172s, 4419.4MB/s
+Best... 10065157632 -> 5246578570 [52.13%]; 25.696s, 373.6MB/s
+
+* consensus.db.10gb
+Default... 10737418240 -> 4562648848 [42.49%]; 882ms, 11610.0MB/s
+Better... 10737418240 -> 4542443833 [42.30%]; 3.3s, 3103.5MB/s
+Best... 10737418240 -> 4272335558 [39.79%]; 38.955s, 262.9MB/s
 ```
 
 Decompression speed should be around the same as using the 'better' compression mode. 

--- a/s2/README.md
+++ b/s2/README.md
@@ -442,11 +442,38 @@ The PDF sample shows a significant slowdown compared to Snappy, as this mode tri
 to compress the data. Very small blocks are also not favorable for better compression, so throughput is way down.
 
 This mode aims to provide better compression at the expense of performance and achieves that 
-without a huge performance pentalty, except on very small blocks. 
+without a huge performance penalty, except on very small blocks. 
 
 Decompression speed suffers a little compared to the regular S2 mode, 
 but still manages to be close to Snappy in spite of increased compression.  
  
+# Best compression mode
+
+S2 offers a "best" compression mode. 
+
+This will compress as much as possible with little regard to CPU usage.
+
+Mainly for offline compression, but where decompression speed should still
+be high and compatible with other S2 compressed data.
+
+Some examples compared to 'better' mode on 16 core CPU:
+
+```
+github-june-2days-2019.json; 6273951764 -> 950079555 [15.14%]; 3541.4MB/s
+github-june-2days-2019.json; 6273951764 -> 846260870 [13.49%]; 661.5MB/s
+
+nyc-taxi-data-10M.csv; 3325605752 -> 960330423 [28.88%]; 3249.5MB/s
+nyc-taxi-data-10M.csv; 3325605752 -> 794873295 [23.90%]; 437.5MB/s
+
+10gb.tar; 10065157632 -> 5650133605 [56.14%]; 3137.9MB/s
+10gb.tar; 10065157632 -> 5250102961 [52.16%]; 390.1MB/s
+
+consensus.db.10gb; 10737418240 -> 4542443833 [42.30%]; 3008.2MB/s
+consensus.db.10gb; 10737418240 -> 4272335541 [39.79%]; 248.8MB/s
+```
+
+Decompression speed should be around the same as using the 'better' compression mode. 
+
 # Concatenating blocks and streams.
 
 Concatenating streams will concatenate the output of both without recompressing them. 

--- a/s2/cmd/s2c/main.go
+++ b/s2/cmd/s2c/main.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	faster    = flag.Bool("faster", false, "Compress faster, but with a minor compression loss")
+	slower    = flag.Bool("slower", false, "Compress more, but a lot slower")
 	cpu       = flag.Int("cpu", runtime.GOMAXPROCS(0), "Compress using this amount of threads")
 	blockSize = flag.String("blocksize", "4M", "Max  block size. Examples: 64K, 256K, 1M, 4M. Must be power of two and <= 4MB")
 	safe      = flag.Bool("safe", false, "Do not overwrite output files")
@@ -55,7 +56,7 @@ func main() {
 	exitErr(err)
 
 	args := flag.Args()
-	if len(args) == 0 || *help {
+	if len(args) == 0 || *help || (*slower && *faster) {
 		_, _ = fmt.Fprintf(os.Stderr, "s2 compress v%v, built at %v.\n\n", version, date)
 		_, _ = fmt.Fprintf(os.Stderr, "Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.\n"+
 			"Copyright (c) 2019 Klaus Post. All rights reserved.\n\n")
@@ -76,6 +77,9 @@ Options:`)
 	opts := []s2.WriterOption{s2.WriterBlockSize(int(sz)), s2.WriterConcurrency(*cpu), s2.WriterPadding(int(pad))}
 	if !*faster {
 		opts = append(opts, s2.WriterBetterCompression())
+	}
+	if *slower {
+		opts = append(opts, s2.WriterBestCompression())
 	}
 	wr := s2.NewWriter(nil, opts...)
 

--- a/s2/encode.go
+++ b/s2/encode.go
@@ -100,6 +100,48 @@ func EncodeBetter(dst, src []byte) []byte {
 	return dst[:d]
 }
 
+// EncodeBest returns the encoded form of src. The returned slice may be a sub-
+// slice of dst if dst was large enough to hold the entire encoded block.
+// Otherwise, a newly allocated slice will be returned.
+//
+// EncodeBest compresses as good as reasonably possible but with a
+// big speed decrease.
+//
+// The dst and src must not overlap. It is valid to pass a nil dst.
+//
+// The blocks will require the same amount of memory to decode as encoding,
+// and does not make for concurrent decoding.
+// Also note that blocks do not contain CRC information, so corruption may be undetected.
+//
+// If you need to encode larger amounts of data, consider using
+// the streaming interface which gives all of these features.
+func EncodeBest(dst, src []byte) []byte {
+	if n := MaxEncodedLen(len(src)); n < 0 {
+		panic(ErrTooLarge)
+	} else if len(dst) < n {
+		dst = make([]byte, n)
+	}
+
+	// The block starts with the varint-encoded length of the decompressed bytes.
+	d := binary.PutUvarint(dst, uint64(len(src)))
+
+	if len(src) == 0 {
+		return dst[:d]
+	}
+	if len(src) < minNonLiteralBlockSize {
+		d += emitLiteral(dst[d:], src)
+		return dst[:d]
+	}
+	n := encodeBlockBest(dst[d:], src)
+	if n > 0 {
+		d += n
+		return dst[:d]
+	}
+	// Not compressible
+	d += emitLiteral(dst[d:], src)
+	return dst[:d]
+}
+
 // EncodeSnappy returns the encoded form of src. The returned slice may be a sub-
 // slice of dst if dst was large enough to hold the entire encoded block.
 // Otherwise, a newly allocated slice will be returned.
@@ -239,6 +281,7 @@ func NewWriter(w io.Writer, opts ...WriterOption) *Writer {
 		blockSize:   defaultBlockSize,
 		concurrency: runtime.GOMAXPROCS(0),
 		randSrc:     rand.Reader,
+		level:       levelFast,
 	}
 	for _, opt := range opts {
 		if err := opt(&w2); err != nil {
@@ -279,9 +322,15 @@ type Writer struct {
 	// wroteStreamHeader is whether we have written the stream header.
 	wroteStreamHeader bool
 	paramsOK          bool
-	better            bool
-	uncompressed      bool
+	level             uint8
 }
+
+const (
+	levelUncompressed = iota + 1
+	levelFast
+	levelBetter
+	levelBest
+)
 
 type result []byte
 
@@ -483,10 +532,13 @@ func (w *Writer) EncodeBuffer(buf []byte) (err error) {
 			// Attempt compressing.
 			n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
 			var n2 int
-			if w.better {
-				n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-			} else if !w.uncompressed {
+			switch w.level {
+			case levelFast:
 				n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
+			case levelBetter:
+				n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
+			case levelBest:
+				n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
 			}
 
 			// Check if we should use this, or store as uncompressed instead.
@@ -560,10 +612,13 @@ func (w *Writer) write(p []byte) (nRet int, errRet error) {
 			// Attempt compressing.
 			n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
 			var n2 int
-			if w.better {
-				n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-			} else if !w.uncompressed {
+			switch w.level {
+			case levelFast:
 				n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
+			case levelBetter:
+				n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
+			case levelBest:
+				n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
 			}
 
 			// Check if we should use this, or store as uncompressed instead.
@@ -636,10 +691,13 @@ func (w *Writer) writeFull(inbuf []byte) (errRet error) {
 		// Attempt compressing.
 		n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
 		var n2 int
-		if w.better {
-			n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-		} else if !w.uncompressed {
+		switch w.level {
+		case levelFast:
 			n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
+		case levelBetter:
+			n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
+		case levelBest:
+			n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
 		}
 
 		// Check if we should use this, or store as uncompressed instead.
@@ -705,10 +763,13 @@ func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
 		// Attempt compressing.
 		n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
 		var n2 int
-		if w.better {
-			n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-		} else if !w.uncompressed {
+		switch w.level {
+		case levelFast:
 			n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
+		case levelBetter:
+			n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
+		case levelBest:
+			n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
 		}
 
 		if n2 > 0 {
@@ -880,8 +941,17 @@ func WriterConcurrency(n int) WriterOption {
 // 10-40% speed decrease on both compression and decompression.
 func WriterBetterCompression() WriterOption {
 	return func(w *Writer) error {
-		w.uncompressed = false
-		w.better = true
+		w.level = levelBetter
+		return nil
+	}
+}
+
+// WriterBestCompression will enable better compression.
+// EncodeBetter compresses better than Encode but typically with a
+// big speed decrease on compression.
+func WriterBestCompression() WriterOption {
+	return func(w *Writer) error {
+		w.level = levelBest
 		return nil
 	}
 }
@@ -891,8 +961,7 @@ func WriterBetterCompression() WriterOption {
 // If concurrency is > 1 CRC and output will still be done async.
 func WriterUncompressed() WriterOption {
 	return func(w *Writer) error {
-		w.better = false
-		w.uncompressed = true
+		w.level = levelUncompressed
 		return nil
 	}
 }

--- a/s2/encode_best.go
+++ b/s2/encode_best.go
@@ -83,6 +83,10 @@ func encodeBlockBest(dst, src []byte) (d int) {
 			candidateS := sTable[hashS]
 
 			matchAt := func(offset, s int, first uint32, rep bool) match {
+				if best.length != 0 && best.s-best.offset == s-offset {
+					// Don't retest if we have the same offset.
+					return match{offset: offset, s: s}
+				}
 				if load32(src, offset) != first {
 					return match{offset: offset, s: s}
 				}

--- a/s2/encode_best.go
+++ b/s2/encode_best.go
@@ -1,0 +1,248 @@
+// Copyright 2016 The Snappy-Go Authors. All rights reserved.
+// Copyright (c) 2019 Klaus Post. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package s2
+
+import (
+	"fmt"
+	"math/bits"
+)
+
+// encodeBlockBest encodes a non-empty src to a guaranteed-large-enough dst. It
+// assumes that the varint-encoded length of the decompressed bytes has already
+// been written.
+//
+// It also assumes that:
+//	len(dst) >= MaxEncodedLen(len(src)) &&
+// 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
+func encodeBlockBest(dst, src []byte) (d int) {
+	// Initialize the hash tables.
+	const (
+		// Long hash matches.
+		lTableBits    = 19
+		maxLTableSize = 1 << lTableBits
+
+		// Short hash matches.
+		sTableBits    = 16
+		maxSTableSize = 1 << sTableBits
+
+		inputMargin = 8 + 2
+	)
+
+	var lTable [maxLTableSize]uint64
+	var sTable [maxSTableSize]uint64
+
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := len(src) - inputMargin
+	if len(src) < minNonLiteralBlockSize {
+		return 0
+	}
+
+	// Bail if we can't compress to at least this.
+	dstLimit := len(src) - 5
+
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := 0
+
+	// The encoded form must start with a literal, as there are no previous
+	// bytes to copy, so we start looking for hash matches at s == 1.
+	s := 1
+	cv := load64(src, s)
+
+	// We search for a repeat at -1, but don't output repeats when nextEmit == 0
+	repeat := 1
+	const lowbitMask = 0xffffffff
+	getCur := func(x uint64) int {
+		return int(x & lowbitMask)
+	}
+	getPrev := func(x uint64) int {
+		return int(x >> 32)
+	}
+
+	for {
+		type match struct {
+			offset int
+			s      int
+			length int
+			rep    bool
+		}
+		var best match
+		for {
+			// Next src position to check
+			nextS := s + (s-nextEmit)>>8 + 1
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			hashL := hash8(cv, lTableBits)
+			hashS := hash4(cv, sTableBits)
+			candidateL := lTable[hashL]
+			candidateS := sTable[hashS]
+
+			matchAt := func(offset, s int, first uint32, rep bool) match {
+				if load32(src, offset) != first {
+					return match{offset: offset, s: s}
+				}
+				m := match{offset: offset, s: s, length: 4, rep: rep}
+				s += 4
+				for s <= sLimit {
+					if diff := load64(src, s) ^ load64(src, offset+m.length); diff != 0 {
+						m.length += bits.TrailingZeros64(diff) >> 3
+						break
+					}
+					s += 8
+					m.length += 8
+				}
+				return m
+			}
+
+			bestOf := func(a, b match) match {
+				aScore := b.s - a.s + a.length
+				bScore := a.s - b.s + b.length
+				if !a.rep {
+					// Estimate bytes needed to store offset.
+					offset := a.s - a.offset
+					if offset >= 65536 {
+						aScore -= 5
+					} else {
+						aScore -= 3
+					}
+				}
+				if !b.rep {
+					// Estimate bytes needed to store offset.
+					offset := b.s - b.offset
+					if offset >= 65536 {
+						bScore -= 5
+					} else {
+						bScore -= 3
+					}
+				}
+				if aScore >= bScore {
+					return a
+				}
+				return b
+			}
+
+			best = bestOf(matchAt(getCur(candidateL), s, uint32(cv), false), matchAt(getPrev(candidateL), s, uint32(cv), false))
+			best = bestOf(best, matchAt(getCur(candidateS), s, uint32(cv), false))
+			best = bestOf(best, matchAt(getPrev(candidateS), s, uint32(cv), false))
+
+			{
+				best = bestOf(best, matchAt(s-repeat+1, s+1, uint32(cv>>8), true))
+				if best.length > 0 {
+					// s+1
+					nextShort := sTable[hash4(cv>>8, sTableBits)]
+					s := s + 1
+					cv := load64(src, s)
+					nextLong := lTable[hash8(cv, lTableBits)]
+					best = bestOf(best, matchAt(getCur(nextShort), s, uint32(cv), false))
+					best = bestOf(best, matchAt(getPrev(nextShort), s, uint32(cv), false))
+					best = bestOf(best, matchAt(getCur(nextLong), s, uint32(cv), false))
+					best = bestOf(best, matchAt(getPrev(nextLong), s, uint32(cv), false))
+					// Repeat at + 2
+					best = bestOf(best, matchAt(s-repeat+1, s+1, uint32(cv>>8), true))
+
+					// s+2
+					if true {
+						nextShort = sTable[hash4(cv>>8, sTableBits)]
+						s++
+						cv = load64(src, s)
+						nextLong = lTable[hash8(cv, lTableBits)]
+						best = bestOf(best, matchAt(getCur(nextShort), s, uint32(cv), false))
+						best = bestOf(best, matchAt(getPrev(nextShort), s, uint32(cv), false))
+						best = bestOf(best, matchAt(getCur(nextLong), s, uint32(cv), false))
+						best = bestOf(best, matchAt(getPrev(nextLong), s, uint32(cv), false))
+					}
+				}
+			}
+
+			// Update table
+			lTable[hashL] = uint64(s) | candidateL<<32
+			sTable[hashS] = uint64(s) | candidateS<<32
+
+			if best.length > 0 {
+				break
+			}
+
+			cv = load64(src, nextS)
+			s = nextS
+		}
+
+		// Extend backwards, not needed for repeats...
+		s = best.s
+		if !best.rep {
+			for best.offset > 0 && s > nextEmit && src[best.offset-1] == src[s-1] {
+				best.offset--
+				best.length++
+				s--
+			}
+		}
+		if false && best.offset >= s {
+			panic(fmt.Errorf("t %d >= s %d", best.offset, s))
+		}
+		// Bail if we exceed the maximum size.
+		if d+(s-nextEmit) > dstLimit {
+			return 0
+		}
+
+		base := s
+		offset := s - best.offset
+
+		s += best.length
+
+		if offset > 65535 && s-base <= 5 && !best.rep {
+			// Bail if the match is equal or worse to the encoding.
+			s = best.s + 1
+			if s >= sLimit {
+				goto emitRemainder
+			}
+			cv = load64(src, s)
+			continue
+		}
+		d += emitLiteral(dst[d:], src[nextEmit:base])
+		if best.rep {
+			if nextEmit > 0 {
+				// same as `add := emitCopy(dst[d:], repeat, s-base)` but skips storing offset.
+				d += emitRepeat(dst[d:], offset, best.length)
+			} else {
+				// First match, cannot be repeat.
+				d += emitCopy(dst[d:], offset, best.length)
+			}
+		} else {
+			d += emitCopy(dst[d:], offset, best.length)
+		}
+		repeat = offset
+
+		nextEmit = s
+		if s >= sLimit {
+			goto emitRemainder
+		}
+
+		if d > dstLimit {
+			// Do we have space for more, if not bail.
+			return 0
+		}
+		// Fill tables...
+		for i := best.s + 1; i < s; i++ {
+			cv0 := load64(src, i)
+			long0 := hash8(cv0, lTableBits)
+			short0 := hash4(cv0, sTableBits)
+			lTable[long0] = uint64(i) | lTable[long0]<<32
+			sTable[short0] = uint64(i) | sTable[short0]<<32
+		}
+		cv = load64(src, s)
+	}
+
+emitRemainder:
+	if nextEmit < len(src) {
+		// Bail if we exceed the maximum size.
+		if d+len(src)-nextEmit > dstLimit {
+			return 0
+		}
+		d += emitLiteral(dst[d:], src[nextEmit:])
+	}
+	return d
+}

--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -20,6 +20,7 @@ func testOptions(t testing.TB) map[string][]WriterOption {
 	var testOptions = map[string][]WriterOption{
 		"default": {},
 		"better":  {WriterBetterCompression()},
+		"best":    {WriterBestCompression()},
 		"none":    {WriterUncompressed()},
 	}
 


### PR DESCRIPTION
Add compression mode that will compress the data very well, but at a significant performance decrease.

Mainly for offline compression, but where decompression speed should still be high and compatible with other S2 compressed data.

Comparing on 16 core CPU:

```
* enwik10:
Default... 10000000000 -> 4761467548 [47.61%]; 1.098s, 8685.6MB/s
Better... 10000000000 -> 4225922984 [42.26%]; 2.817s, 3385.4MB/s
Best... 10000000000 -> 3667646858 [36.68%]; 35.995s, 264.9MB/s

* github-june-2days-2019.json:
Default... 6273951764 -> 1043196283 [16.63%]; 431ms, 13882.3MB/s
Better... 6273951764 -> 950079555 [15.14%]; 736ms, 8129.5MB/s
Best... 6273951764 -> 846260870 [13.49%]; 8.125s, 736.4MB/s

* nyc-taxi-data-10M.csv:
Default... 3325605752 -> 1095998837 [32.96%]; 324ms, 9788.7MB/s
Better... 3325605752 -> 960330423 [28.88%]; 602ms, 5268.4MB/s
Best... 3325605752 -> 794873295 [23.90%]; 6.619s, 479.1MB/s

* 10gb.tar
Default... 10065157632 -> 5916578242 [58.78%]; 1.028s, 9337.4MB/s
Better... 10065157632 -> 5650133605 [56.14%]; 2.172s, 4419.4MB/s
Best... 10065157632 -> 5246578570 [52.13%]; 25.696s, 373.6MB/s

* consensus.db.10gb:
Default... 10737418240 -> 4562648848 [42.49%]; 882ms, 11610.0MB/s
Better... 10737418240 -> 4542443833 [42.30%]; 3.3s, 3103.5MB/s
Best... 10737418240 -> 4272335558 [39.79%]; 38.955s, 262.9MB/s
```