### PR TITLE
s2: Add arm64 decompression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 arch:
-#  - amd64
+  - amd64
   - arm64
 
 go:
@@ -23,9 +23,6 @@ install:
 
 script:
  - diff <(gofmt -d .) <(printf "")
- - go test -v -cpu=2 ./s2
-# - go test -cpu=2 -tags=noasm ./...
-# - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
  - go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d && s2c s2c && s2d s2c.s2 && rm s2c && rm s2d && rm s2c.s2
 
 jobs:
@@ -33,6 +30,15 @@ jobs:
     - go: 'master'
   fast_finish: true
   include:
+    - arch: amd64
+      script:
+        - go test -cpu=2 ./...
+        - go test -cpu=2 -tags=noasm ./...
+        - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
+    - arch: arm64
+      script:
+        - go test -cpu=2 ./s2
+        - go test -cpu=2 -tags=noasm ./s2
     - stage: 386 linux test
       go: 1.16.x
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ install:
 
 script:
  - diff <(gofmt -d .) <(printf "")
- - go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d && s2c s2c && s2d s2c.s2 && rm s2c && rm s2d && rm s2c.s2
  - go test -cpu=2 ./...
  - go test -cpu=2 -tags=noasm ./...
  - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
+ - go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d && s2c s2c && s2d s2c.s2 && rm s2c && rm s2d && rm s2c.s2
 
 jobs:
   allow_failures:
@@ -43,6 +43,7 @@ jobs:
       script:
         - go test -cpu=2 ./s2
         - go test -cpu=2 -tags=noasm ./s2
+        - go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d && s2c s2c && s2d s2c.s2 && rm s2c && rm s2d && rm s2c.s2
 
 deploy:
 - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ jobs:
     - stage: arm64 tests
       arch: arm64
       go:
-        - 1.14.x
-        - 1.15.x
         - 1.16.x
       script:
         - go test -cpu=2 ./s2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ os:
   - linux
   - osx
 
+arch:
+  - amd64
+  - arm64
+
 go:
-  - 1.13.x
   - 1.14.x
   - 1.15.x
   - 1.16.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
 
 arch:
   - amd64
-  - arm64
 
 go:
   - 1.14.x
@@ -24,25 +23,28 @@ install:
 script:
  - diff <(gofmt -d .) <(printf "")
  - go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d && s2c s2c && s2d s2c.s2 && rm s2c && rm s2d && rm s2c.s2
+ - go test -cpu=2 ./...
+ - go test -cpu=2 -tags=noasm ./...
+ - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
 
 jobs:
   allow_failures:
     - go: 'master'
   fast_finish: true
   include:
-    - arch: amd64
-      script:
-        - go test -cpu=2 ./...
-        - go test -cpu=2 -tags=noasm ./...
-        - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
-    - arch: arm64
-      script:
-        - go test -cpu=2 ./s2
-        - go test -cpu=2 -tags=noasm ./s2
     - stage: 386 linux test
       go: 1.16.x
       script:
         - GOOS=linux GOARCH=386 go test -short ./...
+    - stage: arm64 tests
+      arch: arm64
+      go:
+        - 1.14.x
+        - 1.15.x
+        - 1.16.x
+      script:
+        - go test -cpu=2 ./s2
+        - go test -cpu=2 -tags=noasm ./s2
 
 deploy:
 - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 
 script:
  - diff <(gofmt -d .) <(printf "")
- - go test -cpu=2 ./s2
+ - go test -v -cpu=2 ./s2
 # - go test -cpu=2 -tags=noasm ./...
 # - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
  - go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d && s2c s2c && s2d s2c.s2 && rm s2c && rm s2d && rm s2c.s2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 arch:
-  - amd64
+#  - amd64
   - arm64
 
 go:
@@ -23,9 +23,9 @@ install:
 
 script:
  - diff <(gofmt -d .) <(printf "")
- - go test -cpu=2 ./...
- - go test -cpu=2 -tags=noasm ./...
- - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
+ - go test -cpu=2 ./s2
+# - go test -cpu=2 -tags=noasm ./...
+# - CGO_ENABLED=1 go test -cpu=1,4 -short -race ./...
  - go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d && s2c s2c && s2d s2c.s2 && rm s2c && rm s2d && rm s2c.s2
 
 jobs:

--- a/s2/decode_amd64.s
+++ b/s2/decode_amd64.s
@@ -171,6 +171,7 @@ callMemmove:
 	MOVQ R_DST, 24(SP)
 	MOVQ R_SRC, 32(SP)
 	MOVQ R_LEN, 40(SP)
+	MOVQ R_OFF, 48(SP)
 	CALL runtime·memmove(SB)
 
 	// Restore local variables: unspill registers from the stack and
@@ -178,6 +179,7 @@ callMemmove:
 	MOVQ 24(SP), R_DST
 	MOVQ 32(SP), R_SRC
 	MOVQ 40(SP), R_LEN
