### PR TITLE
Add ability to decompress streams created with very large windows (--long=30, --long=31)

### DIFF
--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -52,7 +52,7 @@ type frameDec struct {
 const (
 	// The minimum Window_Size is 1 KB.
 	MinWindowSize = 1 << 10
-	MaxWindowSize = 1 << 29
+	MaxWindowSize = 1 << 31
 )
 
 var (
@@ -170,7 +170,8 @@ func (d *frameDec) reset(br byteBuffer) error {
 	// https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#dictionary_id
 	d.DictionaryID = nil
 	if size := fhd & 3; size != 0 {
-		if size == 3 {
+		if size == 3 {	MaxWindowSize = 1 << 29
+
 			size = 4
 		}
 


### PR DESCRIPTION
The zstd compression program allows for compression with window sizes up to 2 << 31. This pull request adjusts the constant for MaxWindowSize to accommodate larger window sizes.

I do not believe this change would break any existing code that uses this module. 