### PR TITLE
s2: Smaller initial decoder alloc

### DIFF
--- a/s2/decode_test.go
+++ b/s2/decode_test.go
@@ -57,7 +57,7 @@ func TestDecoderMaxBlockSize(t *testing.T) {
 		for _, size := range sizes {
 			t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
 				var buf bytes.Buffer
-				dec := NewReader(nil, ReaderMaxBlockSize(size))
+				dec := NewReader(nil, ReaderMaxBlockSize(size), ReaderAllocBlock(size/2))
 				enc := NewWriter(&buf, WriterBlockSize(size), WriterPadding(16<<10), WriterPaddingSrc(zeroReader{}))
 
 				// Test writer.


### PR DESCRIPTION
Allocate enough for the default window size and add
`ReaderAllocBlock` for custom allocs.