+	MOVQ 48(SP), R_OFF
 	MOVQ dst_base+0(FP), R_DBASE
 	MOVQ dst_len+8(FP), R_DLEN
 	MOVQ R_DBASE, R_DEND

--- a/s2/decode_arm64.s
+++ b/s2/decode_arm64.s
@@ -24,7 +24,7 @@
 #define R_TMP3 R15
 
 // TEST_SRC will check if R_SRC is <= SRC_END
-#define TEST_SRC \
+#define TEST_SRC() \
 	CMP R_SEND, R_SRC \
 	BGT errCorrupt
 

--- a/s2/decode_arm64.s
+++ b/s2/decode_arm64.s
@@ -493,7 +493,7 @@ slowForwardCopy:
 	BGT verySlowForwardCopy
 
 	// We want to keep the offset, so we use R_TMP2 from here.
-	MOVQ R_OFF, R_TMP2
+	MOVD R_OFF, R_TMP2
 
 makeOffsetAtLeast8:
 	// !!! As above, expand the pattern so that offset >= 8 and we can use

--- a/s2/decode_arm64.s
+++ b/s2/decode_arm64.s
@@ -356,7 +356,7 @@ repeatLen2:
 	BGT  errCorrupt
 
 	MOVHU -2(R_SRC), R_LEN
-	ADD   $256, R_LEN, R_LEN
+	ADD   $260, R_LEN, R_LEN
 	B     doCopyRepeat
 
 repeatLen1:

--- a/s2/decode_arm64.s
+++ b/s2/decode_arm64.s
@@ -62,7 +62,7 @@ TEXT ·s2Decode(SB), NOSPLIT, $56-56
 	MOVD R_SBASE, R_SRC
 	MOVD R_SBASE, R_SEND
 	ADD  R_SLEN, R_SEND, R_SEND
-	XORQ R_OFF, R_OFF
+	XOR  R_OFF, R_OFF
 
 loop:
 	// for s < len(src)
@@ -317,7 +317,7 @@ tagCopy:
 	BEQ repeatCode
 
 	// This is a regular copy, transfer our temporary value to R_OFF (length)
-	MOVQ R_TMP0, R_OFF
+	MOVD R_TMP0, R_OFF
 	JMP  doCopy
 
 // This is a repeat code.
@@ -343,7 +343,7 @@ repeatLen3:
 	MOVHU -3(R_SRC), R_LEN
 	ORR   R_TMP0<<16, R_LEN, R_LEN
 	ADD   $65540, R_LEN, R_LEN
-	J     doCopyRepeat
+	B     doCopyRepeat
 
 repeatLen2:
 	// s +=2
@@ -357,7 +357,7 @@ repeatLen2:
 
 	MOVHU -2(R_SRC), R_LEN
 	ADD   $256, R_LEN, R_LEN
-	J     doCopyRepeat
+	B     doCopyRepeat
 
 repeatLen1:
 	// s +=1
@@ -371,7 +371,7 @@ repeatLen1:
 
 	MOVBU -1(R_SRC), R_LEN
 	ADD   $8, R_LEN, R_LEN
-	J     doCopyRepeat
+	B     doCopyRepeat
 
 doCopy:
 	// This is the end of the outer "switch", when we have a copy tag.

--- a/s2/decode_arm64.s
+++ b/s2/decode_arm64.s
@@ -1,5 +1,4 @@
-// Copyright 2016 The Go Authors. All rights reserved.
-// Copyright (c) 2019 Klaus Post. All rights reserved.
+// Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -9,12 +8,12 @@
 
 #include "textflag.h"
 
-#define R_TMP0 AX
-#define R_TMP1 BX
-#define R_LEN CX
-#define R_OFF DX
-#define R_SRC SI
-#define R_DST DI
+#define R_TMP0 R2
+#define R_TMP1 R3
+#define R_LEN R4
+#define R_OFF R5
+#define R_SRC R6
+#define R_DST R7
 #define R_DBASE R8
 #define R_DLEN R9
 #define R_DEND R10
@@ -33,10 +32,10 @@
 // spill registers and push args when issuing a CALL. The register allocation:
 //	- R_TMP0	scratch
 //	- R_TMP1	scratch
-//	- R_LEN	    length or x (shared)
-//	- R_OFF	    offset
-//	- R_SRC	    &src[s]
-//	- R_DST	    &dst[d]
+//	- R_LEN	length or x
+//	- R_OFF	offset
+//	- R_SRC	&src[s]
+//	- R_DST	&dst[d]
 //	+ R_DBASE	dst_base
 //	+ R_DLEN	dst_len
 //	+ R_DEND	dst_base + dst_len
@@ -51,33 +50,34 @@
 //
 // The d variable is implicitly R_DST - R_DBASE,  and len(dst)-d is R_DEND - R_DST.
 // The s variable is implicitly R_SRC - R_SBASE, and len(src)-s is R_SEND - R_SRC.
