### PR TITLE
fixes zip64 headers

### DIFF
--- a/zip/writer.go
+++ b/zip/writer.go
@@ -129,7 +129,7 @@ func (w *Writer) Close() error {
 		b.uint16(uint16(len(h.Comment)))
 		b = b[4:] // skip disk number start and internal file attr (2x uint16)
 		b.uint32(h.ExternalAttrs)
-		if h.offset > uint32max {
+		if h.isZip64() || h.offset > uint32max {
 			b.uint32(uint32max)
 		} else {
 			b.uint32(uint32(h.offset))


### PR DESCRIPTION
See also https://github.com/golang/go/issues/33116

The offset must be written into the central directory
as 0xFFFFFFFF if it's going to be written in the zip64
extended information field.

https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

The following is the layout of the zip64 extended
information "extra" block. If one of the size or
offset fields in the Local or Central directory
record is too small to hold the required data,
a Zip64 extended information record is created.
The order of the fields in the zip64 extended
information record is fixed, but the fields MUST
only appear if the corresponding Local or Central
directory record field is set to 0xFFFF or 0xFFFFFFFF.