### PR TITLE
Update vendored xxhash to 1a548c8655f85f3ffcf3578aa1dc8f922ecb6a98

### DIFF
--- a/zstd/internal/xxhash/README.md
+++ b/zstd/internal/xxhash/README.md
@@ -1,7 +1,6 @@
 # xxhash
 
-VENDORED: Go to [github.com/cespare/xxhash](https://github.com/cespare/xxhash) for original package.
-
+**VENDORED:** Go to [github.com/cespare/xxhash](https://github.com/cespare/xxhash) for original package.
 
 [![GoDoc](https://godoc.org/github.com/cespare/xxhash?status.svg)](https://godoc.org/github.com/cespare/xxhash)
 [![Build Status](https://travis-ci.org/cespare/xxhash.svg?branch=master)](https://travis-ci.org/cespare/xxhash)
@@ -31,6 +30,18 @@ func (*Digest) Sum64() uint64
 This implementation provides a fast pure-Go implementation and an even faster
 assembly implementation for amd64.
 
+## Compatibility
+
+This package is in a module and the latest code is in version 2 of the module.
+You need a version of Go with at least "minimal module compatibility" to use
+github.com/cespare/xxhash/v2:
+
+* 1.9.7+ for Go 1.9
+* 1.10.3+ for Go 1.10
+* Go 1.11 or later
+
+I recommend using the latest release of Go.
+
 ## Benchmarks
 
 Here are some quick benchmarks comparing the pure-Go and assembly
@@ -56,3 +67,4 @@ $ go test -benchtime 10s -bench '/xxhash,direct,bytes'
 - [InfluxDB](https://github.com/influxdata/influxdb)
 - [Prometheus](https://github.com/prometheus/prometheus)
 - [FreeCache](https://github.com/coocood/freecache)
+- [FastCache](https://github.com/VictoriaMetrics/fastcache)

--- a/zstd/internal/xxhash/bench_test.go
+++ b/zstd/internal/xxhash/bench_test.go
@@ -1,0 +1,74 @@
+package xxhash
+
+import (
+	"strings"
+	"testing"
+)
+
+var benchmarks = []struct {
+	name string
+	n    int64
+}{
+	{"4B", 4},
+	{"100B", 100},
+	{"4KB", 4e3},
+	{"10MB", 10e6},
+}
+
+func BenchmarkSum64(b *testing.B) {
+	for _, bb := range benchmarks {
+		in := make([]byte, bb.n)
+		for i := range in {
+			in[i] = byte(i)
+		}
+		b.Run(bb.name, func(b *testing.B) {
+			b.SetBytes(bb.n)
+			for i := 0; i < b.N; i++ {
+				_ = Sum64(in)
+			}
+		})
+	}
+}
+
+func BenchmarkSum64String(b *testing.B) {
+	for _, bb := range benchmarks {
+		s := strings.Repeat("a", int(bb.n))
+		b.Run(bb.name, func(b *testing.B) {
+			b.SetBytes(bb.n)
+			for i := 0; i < b.N; i++ {
+				_ = Sum64String(s)
+			}
+		})
+	}
+}
+
+func BenchmarkDigestBytes(b *testing.B) {
+	for _, bb := range benchmarks {
+		in := make([]byte, bb.n)
+		for i := range in {
+			in[i] = byte(i)
+		}
+		b.Run(bb.name, func(b *testing.B) {
+			b.SetBytes(bb.n)
+			for i := 0; i < b.N; i++ {
+				h := New()
+				h.Write(in)
+				_ = h.Sum64()
+			}
+		})
+	}
+}
+
+func BenchmarkDigestString(b *testing.B) {
+	for _, bb := range benchmarks {
+		s := strings.Repeat("a", int(bb.n))
+		b.Run(bb.name, func(b *testing.B) {
+			b.SetBytes(bb.n)
+			for i := 0; i < b.N; i++ {
+				h := New()
+				h.WriteString(s)
+				_ = h.Sum64()
+			}
+		})
+	}
+}

--- a/zstd/internal/xxhash/xxhash.go
+++ b/zstd/internal/xxhash/xxhash.go
@@ -195,7 +195,6 @@ func (d *Digest) UnmarshalBinary(b []byte) error {
 	b, d.v4 = consumeUint64(b)
 	b, d.total = consumeUint64(b)
 	copy(d.mem[:], b)
-	b = b[len(d.mem):]
 	d.n = int(d.total % uint64(len(d.mem)))
 	return nil
 }

--- a/zstd/internal/xxhash/xxhash_amd64.go
+++ b/zstd/internal/xxhash/xxhash_amd64.go
@@ -10,4 +10,4 @@ package xxhash
 func Sum64(b []byte) uint64
 
 //go:noescape
-func writeBlocks(*Digest, []byte) int
+func writeBlocks(d *Digest, b []byte) int

--- a/zstd/internal/xxhash/xxhash_amd64.s
+++ b/zstd/internal/xxhash/xxhash_amd64.s
@@ -179,13 +179,13 @@ TEXT ·writeBlocks(SB), NOSPLIT, $0-40
 	MOVQ ·prime2v(SB), R14
 
 	// Load slice.
-	MOVQ arg1_base+8(FP), CX
-	MOVQ arg1_len+16(FP), DX
+	MOVQ b_base+8(FP), CX
+	MOVQ b_len+16(FP), DX
 	LEAQ (CX)(DX*1), BX
 	SUBQ $32, BX
 
 	// Load vN from d.
-	MOVQ arg+0(FP), AX
+	MOVQ d+0(FP), AX
 	MOVQ 0(AX), R8   // v1
 	MOVQ 8(AX), R9   // v2
 	MOVQ 16(AX), R10 // v3
@@ -209,7 +209,7 @@ blockLoop:
 	MOVQ R11, 24(AX)
 
 	// The number of bytes written is CX minus the old base pointer.
-	SUBQ arg1_base+8(FP), CX
+	SUBQ b_base+8(FP), CX
 	MOVQ CX, ret+32(FP)
 
 	RET

--- a/zstd/internal/xxhash/xxhash_safe.go
+++ b/zstd/internal/xxhash/xxhash_safe.go
@@ -1,3 +1,7 @@
+// +build appengine
+
+// This file contains the safe implementations of otherwise unsafe-using code.
+
 package xxhash
 
 // Sum64String computes the 64-bit xxHash digest of s.

--- a/zstd/internal/xxhash/xxhash_test.go
+++ b/zstd/internal/xxhash/xxhash_test.go
@@ -26,7 +26,11 @@ func TestAll(t *testing.T) {
 			0x02a2e85470d6fd96,
 		},
 	} {
-		for chunkSize := 1; chunkSize <= len(tt.input); chunkSize++ {
+		lastChunkSize := len(tt.input)
+		if lastChunkSize == 0 {
+			lastChunkSize = 1
+		}
+		for chunkSize := 1; chunkSize <= lastChunkSize; chunkSize++ {
 			name := fmt.Sprintf("%s,chunkSize=%d", tt.name, chunkSize)
 			t.Run(name, func(t *testing.T) {
 				testDigest(t, tt.input, chunkSize, tt.want)

--- a/zstd/internal/xxhash/xxhash_unsafe.go
+++ b/zstd/internal/xxhash/xxhash_unsafe.go
@@ -1,0 +1,57 @@
+// +build !appengine
+
+// This file encapsulates usage of unsafe.
+// xxhash_safe.go contains the safe implementations.
+
+package xxhash
+
+import (
+	"unsafe"
+)
+
+// In the future it's possible that compiler optimizations will make these
+// XxxString functions unnecessary by realizing that calls such as
+// Sum64([]byte(s)) don't need to copy s. See https://golang.org/issue/2205.
+// If that happens, even if we keep these functions they can be replaced with
+// the trivial safe code.
+
+// NOTE: The usual way of doing an unsafe string-to-[]byte conversion is:
+//
+//   var b []byte
+//   bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+//   bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
+//   bh.Len = len(s)
+//   bh.Cap = len(s)
+//
+// Unfortunately, as of Go 1.15.3 the inliner's cost model assigns a high enough
+// weight to this sequence of expressions that any function that uses it will
+// not be inlined. Instead, the functions below use a different unsafe
+// conversion designed to minimize the inliner weight and allow both to be
+// inlined. There is also a test (TestInlining) which verifies that these are
+// inlined.
+//
+// See https://github.com/golang/go/issues/42739 for discussion.
+
+// Sum64String computes the 64-bit xxHash digest of s.
+// It may be faster than Sum64([]byte(s)) by avoiding a copy.
+func Sum64String(s string) uint64 {
+	b := *(*[]byte)(unsafe.Pointer(&sliceHeader{s, len(s)}))
+	return Sum64(b)
+}
+
+// WriteString adds more data to d. It always returns len(s), nil.
+// It may be faster than Write([]byte(s)) by avoiding a copy.
+func (d *Digest) WriteString(s string) (n int, err error) {
+	d.Write(*(*[]byte)(unsafe.Pointer(&sliceHeader{s, len(s)})))
+	// d.Write always returns len(s), nil.
+	// Ignoring the return output and returning these fixed values buys a
+	// savings of 6 in the inliner's cost model.
+	return len(s), nil
+}
+
+// sliceHeader is similar to reflect.SliceHeader, but it assumes that the layout
+// of the first two words is the same as the layout of a string.
+type sliceHeader struct {
+	s   string
+	cap int
+}

--- a/zstd/internal/xxhash/xxhash_unsafe_test.go
+++ b/zstd/internal/xxhash/xxhash_unsafe_test.go
@@ -1,0 +1,61 @@
+// +build !appengine
+
+package xxhash
+
+import (
+	"os/exec"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestStringAllocs(t *testing.T) {
+	longStr := strings.Repeat("a", 1000)
+	t.Run("Sum64String", func(t *testing.T) {
+		testAllocs(t, func() {
+			sink = Sum64String(longStr)
+		})
+	})
+	t.Run("Digest.WriteString", func(t *testing.T) {
+		testAllocs(t, func() {
+			d := New()
+			d.WriteString(longStr)
+			sink = d.Sum64()
+		})
+	})
+}
+
+// This test is inspired by the Go runtime tests in https://golang.org/cl/57410.
+// It asserts that certain important functions may be inlined.
+func TestInlining(t *testing.T) {
+	funcs := map[string]struct{}{
+		"Sum64String":           {},
+		"(*Digest).WriteString": {},
+	}
+
+	// TODO: it would be better to use the go binary that is running
+	// 'go test' (if we are running under 'go test').
+	cmd := exec.Command("go", "test", "-gcflags=-m", "-run", "xxxx")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(out))
+		t.Fatal(err)
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.Split(line, ": can inline")
+		if len(parts) < 2 {
+			continue
+		}
+		delete(funcs, strings.TrimSpace(parts[1]))
+	}
+
+	var failed []string
+	for fn := range funcs {
+		failed = append(failed, fn)
+	}
+	sort.Strings(failed)
+	for _, fn := range failed {
+		t.Errorf("function %s not inlined", fn)
+	}
+}


### PR DESCRIPTION
There are two changes of note here. Firstly there is https://github.com/cespare/xxhash/commit/fd5c34b71e8ec6a322b55ae01fde54e8edea759a that removes a useless assignment. More importantly, there is also https://github.com/cespare/xxhash/commit/a7909af24e080cb18e105af79be6915531147a86 which allows some parts of the code to be inlined for between 10 to 30 percent speed improvements.