-TEXT ·s2Decode(SB), NOSPLIT, $48-56
+TEXT ·s2Decode(SB), NOSPLIT, $56-56
 	// Initialize R_SRC, R_DST and R_DBASE-R_SEND.
-	MOVQ dst_base+0(FP), R_DBASE
-	MOVQ dst_len+8(FP), R_DLEN
-	MOVQ R_DBASE, R_DST
-	MOVQ R_DBASE, R_DEND
-	ADDQ R_DLEN, R_DEND
-	MOVQ src_base+24(FP), R_SBASE
-	MOVQ src_len+32(FP), R_SLEN
-	MOVQ R_SBASE, R_SRC
-	MOVQ R_SBASE, R_SEND
-	ADDQ R_SLEN, R_SEND
+	MOVD dst_base+0(FP), R_DBASE
+	MOVD dst_len+8(FP), R_DLEN
+	MOVD R_DBASE, R_DST
+	MOVD R_DBASE, R_DEND
+	ADD  R_DLEN, R_DEND, R_DEND
+	MOVD src_base+24(FP), R_SBASE
+	MOVD src_len+32(FP), R_SLEN
+	MOVD R_SBASE, R_SRC
+	MOVD R_SBASE, R_SEND
+	ADD  R_SLEN, R_SEND, R_SEND
 	XORQ R_OFF, R_OFF
 
 loop:
 	// for s < len(src)
-	CMPQ R_SRC, R_SEND
-	JEQ  end
+	CMP R_SEND, R_SRC
+	BEQ end
 
 	// R_LEN = uint32(src[s])
 	//
 	// switch src[s] & 0x03
-	MOVBLZX (R_SRC), R_LEN
-	MOVL    R_LEN, R_TMP1
-	ANDL    $3, R_TMP1
-	CMPL    R_TMP1, $1
-	JAE     tagCopy
+	MOVBU (R_SRC), R_LEN
+	MOVW  R_LEN, R_TMP1
+	ANDW  $3, R_TMP1
+	MOVW  $1, R1
+	CMPW  R1, R_TMP1
+	BGE   tagCopy
 
 	// ----------------------------------------
 	// The code below handles literal tags.
@@ -85,13 +85,14 @@ loop:
 	// case tagLiteral:
 	// x := uint32(src[s] >> 2)
 	// switch
-	SHRL $2, R_LEN
-	CMPL R_LEN, $60
-	JAE  tagLit60Plus
+	MOVW $60, R1
+	LSRW $2, R_LEN, R_LEN
+	CMPW R_LEN, R1
+	BLS  tagLit60Plus
 
 	// case x < 60:
 	// s++
-	INCQ R_SRC
+	ADD $1, R_SRC, R_SRC
 
 doLit:
 	// This is the end of the inner "switch", when we have a literal tag.
@@ -103,17 +104,17 @@ doLit:
 	//
 	// Unlike the pure Go code, we don't need to check if length <= 0 because
 	// R_LEN can hold 64 bits, so the increment cannot overflow.
-	INCQ R_LEN
+	ADD $1, R_LEN, R_LEN
 
 	// Prepare to check if copying length bytes will run past the end of dst or
 	// src.
 	//
 	// R_TMP0 = len(dst) - d
 	// R_TMP1 = len(src) - s
-	MOVQ R_DEND, R_TMP0
-	SUBQ R_DST, R_TMP0
-	MOVQ R_SEND, R_TMP1
-	SUBQ R_SRC, R_TMP1
+	MOVD R_DEND, R_TMP0
+	SUB  R_DST, R_TMP0, R_TMP0
+	MOVD R_SEND, R_TMP1
+	SUB  R_SRC, R_TMP1, R_TMP1
 
 	// !!! Try a faster technique for short (16 or fewer bytes) copies.
 	//
@@ -126,12 +127,12 @@ doLit:
 	// is contiguous in memory and so it needs to leave enough source bytes to
 	// read the next tag without refilling buffers, but Go's Decode assumes
 	// contiguousness (the src argument is a []byte).
-	CMPQ R_LEN, $16
-	JGT  callMemmove
-	CMPQ R_TMP0, $16
-	JLT  callMemmove
-	CMPQ R_TMP1, $16
-	JLT  callMemmove
+	CMP $16, R_LEN
+	BGT callMemmove
+	CMP $16, R_TMP0
+	BLT callMemmove
+	CMP $16, R_TMP1
+	BLT callMemmove
 
 	// !!! Implement the copy from src to dst as a 16-byte load and store.
 	// (Decode's documentation says that dst and src must not overlap.)
@@ -141,57 +142,57 @@ doLit:
 	// will fix up the overrun. Otherwise, Decode returns a nil []byte (and a
 	// non-nil error), so the overrun will be ignored.
 	//
-	// Note that on amd64, it is legal and cheap to issue unaligned 8-byte or
+	// Note that on arm64, it is legal and cheap to issue unaligned 8-byte or
 	// 16-byte loads and stores. This technique probably wouldn't be as
 	// effective on architectures that are fussier about alignment.
