### PR TITLE
s2: More accurate scoring in best mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,7 @@ deploy:
     tags: true
     condition: ($TRAVIS_OS_NAME = linux) && ($TRAVIS_CPU_ARCH = amd64)
     go: 1.16.x
-    branch: master
-
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,5 @@ deploy:
     tags: true
     condition: ($TRAVIS_OS_NAME = linux) && ($TRAVIS_CPU_ARCH = amd64)
     go: 1.16.x
-branches:
-  only:
-    - master
-    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+    branch: master
+


### PR DESCRIPTION
Improves compression.

Use more accurate scoring function for best mode. More often a benefit than not.

```
BEFORE/AFTER:

Reading nyc-taxi-data-10M.csv...
Compressing... 3325605752 -> 794873465 [23.90%]; 6.172s, 513.9MB/s
Compressing... 3325605752 -> 786648492 [23.65%]; 7.389s, 429.2MB/s

Reading adresser.json...
Compressing... 7983034785 -> 375370404 [4.70%]; 3.527s, 2158.6MB/s
Compressing... 7983034785 -> 380912248 [4.77%]; 3.924s, 1940.0MB/s

Reading 10gb.tar...
Compressing... 10065157632 -> 5246634524 [52.13%]; 24.294s, 395.1MB/s
Compressing... 10065157632 -> 5215462149 [51.82%]; 29.462s, 325.8MB/s

Reading enwik9...
Compressing... 1000000000 -> 375981068 [37.60%]; 3.562s, 267.7MB/s
Compressing... 1000000000 -> 373289535 [37.33%]; 4.047s, 235.6MB/s

Reading sample.tar...
Compressing... 808796160 -> 297514564 [36.78%]; 1.458s, 529.0MB/s
Compressing... 808796160 -> 277822539 [34.35%]; 2.043s, 377.5MB/s
```