### PR TITLE
zstd: Increase speed on incompressible data for best

### DIFF
--- a/zstd/enc_best.go
+++ b/zstd/enc_best.go
@@ -112,7 +112,7 @@ func (e *bestFastEncoder) Encode(blk *blockEnc, src []byte) {
 	// Override src
 	src = e.hist
 	sLimit := int32(len(src)) - inputMargin
-	const kSearchStrength = 12
+	const kSearchStrength = 10
 
 	// nextEmit is where in src the next emitLiteral should start from.
 	nextEmit := s
@@ -186,9 +186,11 @@ encodeLoop:
 			best = bestOf(best, matchAt(s-offset1+1, s+1, uint32(cv>>8), 1))
 			best = bestOf(best, matchAt(s-offset2+1, s+1, uint32(cv>>8), 2))
 			best = bestOf(best, matchAt(s-offset3+1, s+1, uint32(cv>>8), 3))
-			best = bestOf(best, matchAt(s-offset1+3, s+3, uint32(cv>>24), 1))
-			best = bestOf(best, matchAt(s-offset2+3, s+3, uint32(cv>>24), 2))
-			best = bestOf(best, matchAt(s-offset3+3, s+3, uint32(cv>>24), 3))
+			if best.length > 0 {
+				best = bestOf(best, matchAt(s-offset1+3, s+3, uint32(cv>>24), 1))
+				best = bestOf(best, matchAt(s-offset2+3, s+3, uint32(cv>>24), 2))
+				best = bestOf(best, matchAt(s-offset3+3, s+3, uint32(cv>>24), 3))
+			}
 		}
 		// Load next and check...
 		e.longTable[nextHashL] = prevEntry{offset: s + e.cur, prev: candidateL.offset}

--- a/zstd/enc_fast.go
+++ b/zstd/enc_fast.go
@@ -78,7 +78,7 @@ func (e *fastEncoder) Encode(blk *blockEnc, src []byte) {
 	// TEMPLATE
 	const hashLog = tableBits
 	// seems global, but would be nice to tweak.
-	const kSearchStrength = 8
+	const kSearchStrength = 7
 
 	// nextEmit is where in src the next emitLiteral should start from.
 	nextEmit := s

--- a/zstd/encoder_test.go
+++ b/zstd/encoder_test.go
@@ -1024,7 +1024,7 @@ func BenchmarkRandom10MBEncodeAllFastest(b *testing.B) {
 	rng := rand.New(rand.NewSource(1))
 	data := make([]byte, 10<<20)
 	rng.Read(data)
-	enc, _ := NewWriter(nil, WithEncoderLevel(SpeedFastest), WithEncoderConcurrency(1))
+	enc, _ := NewWriter(nil, WithEncoderLevel(SpeedFastest), WithEncoderConcurrency(2))
 	defer enc.Close()
 	dst := enc.EncodeAll(data, nil)
 	wantSize := len(dst)


### PR DESCRIPTION
Increase speed of incompressible data for "best"/"fastest" mode.

Should not have any impact on compressible data:

before/after...
```
sharnd.out.2gb	zskp	4	2147483647	2147581961	52931	38.69
sharnd.out.2gb	zskp	4	2147483647	2147581961	15426	132.76

silesia.tar	zskp	4	211947520	61381950	8394	24.08
silesia.tar	zskp	4	211947520	61327981	8142	24.82

BenchmarkRandom10MBEncodeAllFastest-32    	     279	   3971326 ns/op	2640.37 MB/s	       0 B/op	       0 allocs/op
BenchmarkRandom10MBEncodeAllFastest-32    	     349	   3498572 ns/op	2997.15 MB/s	       0 B/op	       0 allocs/op
```