### PR TITLE
s2sx: Add more extraction options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ deploy:
   script: curl -sL https://git.io/goreleaser | VERSION=v0.157.0 bash || true
   on:
     tags: true
-    condition: $TRAVIS_OS_NAME = linux AND $TRAVIS_CPU_ARCH = amd64
+    condition: ($TRAVIS_OS_NAME = linux) && ($TRAVIS_CPU_ARCH = amd64)
     go: 1.16.x
 branches:
   only:


### PR DESCRIPTION
```
s2sx Self Extracting Archive

Usage: sample.tar.s2sfx.exe [options] [output-file/dir]

Use - as file name to extract to stdout when not untarring.

Options:
  -force-untar
        Always untar file
  -help
        Display help
  -q    Don't write any output to terminal, except errors
  -untar
        Untar tar files if specified at creation (default true)
```