-	MOVOU 0(R_SRC), X0
-	MOVOU X0, 0(R_DST)
+	LDP 0(R_SRC), (R_TMP2, R_TMP3)
+	STP (R_TMP2, R_TMP3), 0(R_DST)
 
 	// d += length
 	// s += length
-	ADDQ R_LEN, R_DST
-	ADDQ R_LEN, R_SRC
-	JMP  loop
+	ADD R_LEN, R_DST, R_DST
+	ADD R_LEN, R_SRC, R_SRC
+	B   loop
 
 callMemmove:
 	// if length > len(dst)-d || length > len(src)-s { etc }
-	CMPQ R_LEN, R_TMP0
-	JGT  errCorrupt
-	CMPQ R_LEN, R_TMP1
-	JGT  errCorrupt
+	CMP R_TMP0, R_LEN
+	BGT errCorrupt
+	CMP R_TMP1, R_LEN
+	BGT errCorrupt
 
 	// copy(dst[d:], src[s:s+length])
 	//
 	// This means calling runtime·memmove(&dst[d], &src[s], length), so we push
 	// R_DST, R_SRC and R_LEN as arguments. Coincidentally, we also need to spill those
 	// three registers to the stack, to save local variables across the CALL.
-	MOVQ R_DST, 0(SP)
-	MOVQ R_SRC, 8(SP)
-	MOVQ R_LEN, 16(SP)
-	MOVQ R_DST, 24(SP)
-	MOVQ R_SRC, 32(SP)
-	MOVQ R_LEN, 40(SP)
+	MOVD R_DST, 8(RSP)
+	MOVD R_SRC, 16(RSP)
+	MOVD R_LEN, 24(RSP)
+	MOVD R_DST, 32(RSP)
+	MOVD R_SRC, 40(RSP)
+	MOVD R_LEN, 48(RSP)
 	CALL runtime·memmove(SB)
 
 	// Restore local variables: unspill registers from the stack and
 	// re-calculate R_DBASE-R_SEND.
-	MOVQ 24(SP), R_DST
-	MOVQ 32(SP), R_SRC
-	MOVQ 40(SP), R_LEN
-	MOVQ dst_base+0(FP), R_DBASE
-	MOVQ dst_len+8(FP), R_DLEN
-	MOVQ R_DBASE, R_DEND
-	ADDQ R_DLEN, R_DEND
-	MOVQ src_base+24(FP), R_SBASE
-	MOVQ src_len+32(FP), R_SLEN
-	MOVQ R_SBASE, R_SEND
-	ADDQ R_SLEN, R_SEND
+	MOVD 32(RSP), R_DST
+	MOVD 40(RSP), R_SRC
+	MOVD 48(RSP), R_LEN
+	MOVD dst_base+0(FP), R_DBASE
+	MOVD dst_len+8(FP), R_DLEN
+	MOVD R_DBASE, R_DEND
+	ADD  R_DLEN, R_DEND, R_DEND
+	MOVD src_base+24(FP), R_SBASE
+	MOVD src_len+32(FP), R_SLEN
+	MOVD R_SBASE, R_SEND
+	ADD  R_SLEN, R_SEND, R_SEND
 
 	// d += length
 	// s += length
-	ADDQ R_LEN, R_DST
-	ADDQ R_LEN, R_SRC
-	JMP  loop
+	ADD R_LEN, R_DST, R_DST
+	ADD R_LEN, R_SRC, R_SRC
+	B   loop
 
 tagLit60Plus:
 	// !!! This fragment does the
@@ -199,113 +200,121 @@ tagLit60Plus:
 	// s += x - 58; if uint(s) > uint(len(src)) { etc }
 	//
 	// checks. In the asm version, we code it once instead of once per switch case.
-	ADDQ R_LEN, R_SRC
-	SUBQ $58, R_SRC
-	CMPQ R_SRC, R_SEND
-	JA   errCorrupt
+	ADD  R_LEN, R_SRC, R_SRC
+	SUB  $58, R_SRC, R_SRC
+	MOVD R_SRC, R_TMP1
+	SUB  R_SBASE, R_TMP1, R_TMP1
+	CMP  R_SLEN, R_TMP1
+	BGT  errCorrupt
 
 	// case x == 60:
-	CMPL R_LEN, $61
-	JEQ  tagLit61
-	JA   tagLit62Plus
+	MOVW $61, R1
+	CMPW R1, R_LEN
+	BEQ  tagLit61
+	BGT  tagLit62Plus
 
 	// x = uint32(src[s-1])
-	MOVBLZX -1(R_SRC), R_LEN
-	JMP     doLit
+	MOVBU -1(R_SRC), R_LEN
+	B     doLit
 
 tagLit61:
 	// case x == 61:
 	// x = uint32(src[s-2]) | uint32(src[s-1])<<8
