### PR TITLE
Fix some minor issues reported by staticcheck

### DIFF
--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -440,8 +440,7 @@ func (d *compressor) deflateLazy() {
 			// index and index-1 are already inserted. If there is not enough
 			// lookahead, the last two strings are not inserted into the hash
 			// table.
-			var newIndex int
-			newIndex = s.index + prevLength - 1
+			newIndex := s.index + prevLength - 1
 			// Calculate missing hashes
 			end := newIndex
 			if end > s.maxInsertIndex {

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -100,9 +100,9 @@ func TestBulkHash4(t *testing.T) {
 						t.Errorf("Len:%d Index:%d, expected 0x%08x but not modified", len(y), i, expect)
 					} else if got != expect {
 						t.Errorf("Len:%d Index:%d, got 0x%08x expected:0x%08x", len(y), i, got, expect)
-					} else {
-						//t.Logf("Len:%d Index:%d OK (0x%08x)", len(y), i, got)
-					}
+					} /*else {
+						t.Logf("Len:%d Index:%d OK (0x%08x)", len(y), i, got)
+					} */
 				}
 			}
 		}
@@ -561,7 +561,7 @@ func testResetOutput(t *testing.T, name string, newWriter func(w io.Writer) (*Wr
 		if len(out1) != len(out2) {
 			t.Errorf("got %d, expected %d bytes", len(out2), len(out1))
 		}
-		if bytes.Compare(out1, out2) != 0 {
+		if !bytes.Equal(out1, out2) {
 			mm := 0
 			for i, b := range out1[:len(out2)] {
 				if b != out2[i] {

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -100,9 +100,9 @@ func TestBulkHash4(t *testing.T) {
 						t.Errorf("Len:%d Index:%d, expected 0x%08x but not modified", len(y), i, expect)
 					} else if got != expect {
 						t.Errorf("Len:%d Index:%d, got 0x%08x expected:0x%08x", len(y), i, got, expect)
-					} /*else {
-						t.Logf("Len:%d Index:%d OK (0x%08x)", len(y), i, got)
-					} */
+					} else {
+						//t.Logf("Len:%d Index:%d OK (0x%08x)", len(y), i, got)
+					}
 				}
 			}
 		}

--- a/flate/flate_test.go
+++ b/flate/flate_test.go
@@ -115,7 +115,7 @@ func TestRegressions(t *testing.T) {
 					if err != nil {
 						t.Error(err)
 					}
-					if bytes.Compare(data1, data2) != 0 {
+					if !bytes.Equal(data1, data2) {
 						t.Error("not equal")
 					}
 					// Do it again...
@@ -137,7 +137,7 @@ func TestRegressions(t *testing.T) {
 					if err != nil {
 						t.Error(err)
 					}
-					if bytes.Compare(data1, data2) != 0 {
+					if !bytes.Equal(data1, data2) {
 						t.Error("not equal")
 					}
 				})
@@ -162,7 +162,7 @@ func TestRegressions(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				if bytes.Compare(data1, data2) != 0 {
+				if !bytes.Equal(data1, data2) {
 					fmt.Printf("want:%x\ngot: %x\n", data1, data2)
 					t.Error("not equal")
 				}

--- a/flate/inflate_test.go
+++ b/flate/inflate_test.go
@@ -276,7 +276,7 @@ func TestWriteTo(t *testing.T) {
 	if wtbuf.Len() != len(input) {
 		t.Error("Actual Length did not match, expected", len(input), "got", wtbuf.Len())
 	}
-	if bytes.Compare(wtbuf.Bytes(), input) != 0 {
+	if !bytes.Equal(wtbuf.Bytes(), input) {
 		t.Fatal("output did not match input")
 	}
 }

--- a/flate/writer_test.go
+++ b/flate/writer_test.go
@@ -70,7 +70,7 @@ func TestWriterRegression(t *testing.T) {
 					if err != nil {
 						t.Fatal(msg + err.Error())
 					}
-					if bytes.Compare(in, data2) != 0 {
+					if !bytes.Equal(in, data2) {
 						t.Fatal(msg + "not equal")
 					}
 					// Do it again...
@@ -93,7 +93,7 @@ func TestWriterRegression(t *testing.T) {
 					if err != nil {
 						t.Fatal(msg + err.Error())
 					}
-					if bytes.Compare(in, data2) != 0 {
+					if !bytes.Equal(in, data2) {
 						t.Fatal(msg + "not equal")
 					}
 				})
@@ -121,6 +121,9 @@ func benchmarkEncoder(b *testing.B, testfile, level, n int) {
 	buf0 = nil
 	runtime.GC()
 	w, err := NewWriter(ioutil.Discard, level)
+	if err != nil {
+		b.Fatal(err)
+	}
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/fse/compress.go
+++ b/fse/compress.go
@@ -92,7 +92,6 @@ func (c *cState) init(bw *bitWriter, ct *cTable, tableLog uint8, first symbolTra
 	im := int32((nbBitsOut << 16) - first.deltaNbBits)
 	lu := (im >> nbBitsOut) + first.deltaFindState
 	c.state = c.stateTable[lu]
-	return
 }
 
 // encode the output symbol provided and write it to the bitstream.

--- a/gzip/gunzip_test.go
+++ b/gzip/gunzip_test.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/klauspost/compress/flate"
 )
 
 type gunzipTest struct {
@@ -531,7 +529,7 @@ func TestWriteTo(t *testing.T) {
 	if len(readall) != len(input) {
 		t.Errorf("did not decompress everything, want %d, got %d", len(input), len(readall))
 	}
-	if bytes.Compare(readall, input) != 0 {
+	if !bytes.Equal(readall, input) {
 		t.Error("output did not match input")
 	}
 
@@ -550,7 +548,7 @@ func TestWriteTo(t *testing.T) {
 	if wtbuf.Len() != len(input) {
 		t.Error("Actual Length did not match, expected", len(input), "got", wtbuf.Len())
 	}
-	if bytes.Compare(wtbuf.Bytes(), input) != 0 {
+	if !bytes.Equal(wtbuf.Bytes(), input) {
 		t.Fatal("output did not match input")
 	}
 }
@@ -577,9 +575,6 @@ func TestTruncatedStreams(t *testing.T) {
 			continue
 		}
 		_, err = io.Copy(ioutil.Discard, r)
-		if ferr, ok := err.(*flate.ReadError); ok {
-			err = ferr.Err
-		}
 		if err != io.ErrUnexpectedEOF {
 			t.Errorf("io.Copy(%d) on truncated stream: got %v, want %v", i, err, io.ErrUnexpectedEOF)
 		}

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -212,6 +212,9 @@ func TestConcat(t *testing.T) {
 	w.Close()
 
 	r, err := NewReader(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	data, err := ioutil.ReadAll(r)
 	if string(data) != "hello world\n" || err != nil {
 		t.Fatalf("ReadAll = %q, %v, want %q, nil", data, err, "hello world")
@@ -440,7 +443,7 @@ func testDeterm(i int, t *testing.T) {
 	b1b := b1.Bytes()
 	b2b := b2.Bytes()
 
-	if bytes.Compare(b1b, b2b) != 0 {
+	if !bytes.Equal(b1b, b2b) {
 		t.Fatalf("Level %d did not produce deterministric result, len(a) = %d, len(b) = %d", i, len(b1b), len(b2b))
 	}
 }

--- a/huff0/compress.go
+++ b/huff0/compress.go
@@ -536,7 +536,6 @@ func (s *Scratch) huffSort() {
 		}
 		nodes[pos&huffNodesMask] = nodeElt{count: c, symbol: byte(n)}
 	}
-	return
 }
 
 func (s *Scratch) setMaxHeight(lastNonNull int) uint8 {

--- a/huff0/compress_test.go
+++ b/huff0/compress_test.go
@@ -474,7 +474,7 @@ func TestCompress1XReuse(t *testing.T) {
 			if len(buf0) > BlockSizeMax {
 				buf0 = buf0[:BlockSizeMax]
 			}
-			b, re, err := Compress1X(buf0, &s)
+			b, _, err := Compress1X(buf0, &s)
 			if err != test.err1X {
 				t.Errorf("want error %v (%T), got %v (%T)", test.err1X, test.err1X, err, err)
 			}
@@ -488,7 +488,7 @@ func TestCompress1XReuse(t *testing.T) {
 			}
 			firstData := len(s.OutData)
 			s.Reuse = ReusePolicyAllow
-			b, re, err = Compress1X(buf0, &s)
+			b, re, err := Compress1X(buf0, &s)
 			if err != nil {
 				t.Errorf("got secondary error %v (%T)", err, err)
 				return
@@ -565,7 +565,7 @@ func BenchmarkCompress1XReuseNone(b *testing.B) {
 			if len(buf0) > BlockSizeMax {
 				buf0 = buf0[:BlockSizeMax]
 			}
-			_, re, err := Compress1X(buf0, &s)
+			_, _, err = Compress1X(buf0, &s)
 			if err != test.err1X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -573,7 +573,7 @@ func BenchmarkCompress1XReuseNone(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress1X(buf0, &s)
+				_, re, _ := Compress1X(buf0, &s)
 				if re {
 					b.Fatal("reused")
 				}
@@ -598,7 +598,7 @@ func BenchmarkCompress1XReuseAllow(b *testing.B) {
 			if len(buf0) > BlockSizeMax {
 				buf0 = buf0[:BlockSizeMax]
 			}
-			_, re, err := Compress1X(buf0, &s)
+			_, _, err = Compress1X(buf0, &s)
 			if err != test.err1X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -606,7 +606,7 @@ func BenchmarkCompress1XReuseAllow(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress1X(buf0, &s)
+				_, re, _ := Compress1X(buf0, &s)
 				if !re {
 					b.Fatal("not reused")
 				}
@@ -631,7 +631,7 @@ func BenchmarkCompress1XReusePrefer(b *testing.B) {
 			if len(buf0) > BlockSizeMax {
 				buf0 = buf0[:BlockSizeMax]
 			}
-			_, re, err := Compress1X(buf0, &s)
+			_, _, err = Compress1X(buf0, &s)
 			if err != test.err1X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -639,7 +639,7 @@ func BenchmarkCompress1XReusePrefer(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress1X(buf0, &s)
+				_, re, _ := Compress1X(buf0, &s)
 				if !re {
 					b.Fatal("not reused")
 				}
@@ -664,7 +664,7 @@ func BenchmarkCompress4XReuseNone(b *testing.B) {
 			if len(buf0) > BlockSizeMax {
 				buf0 = buf0[:BlockSizeMax]
 			}
-			_, re, err := Compress4X(buf0, &s)
+			_, _, err = Compress4X(buf0, &s)
 			if err != test.err1X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -672,7 +672,7 @@ func BenchmarkCompress4XReuseNone(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress4X(buf0, &s)
+				_, re, _ := Compress4X(buf0, &s)
 				if re {
 					b.Fatal("reused")
 				}
@@ -697,7 +697,7 @@ func BenchmarkCompress4XReuseAllow(b *testing.B) {
 			if len(buf0) > BlockSizeMax {
 				buf0 = buf0[:BlockSizeMax]
 			}
-			_, re, err := Compress4X(buf0, &s)
+			_, _, err = Compress4X(buf0, &s)
 			if err != test.err1X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -705,7 +705,7 @@ func BenchmarkCompress4XReuseAllow(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress4X(buf0, &s)
+				_, re, _ := Compress4X(buf0, &s)
 				if !re {
 					b.Fatal("not reused")
 				}
@@ -730,7 +730,7 @@ func BenchmarkCompress4XReusePrefer(b *testing.B) {
 			if len(buf0) > BlockSizeMax {
 				buf0 = buf0[:BlockSizeMax]
 			}
-			_, re, err := Compress4X(buf0, &s)
+			_, _, err = Compress4X(buf0, &s)
 			if err != test.err4X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -738,7 +738,7 @@ func BenchmarkCompress4XReusePrefer(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress4X(buf0, &s)
+				_, re, _ := Compress4X(buf0, &s)
 				if !re {
 					b.Fatal("not reused")
 				}
@@ -759,7 +759,7 @@ func BenchmarkCompress1XSizes(b *testing.B) {
 				b.Fatal(err)
 			}
 			buf0 = buf0[:size]
-			_, re, err := Compress1X(buf0, &s)
+			_, _, err = Compress1X(buf0, &s)
 			if err != test.err1X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -768,7 +768,7 @@ func BenchmarkCompress1XSizes(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress1X(buf0, &s)
+				_, re, _ := Compress1X(buf0, &s)
 				if re {
 					b.Fatal("reused")
 				}
@@ -789,7 +789,7 @@ func BenchmarkCompress4XSizes(b *testing.B) {
 				b.Fatal(err)
 			}
 			buf0 = buf0[:size]
-			_, re, err := Compress4X(buf0, &s)
+			_, _, err = Compress4X(buf0, &s)
 			if err != test.err1X {
 				b.Fatal("unexpected error:", err)
 			}
@@ -798,7 +798,7 @@ func BenchmarkCompress4XSizes(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(buf0)))
 			for i := 0; i < b.N; i++ {
-				_, re, _ = Compress4X(buf0, &s)
+				_, re, _ := Compress4X(buf0, &s)
 				if re {
 					b.Fatal("reused")
 				}

--- a/s2/cmd/internal/readahead/reader.go
+++ b/s2/cmd/internal/readahead/reader.go
@@ -69,8 +69,8 @@ func (a *reader) init(rd io.Reader, buffers, size int) {
 	a.in = rd
 	a.ready = make(chan *buffer, buffers)
 	a.reuse = make(chan *buffer, buffers)
-	a.exit = make(chan struct{}, 0)
-	a.exited = make(chan struct{}, 0)
+	a.exit = make(chan struct{})
+	a.exited = make(chan struct{})
 	a.buffers = buffers
 	a.size = size
 	a.cur = nil

--- a/s2/cmd/s2c/main.go
+++ b/s2/cmd/s2c/main.go
@@ -90,7 +90,7 @@ Options:`)
 	if len(args) == 1 && args[0] == "-" {
 		// Catch interrupt, so we don't exit at once.
 		// os.Stdin will return EOF, so we should be able to get everything.
-		signal.Notify(make(chan os.Signal), os.Interrupt)
+		signal.Notify(make(chan os.Signal, 1), os.Interrupt)
 		wr.Reset(os.Stdout)
 		_, err = wr.ReadFrom(os.Stdin)
 		printErr(err)

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -1093,8 +1093,7 @@ func TestReaderReset(t *testing.T) {
 func TestWriterReset(t *testing.T) {
 	gold := bytes.Repeat([]byte("Not all those who wander are lost;\n"), 10000)
 	const n = 20
-	var w *Writer
-	w = NewWriter(nil)
+	w := NewWriter(nil)
 	defer w.Close()
 
 	var gots, wants [][]byte
@@ -1870,7 +1869,7 @@ func TestDataRoundtrips(t *testing.T) {
 }
 
 func BenchmarkDecodeS2Block(b *testing.B) {
-	for i, _ := range testFiles {
+	for i := range testFiles {
 		b.Run(fmt.Sprint(i, "-", testFiles[i].label), func(b *testing.B) {
 			benchFile(b, i, true)
 		})
@@ -1878,7 +1877,7 @@ func BenchmarkDecodeS2Block(b *testing.B) {
 }
 
 func BenchmarkEncodeS2Block(b *testing.B) {
-	for i, _ := range testFiles {
+	for i := range testFiles {
 		b.Run(fmt.Sprint(i, "-", testFiles[i].label), func(b *testing.B) {
 			benchFile(b, i, false)
 		})
@@ -1886,7 +1885,7 @@ func BenchmarkEncodeS2Block(b *testing.B) {
 }
 
 func BenchmarkDecodeSnappyBlock(b *testing.B) {
-	for i, _ := range testFiles {
+	for i := range testFiles {
 		b.Run(fmt.Sprint(i, "-", testFiles[i].label), func(b *testing.B) {
 			benchFileSnappy(b, i, true)
 		})
@@ -1894,7 +1893,7 @@ func BenchmarkDecodeSnappyBlock(b *testing.B) {
 }
 
 func BenchmarkEncodeSnappyBlock(b *testing.B) {
-	for i, _ := range testFiles {
+	for i := range testFiles {
 		b.Run(fmt.Sprint(i, "-", testFiles[i].label), func(b *testing.B) {
 			benchFileSnappy(b, i, false)
 		})

--- a/zip/writer_test.go
+++ b/zip/writer_test.go
@@ -400,7 +400,7 @@ func TestWriterDirAttributes(t *testing.T) {
 	}
 
 	binary.LittleEndian.PutUint32(sig[:], uint32(dataDescriptorSignature))
-	if bytes.Index(b, sig[:]) != -1 {
+	if bytes.Contains(b, sig[:]) {
 		t.Error("there should be no data descriptor")
 	}
 }

--- a/zstd/blockenc.go
+++ b/zstd/blockenc.go
@@ -386,9 +386,9 @@ func (b *blockEnc) encodeLits(lits []byte, raw bool) error {
 		b.output = bh.appendTo(b.output)
 		b.output = append(b.output, lits[0])
 		return nil
+	case nil:
 	default:
 		return err
-	case nil:
 	}
 	// Compressed...
 	// Now, allow reuse
@@ -528,11 +528,6 @@ func (b *blockEnc) encode(org []byte, raw, rawAllLits bool) error {
 		if debug {
 			println("Adding literals RLE")
 		}
-	default:
-		if debug {
-			println("Adding literals ERROR:", err)
-		}
-		return err
 	case nil:
 		// Compressed litLen...
 		if reUsed {
@@ -563,6 +558,11 @@ func (b *blockEnc) encode(org []byte, raw, rawAllLits bool) error {
 		if debug {
 			println("Adding literals compressed")
 		}
+	default:
+		if debug {
+			println("Adding literals ERROR:", err)
+		}
+		return err
 	}
 	// Sequence compression
 

--- a/zstd/decodeheader.go
+++ b/zstd/decodeheader.go
@@ -93,7 +93,7 @@ func (h *Header) Decode(in []byte) error {
 	h.HasCheckSum = fhd&(1<<2) != 0
 
 	if fhd&(1<<3) != 0 {
-		return errors.New("Reserved bit set on frame header")
+		return errors.New("reserved bit set on frame header")
 	}
 
 	// Read Window_Descriptor
@@ -174,7 +174,7 @@ func (h *Header) Decode(in []byte) error {
 	if len(in) < 3 {
 		return nil
 	}
-	tmp, in := in[:3], in[3:]
+	tmp := in[:3]
 	bh := uint32(tmp[0]) | (uint32(tmp[1]) << 8) | (uint32(tmp[2]) << 16)
 	h.FirstBlock.Last = bh&1 != 0
 	blockType := blockType((bh >> 1) & 3)

--- a/zstd/decodeheader_test.go
+++ b/zstd/decodeheader_test.go
@@ -93,6 +93,9 @@ func TestHeader_Decode(t *testing.T) {
 		}
 		defer w.Close()
 		enc, err := NewWriter(w, WithEncoderLevel(SpeedBestCompression))
+		if err != nil {
+			t.Fatal(err)
+		}
 		b, err := json.Marshal(golden)
 		if err != nil {
 			t.Fatal(err)
@@ -100,6 +103,5 @@ func TestHeader_Decode(t *testing.T) {
 		enc.ReadFrom(bytes.NewBuffer(b))
 		enc.Close()
 		t.SkipNow()
-		return
 	}
 }

--- a/zstd/decoder_options.go
+++ b/zstd/decoder_options.go
@@ -6,7 +6,6 @@ package zstd
 
 import (
 	"errors"
-	"fmt"
 	"runtime"
 )
 
@@ -43,7 +42,7 @@ func WithDecoderLowmem(b bool) DOption {
 func WithDecoderConcurrency(n int) DOption {
 	return func(o *decoderOptions) error {
 		if n <= 0 {
-			return fmt.Errorf("Concurrency must be at least 1")
+			return errors.New("concurrency must be at least 1")
 		}
 		o.concurrent = n
 		return nil
@@ -61,7 +60,7 @@ func WithDecoderMaxMemory(n uint64) DOption {
 			return errors.New("WithDecoderMaxMemory must be at least 1")
 		}
 		if n > 1<<63 {
-			return fmt.Errorf("WithDecoderMaxmemory must be less than 1 << 63")
+			return errors.New("WithDecoderMaxmemory must be less than 1 << 63")
 		}
 		o.maxDecodedSize = n
 		return nil

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -118,6 +118,9 @@ func TestNewReaderMismatch(t *testing.T) {
 						start = 0
 					}
 					_, err = org.Seek(start, io.SeekStart)
+					if err != nil {
+						t.Fatal(err)
+					}
 					buf2 := make([]byte, sizeBack+1<<20)
 					n, _ := io.ReadFull(org, buf2)
 					if n > 0 {

--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -340,13 +340,13 @@ func (e *Encoder) ReadFrom(r io.Reader) (n int64, err error) {
 				println("ReadFrom: got EOF final block:", len(e.state.filling))
 			}
 			return n, nil
+		case nil:
 		default:
 			if debug {
 				println("ReadFrom: got error:", err)
 			}
 			e.state.err = err
 			return n, err
-		case nil:
 		}
 		if len(src) > 0 {
 			if debug {

--- a/zstd/encoder_test.go
+++ b/zstd/encoder_test.go
@@ -141,7 +141,8 @@ func TestEncoder_EncodeAllConcurrent(t *testing.T) {
 					if !bytes.Equal(decoded, in) {
 						//ioutil.WriteFile("testdata/"+t.Name()+"-z000028.got", decoded, os.ModePerm)
 						//ioutil.WriteFile("testdata/"+t.Name()+"-z000028.want", in, os.ModePerm)
-						t.Fatal("Decoded does not match")
+						t.Error("Decoded does not match")
+						return
 					}
 				}()
 			}
@@ -188,7 +189,8 @@ func TestEncoder_EncodeAllEncodeXML(t *testing.T) {
 			}
 			if !bytes.Equal(decoded, in) {
 				ioutil.WriteFile("testdata/"+t.Name()+"-xml.got", decoded, os.ModePerm)
-				t.Fatal("Decoded does not match")
+				t.Error("Decoded does not match")
+				return
 			}
 			t.Log("Encoded content matched")
 		})
@@ -533,12 +535,14 @@ func testEncoderRoundtrip(t *testing.T, file string, wantCRC []byte) {
 			go func() {
 				n, err := enc.ReadFrom(input)
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 				wantSize = n
 				err = enc.Close()
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
+					return
 				}
 				pw.Close()
 			}()
@@ -630,12 +634,14 @@ func testEncoderRoundtripWriter(t *testing.T, file string, wantCRC []byte) {
 	go func() {
 		n, err := io.CopyBuffer(encW, input, make([]byte, 1337))
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		wantSize = n
 		err = enc.Close()
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		pw.Close()
 	}()

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -121,7 +121,7 @@ func (d *frameDec) reset(br byteBuffer) error {
 	d.SingleSegment = fhd&(1<<5) != 0
 
 	if fhd&(1<<3) != 0 {
-		return errors.New("Reserved bit set on frame header")
+		return errors.New("reserved bit set on frame header")
 	}
 
 	// Read Window_Descriptor

--- a/zstd/fse_encoder.go
+++ b/zstd/fse_encoder.go
@@ -708,7 +708,6 @@ func (c *cState) init(bw *bitWriter, ct *cTable, first symbolTransform) {
 	im := int32((nbBitsOut << 16) - first.deltaNbBits)
 	lu := (im >> nbBitsOut) + int32(first.deltaFindState)
 	c.state = c.stateTable[lu]
-	return
 }
 
 // encode the output symbol provided and write it to the bitstream.

--- a/zstd/fse_predefined.go
+++ b/zstd/fse_predefined.go
@@ -59,7 +59,7 @@ func fillBase(dst []baseOffset, base uint32, bits ...uint8) {
 	}
 	for i, bit := range bits {
 		if base > math.MaxInt32 {
-			panic(fmt.Sprintf("invalid decoding table, base overflows int32"))
+			panic("invalid decoding table, base overflows int32")
 		}
 
 		dst[i] = baseOffset{

--- a/zstd/seqenc.go
+++ b/zstd/seqenc.go
@@ -35,7 +35,6 @@ func (s *seqCoders) setPrev(ll, ml, of *fseEncoder) {
 		// Ensure we cannot reuse by accident
 		prevEnc := *prev
 		prevEnc.symbolLen = 0
-		return
 	}
 	compareSwap(ll, &s.llEnc, &s.llPrev)
 	compareSwap(ml, &s.mlEnc, &s.mlPrev)


### PR DESCRIPTION
This just fixes a few minor issues reported by staticcheck. Nothing major.

I did not know how to solve these, but I expect that they may be of interest for performance reasons:
```
/home/jacob/Git/compress/s2/encode.go
  (402, 19)  SA6002  argument should be pointer-like to avoid allocations
  (655, 18)  SA6002  argument should be pointer-like to avoid allocations
  (734, 17)  SA6002  argument should be pointer-like to avoid allocations
  (819, 17)  SA6002  argument should be pointer-like to avoid allocations
```