### PR TITLE
Update framedec.go MaxWindowSize constant to 2 << 31

### DIFF
--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -52,7 +52,7 @@ type frameDec struct {
 const (
 	// The minimum Window_Size is 1 KB.
 	MinWindowSize = 1 << 10
-	MaxWindowSize = 1 << 29
+	MaxWindowSize = 1 << 31
 )
 
 var (


### PR DESCRIPTION
Add support for very large window sizes (up to 2 << 31 -- the max allowed via the zstd compressor itself). This should not break any existing code that uses this module.