-	MOVWLZX -2(R_SRC), R_LEN
-	JMP     doLit
+	MOVHU -2(R_SRC), R_LEN
+	B     doLit
 
 tagLit62Plus:
-	CMPL R_LEN, $62
-	JA   tagLit63
+	CMPW $62, R_LEN
+	BHI  tagLit63
 
 	// case x == 62:
 	// x = uint32(src[s-3]) | uint32(src[s-2])<<8 | uint32(src[s-1])<<16
-	MOVWLZX -3(R_SRC), R_LEN
-	MOVBLZX -1(R_SRC), R_TMP1
-	SHLL    $16, R_TMP1
-	ORL     R_TMP1, R_LEN
-	JMP     doLit
+	MOVHU -3(R_SRC), R_LEN
+	MOVBU -1(R_SRC), R_TMP1
+	ORR   R_TMP1<<16, R_LEN
+	B     doLit
 
 tagLit63:
 	// case x == 63:
 	// x = uint32(src[s-4]) | uint32(src[s-3])<<8 | uint32(src[s-2])<<16 | uint32(src[s-1])<<24
-	MOVL -4(R_SRC), R_LEN
-	JMP  doLit
+	MOVWU -4(R_SRC), R_LEN
+	B     doLit
 
-// The code above handles literal tags.
-// ----------------------------------------
-// The code below handles copy tags.
+	// The code above handles literal tags.
+	// ----------------------------------------
+	// The code below handles copy tags.
 
 tagCopy4:
 	// case tagCopy4:
 	// s += 5
-	ADDQ $5, R_SRC
+	ADD $5, R_SRC, R_SRC
 
 	// if uint(s) > uint(len(src)) { etc }
-	CMPQ R_SRC, R_SEND
-	JA   errCorrupt
+	MOVD R_SRC, R_TMP1
+	SUB  R_SBASE, R_TMP1, R_TMP1
+	CMP  R_SLEN, R_TMP1
+	BGT  errCorrupt
 
 	// length = 1 + int(src[s-5])>>2
-	SHRQ $2, R_LEN
-	INCQ R_LEN
+	MOVD $1, R1
+	ADD  R_LEN>>2, R1, R_LEN
 
 	// offset = int(uint32(src[s-4]) | uint32(src[s-3])<<8 | uint32(src[s-2])<<16 | uint32(src[s-1])<<24)
-	MOVLQZX -4(R_SRC), R_OFF
-	JMP     doCopy
+	MOVWU -4(R_SRC), R_OFF
+	B     doCopy
 
 tagCopy2:
 	// case tagCopy2:
 	// s += 3
-	ADDQ $3, R_SRC
+	ADD $3, R_SRC, R_SRC
 
 	// if uint(s) > uint(len(src)) { etc }
-	CMPQ R_SRC, R_SEND
-	JA   errCorrupt
+	MOVD R_SRC, R_TMP1
+	SUB  R_SBASE, R_TMP1, R_TMP1
+	CMP  R_SLEN, R_TMP1
+	BGT  errCorrupt
 
 	// length = 1 + int(src[s-3])>>2
-	SHRQ $2, R_LEN
-	INCQ R_LEN
+	MOVD $1, R1
+	ADD  R_LEN>>2, R1, R_LEN
 
 	// offset = int(uint32(src[s-2]) | uint32(src[s-1])<<8)
-	MOVWQZX -2(R_SRC), R_OFF
-	JMP     doCopy
+	MOVHU -2(R_SRC), R_OFF
+	B     doCopy
 
 tagCopy:
 	// We have a copy tag. We assume that:
 	//	- R_TMP1 == src[s] & 0x03
 	//	- R_LEN == src[s]
-	CMPQ R_TMP1, $2
-	JEQ  tagCopy2
-	JA   tagCopy4
+	CMP $2, R_TMP1
+	BEQ tagCopy2
+	BGT tagCopy4
 
 	// case tagCopy1:
 	// s += 2
-	ADDQ $2, R_SRC
+	ADD $2, R_SRC, R_SRC
 
 	// if uint(s) > uint(len(src)) { etc }
-	CMPQ R_SRC, R_SEND
-	JA   errCorrupt
+	MOVD R_SRC, R_TMP1
+	SUB  R_SBASE, R_TMP1, R_TMP1
+	CMP  R_SLEN, R_TMP1
+	BGT  errCorrupt
 
 	// offset = int(uint32(src[s-2])&0xe0<<3 | uint32(src[s-1]))
-	MOVQ    R_LEN, R_TMP0
-	ANDQ    $0xe0, R_TMP0
-	SHLQ    $3, R_TMP0
-	MOVBQZX -1(R_SRC), R_TMP1
-	ORQ     R_TMP1, R_TMP0
+	// Calculate offset in R_TMP0 in case it is a repeat.
+	MOVD  R_LEN, R_TMP0
+	AND   $0xe0, R_TMP0
+	MOVBU -1(R_SRC), R_TMP1
+	ORR   R_TMP0<<3, R_TMP1, R_TMP0
 
 	// length = 4 + int(src[s-2])>>2&0x7
-	SHRQ $2, R_LEN
-	ANDQ $7, R_LEN
-	ADDQ $4, R_LEN
+	MOVD $7, R1
+	AND  R_LEN>>2, R1, R_LEN
+	ADD  $4, R_LEN, R_LEN
 
-	// check if repeat code
-	CMPQ R_TMP0, $0
-	JE   repeatCode
+	// check if repeat code with offset 0.
+	CMP $0, R_TMP0
+	BEQ repeatCode
 
 	// This is a regular copy, transfer our temporary value to R_OFF (length)
 	MOVQ R_TMP0, R_OFF
@@ -314,59 +323,55 @@ tagCopy:
 // This is a repeat code.
 repeatCode:
 	// If length < 9, reuse last offset, with the length already calculated.
-	CMPQ R_LEN, $9
-	JL   doCopyRepeat
-
-	// Read additional bytes for length.
-	JE repeatLen1
-
-	// Rare, so the extra branch shouldn't hurt too much.
-	CMPQ R_LEN, $10
-	JE   repeatLen2
-	JMP  repeatLen3
-
-// Read repeat lengths.
-repeatLen1:
-	// s ++
-	ADDQ $1, R_SRC
-
-	// if uint(s) > uint(len(src)) { etc }
-	CMPQ R_SRC, R_SEND
-	JA   errCorrupt
-
-	// length = src[s-1] + 8
-	MOVBQZX -1(R_SRC), R_LEN
-	ADDL    $8, R_LEN
-	JMP     doCopyRepeat
-
-repeatLen2:
-	// s +=2
-	ADDQ $2, R_SRC
-
-	// if uint(s) > uint(len(src)) { etc }
-	CMPQ R_SRC, R_SEND
-	JA   errCorrupt
-
-	// length = uint32(src[s-2]) | (uint32(src[s-1])<<8) + (1 << 8)
-	MOVWQZX -2(R_SRC), R_LEN
-	ADDL    $260, R_LEN
-	JMP     doCopyRepeat
+	CMP $9, R_LEN
+	BLT doCopyRepeat
+	BEQ repeatLen1
+	CMP $10, R_LEN
+	BEQ repeatLen2
 
 repeatLen3:
 	// s +=3
-	ADDQ $3, R_SRC
+	ADD $3, R_SRC, R_SRC
 
 	// if uint(s) > uint(len(src)) { etc }
-	CMPQ R_SRC, R_SEND
-	JA   errCorrupt
+	MOVD R_SRC, R_TMP1
+	SUB  R_SBASE, R_TMP1, R_TMP1
+	CMP  R_SLEN, R_TMP1
+	BGT  errCorrupt
 
-	// length = uint32(src[s-3]) | (uint32(src[s-2])<<8) | (uint32(src[s-1])<<16) + (1 << 16)
-	MOVBLZX -1(R_SRC), R_TMP0
-	MOVWLZX -3(R_SRC), R_LEN
-	SHLL    $16, R_TMP0
-	ORL     R_TMP0, R_LEN
-	ADDL    $65540, R_LEN
-	JMP     doCopyRepeat
+	MOVBU -1(R_SRC), R_TMP0
+	MOVHU -3(R_SRC), R_LEN
+	ORR   R_TMP0<<16, R_LEN, R_LEN
+	ADD   $65540, R_LEN, R_LEN
+	J     doCopyRepeat
+
+repeatLen2:
+	// s +=2
+	ADD $2, R_SRC, R_SRC
+
+	// if uint(s) > uint(len(src)) { etc }
+	MOVD R_SRC, R_TMP1
+	SUB  R_SBASE, R_TMP1, R_TMP1
+	CMP  R_SLEN, R_TMP1
+	BGT  errCorrupt
+
+	MOVHU -2(R_SRC), R_LEN
+	ADD   $256, R_LEN, R_LEN
+	J     doCopyRepeat
+
+repeatLen1:
+	// s +=1
+	ADD $1, R_SRC, R_SRC
+
+	// if uint(s) > uint(len(src)) { etc }
+	MOVD R_SRC, R_TMP1
+	SUB  R_SBASE, R_TMP1, R_TMP1
+	CMP  R_SLEN, R_TMP1
+	BGT  errCorrupt
+
+	MOVBU -1(R_SRC), R_LEN
+	ADD   $8, R_LEN, R_LEN
+	J     doCopyRepeat
 
 doCopy:
 	// This is the end of the outer "switch", when we have a copy tag.
@@ -376,32 +381,34 @@ doCopy:
 	//	- R_OFF == offset
 
 	// if d < offset { etc }
-	MOVQ R_DST, R_TMP1
-	SUBQ R_DBASE, R_TMP1
-	CMPQ R_TMP1, R_OFF
-	JLT  errCorrupt
+	MOVD R_DST, R_TMP1
+	SUB  R_DBASE, R_TMP1, R_TMP1
+	CMP  R_OFF, R_TMP1
+	BLT  errCorrupt
 
 	// Repeat values can skip the test above, since any offset > 0 will be in dst.
 doCopyRepeat:
+
 	// if offset <= 0 { etc }
-	CMPQ R_OFF, $0
-	JLE  errCorrupt
+	MOVD $0, R1
+	CMP  R1, R_OFF
+	BLE  errCorrupt
 
 	// if length > len(dst)-d { etc }
-	MOVQ R_DEND, R_TMP1
-	SUBQ R_DST, R_TMP1
-	CMPQ R_LEN, R_TMP1
-	JGT  errCorrupt
+	MOVD R_DEND, R_TMP1
+	SUB  R_DST, R_TMP1, R_TMP1
+	CMP  R_TMP1, R_LEN
+	BGT  errCorrupt
 
 	// forwardCopy(dst[d:d+length], dst[d-offset:]); d += length
 	//
 	// Set:
 	//	- R_TMP2 = len(dst)-d
 	//	- R_TMP3 = &dst[d-offset]
-	MOVQ R_DEND, R_TMP2
-	SUBQ R_DST, R_TMP2
-	MOVQ R_DST, R_TMP3
-	SUBQ R_OFF, R_TMP3
+	MOVD R_DEND, R_TMP2
+	SUB  R_DST, R_TMP2, R_TMP2
+	MOVD R_DST, R_TMP3
+	SUB  R_OFF, R_TMP3, R_TMP3
 
 	// !!! Try a faster technique for short (16 or fewer bytes) forward copies.
 	//
@@ -416,18 +423,18 @@ doCopyRepeat:
 	// }
 	// copy 16 bytes
 	// d += length
-	CMPQ R_LEN, $16
-	JGT  slowForwardCopy
-	CMPQ R_OFF, $8
-	JLT  slowForwardCopy
-	CMPQ R_TMP2, $16
-	JLT  slowForwardCopy
-	MOVQ 0(R_TMP3), R_TMP0
-	MOVQ R_TMP0, 0(R_DST)
-	MOVQ 8(R_TMP3), R_TMP1
-	MOVQ R_TMP1, 8(R_DST)
-	ADDQ R_LEN, R_DST
-	JMP  loop
+	CMP  $16, R_LEN
+	BGT  slowForwardCopy
+	CMP  $8, R_OFF
+	BLT  slowForwardCopy
+	CMP  $16, R_TMP2
+	BLT  slowForwardCopy
+	MOVD 0(R_TMP3), R_TMP0
+	MOVD R_TMP0, 0(R_DST)
+	MOVD 8(R_TMP3), R_TMP1
+	MOVD R_TMP1, 8(R_DST)
+	ADD  R_LEN, R_DST, R_DST
+	B    loop
 
 slowForwardCopy:
 	// !!! If the forward copy is longer than 16 bytes, or if offset < 8, we
@@ -478,12 +485,9 @@ slowForwardCopy:
 	// if length > len(dst)-d-10 {
 	//   goto verySlowForwardCopy
 	// }
-	SUBQ $10, R_TMP2
-	CMPQ R_LEN, R_TMP2
-	JGT  verySlowForwardCopy
-
-	// We want to keep the offset, so we use R_TMP2 from here.
-	MOVQ R_OFF, R_TMP2
+	SUB $10, R_TMP2, R_TMP2
+	CMP R_TMP2, R_LEN
+	BGT verySlowForwardCopy
 
 makeOffsetAtLeast8:
 	// !!! As above, expand the pattern so that offset >= 8 and we can use
@@ -497,14 +501,14 @@ makeOffsetAtLeast8:
 	//   // The two previous lines together means that d-offset, and therefore
 	//   // R_TMP3, is unchanged.
 	// }
-	CMPQ R_TMP2, $8
-	JGE  fixUpSlowForwardCopy
-	MOVQ (R_TMP3), R_TMP1
-	MOVQ R_TMP1, (R_DST)
-	SUBQ R_TMP2, R_LEN
-	ADDQ R_TMP2, R_DST
-	ADDQ R_TMP2, R_TMP2
-	JMP  makeOffsetAtLeast8
+	CMP  $8, R_OFF
+	BGE  fixUpSlowForwardCopy
+	MOVD (R_TMP3), R_TMP1
+	MOVD R_TMP1, (R_DST)
+	SUB  R_OFF, R_LEN, R_LEN
+	ADD  R_OFF, R_DST, R_DST
+	ADD  R_OFF, R_OFF, R_OFF
+	B    makeOffsetAtLeast8
 
 fixUpSlowForwardCopy:
 	// !!! Add length (which might be negative now) to d (implied by R_DST being
@@ -512,21 +516,22 @@ fixUpSlowForwardCopy:
 	// top of the loop. Before we do that, though, we save R_DST to R_TMP0 so that, if
 	// length is positive, copying the remaining length bytes will write to the
 	// right place.
-	MOVQ R_DST, R_TMP0
-	ADDQ R_LEN, R_DST
+	MOVD R_DST, R_TMP0
+	ADD  R_LEN, R_DST, R_DST
 
 finishSlowForwardCopy:
 	// !!! Repeat 8-byte load/stores until length <= 0. Ending with a negative
 	// length means that we overrun, but as above, that will be fixed up by
 	// subsequent iterations of the outermost loop.
-	CMPQ R_LEN, $0
-	JLE  loop
-	MOVQ (R_TMP3), R_TMP1
-	MOVQ R_TMP1, (R_TMP0)
-	ADDQ $8, R_TMP3
-	ADDQ $8, R_TMP0
-	SUBQ $8, R_LEN
-	JMP  finishSlowForwardCopy
+	MOVD $0, R1
+	CMP  R1, R_LEN
+	BLE  loop
+	MOVD (R_TMP3), R_TMP1
+	MOVD R_TMP1, (R_TMP0)
+	ADD  $8, R_TMP3, R_TMP3
+	ADD  $8, R_TMP0, R_TMP0
+	SUB  $8, R_LEN, R_LEN
+	B    finishSlowForwardCopy
 
 verySlowForwardCopy:
 	// verySlowForwardCopy is a simple implementation of forward copy. In C
@@ -543,27 +548,28 @@ verySlowForwardCopy:
 	// }
 	MOVB (R_TMP3), R_TMP1
 	MOVB R_TMP1, (R_DST)
-	INCQ R_TMP3
-	INCQ R_DST
-	DECQ R_LEN
-	JNZ  verySlowForwardCopy
-	JMP  loop
+	ADD  $1, R_TMP3, R_TMP3
+	ADD  $1, R_DST, R_DST
+	SUB  $1, R_LEN, R_LEN
+	CBNZ R_LEN, verySlowForwardCopy
+	B    loop
 
-// The code above handles copy tags.
-// ----------------------------------------
+	// The code above handles copy tags.
+	// ----------------------------------------
 
 end:
 	// This is the end of the "for s < len(src)".
 	//
 	// if d != len(dst) { etc }
-	CMPQ R_DST, R_DEND
-	JNE  errCorrupt
+	CMP R_DEND, R_DST
+	BNE errCorrupt
 
 	// return 0
-	MOVQ $0, ret+48(FP)
+	MOVD $0, ret+48(FP)
 	RET
 
 errCorrupt:
 	// return decodeErrCodeCorrupt
-	MOVQ $1, ret+48(FP)
+	MOVD $1, R_TMP0
+	MOVD R_TMP0, ret+48(FP)
 	RET

--- a/s2/decode_arm64.s
+++ b/s2/decode_arm64.s
@@ -62,7 +62,7 @@ TEXT ·s2Decode(SB), NOSPLIT, $56-56
 	MOVD R_SBASE, R_SRC
 	MOVD R_SBASE, R_SEND
 	ADD  R_SLEN, R_SEND, R_SEND
-	XOR  R_OFF, R_OFF
+	MOVD $0, R_OFF
 
 loop:
 	// for s < len(src)

--- a/s2/decode_asm.go
+++ b/s2/decode_asm.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build amd64 arm64
 // +build !appengine
 // +build gc
 // +build !noasm

--- a/s2/decode_other.go
+++ b/s2/decode_other.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64 appengine !gc noasm
+// +build !amd64,!arm64 appengine !gc noasm
 
 package s2
 


### PR DESCRIPTION
Adapted from Snappy equiv. Minor optimizations along the way.
```
enwik9 (stream):
Decompressing. 426854614 -> 1000000000 [234.27%]; 7.618s, 125.2MB/s
Decompressing. 426854614 -> 1000000000 [234.27%]; 4.258s, 224.0MB/s

Blocks:
benchmark                     old ns/op     new ns/op     delta
BenchmarkTwainDecode1e1-4     69.5          63.0          -9.27%
BenchmarkTwainDecode1e2-4     184           153           -16.61%
BenchmarkTwainDecode1e3-4     852           522           -38.74%
BenchmarkTwainDecode1e4-4     30220         14678         -51.43%
BenchmarkTwainDecode1e5-4     570195        231880        -59.33%
BenchmarkTwainDecode1e6-4     3349753       1920724       -42.66%

benchmark                     old MB/s     new MB/s     speedup
BenchmarkTwainDecode1e1-4     143.97       158.69       1.10x
BenchmarkTwainDecode1e2-4     544.75       653.07       1.20x
BenchmarkTwainDecode1e3-4     1174.00      1916.39      1.63x
BenchmarkTwainDecode1e4-4     330.90       681.27       2.06x
BenchmarkTwainDecode1e5-4     175.38       431.26       2.46x
BenchmarkTwainDecode1e6-4     298.53       520.64       1.74x
```