### PR TITLE
s2: Add full Snappy output support

### DIFF
--- a/s2/README.md
+++ b/s2/README.md
@@ -16,20 +16,21 @@ This is important, so you don't have to worry about spending CPU cycles on alrea
 ## Benefits over Snappy
 
 * Better compression
+* Adjustable compression (3 levels) 
 * Concurrent stream compression
-* Faster decompression
+* Faster decompression, even for Snappy compatible content
 * Ability to quickly skip forward in compressed stream
 * Compatible with reading Snappy compressed content
-* Offers alternative, more efficient, but slightly slower compression mode.
-* Smaller block size overhead on incompressible blocks.
+* Smaller block size overhead on incompressible blocks
 * Block concatenation
-* Automatic stream size padding.
-* Snappy compatible block compression.
+* Uncompressed stream mode
+* Automatic stream size padding
+* Snappy compatible block compression
 
 ## Drawbacks over Snappy
 
 * Not optimized for 32 bit systems.
-* Uses slightly more memory (4MB per core) due to larger blocks and concurrency (configurable).
+* Streams use slightly more memory due to larger blocks and concurrency (configurable).
 
 # Usage
 
@@ -608,36 +609,56 @@ Decompression speed should be around the same as using the 'better' compression 
 
 S2 now offers full compatibility with Snappy.
 
-This means that the efficient encoders of S2 can be used 
+This means that the efficient encoders of S2 can be used to generate fully Snappy compatible output.
 
 ## Blocks
 
 Snappy compatible blocks can be generated with the S2 encoder. 
 Compression and speed is typically a bit better `MaxEncodedLen` is also smaller for smaller memory usage. Replace 
 
-| Snappy                       | S2 replacement                |
-|------------------------------|-------------------------------|
-| `snappy.Encode(...)`         | `s2.EncodeSnappy(...)`   |
-| `snappy.MaxEncodedLen(...)`  | `s2.MaxEncodedLen(...)`      |
+| Snappy                     | S2 replacement          |
+|----------------------------|-------------------------|
+| snappy.Encode(...)         | s2.EncodeSnappy(...)`   |
+| snappy.MaxEncodedLen(...)  | s2.MaxEncodedLen(...)   |
 
 `s2.EncodeSnappy` can be replaced with `s2.EncodeSnappyBetter` or `s2.EncodeSnappyBest` to get more efficiently compressed snappy compatible output. 
 
 `s2ConcatBlocks` is compatible with snappy blocks.
+
+Comparison of [`webdevdata.org-2015-01-07-subset`](https://files.klauspost.com/compress/webdevdata.org-2015-01-07-4GB-subset.7z),
+53927 files, total input size: 4,014,735,833 bytes. amd64, single goroutine used:
+
+| Encoder               | Size       | MB/s   |
+|-----------------------|------------|--------|
+| snappy.Encode         | 1128706759 | 725.59 |
+| s2.EncodeSnappy       | 1093823291 | 899.16 |
+| s2.EncodeSnappyBetter | 1001158548 | 578.49 |
+| s2.EncodeSnappyBest   | 944507998  | 66.00  |
 
 ## Streams
 
 For streams, replace `enc = snappy.NewWriter(w)` with `enc = s2.NewWriter(w, s2.WriterSnappyCompat())`.
 All other options are available, but note that block size limit is different for snappy.
 
+Comparison of different streams, AMD Ryzen 3950x, 16 cores. Size and throughput: 
+
+| File                        | snappy.NewWriter         | S2 Snappy                 | S2 Snappy, Better        | S2 Snappy, Best         |
+|-----------------------------|--------------------------|---------------------------|--------------------------|-------------------------|
+| nyc-taxi-data-10M.csv       | 1316042016 - 517.54MB/s  | 1307003093 - 8406.29MB/s  | 1174534014 - 4984.35MB/s | 1115904679 - 177.81MB/s |
+| enwik10                     | 5088294643 - 433.45MB/s  | 5175840939 - 8454.52MB/s  | 4560784526 - 4403.10MB/s | 4340299103 - 159.71MB/s |
+| 10gb.tar                    | 6056946612 - 703.25MB/s  | 6208571995 - 9035.75MB/s  | 5741646126 - 2402.08MB/s | 5548973895 - 171.17MB/s |
+| github-june-2days-2019.json | 1525176492 - 908.11MB/s  | 1476519054 - 12625.93MB/s | 1400547532 - 6163.61MB/s | 1321887137 - 200.71MB/s |
+| consensus.db.10gb           | 5412897703 - 1054.38MB/s | 5354073487 - 12634.82MB/s | 5335069899 - 2472.23MB/s | 5201000954 - 166.32MB/s |
+
 # Decompression
 
 All decompression functions map directly to equivalent s2 functions.
 
-| Snappy                   | S2 replacement       |
-|--------------------------|----------------------|
-| `snappy.Decode(...)`     | `s2.Decode(...)`     |
-| `snappy.DecodedLen(...)` | `s2.DecodedLen(...)` |
-| `snappy.NewReader(...)`  | `s2.NewReader(...)`  |
+| Snappy                 | S2 replacement     |
+|------------------------|--------------------|
+| snappy.Decode(...)     | s2.Decode(...)     |
+| snappy.DecodedLen(...) | s2.DecodedLen(...) |
+| snappy.NewReader(...)  | s2.NewReader(...)  |
 
 Features like [quick forward skipping without decompression](https://pkg.go.dev/github.com/klauspost/compress/s2#Reader.Skip)
 are also available for Snappy streams.

--- a/s2/encode.go
+++ b/s2/encode.go
@@ -186,6 +186,94 @@ func EncodeSnappy(dst, src []byte) []byte {
 	return dst[:d]
 }
 
+// EncodeSnappyBetter returns the encoded form of src. The returned slice may be a sub-
+// slice of dst if dst was large enough to hold the entire encoded block.
+// Otherwise, a newly allocated slice will be returned.
+//
+// The output is Snappy compatible and will likely decompress faster.
+//
+// The dst and src must not overlap. It is valid to pass a nil dst.
+//
+// The blocks will require the same amount of memory to decode as encoding,
+// and does not make for concurrent decoding.
+// Also note that blocks do not contain CRC information, so corruption may be undetected.
+//
+// If you need to encode larger amounts of data, consider using
+// the streaming interface which gives all of these features.
+func EncodeSnappyBetter(dst, src []byte) []byte {
+	if n := MaxEncodedLen(len(src)); n < 0 {
+		panic(ErrTooLarge)
+	} else if cap(dst) < n {
+		dst = make([]byte, n)
+	} else {
+		dst = dst[:n]
+	}
+
+	// The block starts with the varint-encoded length of the decompressed bytes.
+	d := binary.PutUvarint(dst, uint64(len(src)))
+
+	if len(src) == 0 {
+		return dst[:d]
+	}
+	if len(src) < minNonLiteralBlockSize {
+		d += emitLiteral(dst[d:], src)
+		return dst[:d]
+	}
+
+	n := encodeBlockBetterSnappy(dst[d:], src)
+	if n > 0 {
+		d += n
+		return dst[:d]
+	}
+	// Not compressible
+	d += emitLiteral(dst[d:], src)
+	return dst[:d]
+}
+
+// EncodeSnappyBest returns the encoded form of src. The returned slice may be a sub-
+// slice of dst if dst was large enough to hold the entire encoded block.
+// Otherwise, a newly allocated slice will be returned.
+//
+// The output is Snappy compatible and will likely decompress faster.
+//
+// The dst and src must not overlap. It is valid to pass a nil dst.
+//
+// The blocks will require the same amount of memory to decode as encoding,
+// and does not make for concurrent decoding.
+// Also note that blocks do not contain CRC information, so corruption may be undetected.
+//
+// If you need to encode larger amounts of data, consider using
+// the streaming interface which gives all of these features.
+func EncodeSnappyBest(dst, src []byte) []byte {
+	if n := MaxEncodedLen(len(src)); n < 0 {
+		panic(ErrTooLarge)
+	} else if cap(dst) < n {
+		dst = make([]byte, n)
+	} else {
+		dst = dst[:n]
+	}
+
+	// The block starts with the varint-encoded length of the decompressed bytes.
+	d := binary.PutUvarint(dst, uint64(len(src)))
+
+	if len(src) == 0 {
+		return dst[:d]
+	}
+	if len(src) < minNonLiteralBlockSize {
+		d += emitLiteral(dst[d:], src)
+		return dst[:d]
+	}
+
+	n := encodeBlockBestSnappy(dst[d:], src)
+	if n > 0 {
+		d += n
+		return dst[:d]
+	}
+	// Not compressible
+	d += emitLiteral(dst[d:], src)
+	return dst[:d]
+}
+
 // ConcatBlocks will concatenate the supplied blocks and append them to the supplied destination.
 // If the destination is nil or too small, a new will be allocated.
 // The blocks are not validated, so garbage in = garbage out.
@@ -322,6 +410,7 @@ type Writer struct {
 	// wroteStreamHeader is whether we have written the stream header.
 	wroteStreamHeader bool
 	paramsOK          bool
+	snappy            bool
 	level             uint8
 }
 
@@ -516,7 +605,11 @@ func (w *Writer) EncodeBuffer(buf []byte) (err error) {
 		w.wroteStreamHeader = true
 		hWriter := make(chan result)
 		w.output <- hWriter
-		hWriter <- []byte(magicChunk)
+		if w.snappy {
+			hWriter <- []byte(magicChunkSnappy)
+		} else {
+			hWriter <- []byte(magicChunk)
+		}
 	}
 
 	for len(buf) > 0 {
@@ -540,15 +633,7 @@ func (w *Writer) EncodeBuffer(buf []byte) (err error) {
 
 			// Attempt compressing.
 			n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
-			var n2 int
-			switch w.level {
-			case levelFast:
-				n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
-			case levelBetter:
-				n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-			case levelBest:
-				n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
-			}
+			n2 := w.encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
 
 			// Check if we should use this, or store as uncompressed instead.
 			if n2 > 0 {
@@ -577,6 +662,29 @@ func (w *Writer) EncodeBuffer(buf []byte) (err error) {
 	return nil
 }
 
+func (w *Writer) encodeBlock(obuf, uncompressed []byte) int {
+	if w.snappy {
+		switch w.level {
+		case levelFast:
+			return encodeBlockSnappy(obuf, uncompressed)
+		case levelBetter:
+			return encodeBlockBetterSnappy(obuf, uncompressed)
+		case levelBest:
+			return encodeBlockBestSnappy(obuf, uncompressed)
+		}
+		return 0
+	}
+	switch w.level {
+	case levelFast:
+		return encodeBlock(obuf, uncompressed)
+	case levelBetter:
+		return encodeBlockBetter(obuf, uncompressed)
+	case levelBest:
+		return encodeBlockBest(obuf, uncompressed)
+	}
+	return 0
+}
+
 func (w *Writer) write(p []byte) (nRet int, errRet error) {
 	if err := w.err(nil); err != nil {
 		return 0, err
@@ -591,7 +699,11 @@ func (w *Writer) write(p []byte) (nRet int, errRet error) {
 			w.wroteStreamHeader = true
 			hWriter := make(chan result)
 			w.output <- hWriter
-			hWriter <- []byte(magicChunk)
+			if w.snappy {
+				hWriter <- []byte(magicChunkSnappy)
+			} else {
+				hWriter <- []byte(magicChunk)
+			}
 		}
 
 		var uncompressed []byte
@@ -620,15 +732,7 @@ func (w *Writer) write(p []byte) (nRet int, errRet error) {
 
 			// Attempt compressing.
 			n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
-			var n2 int
-			switch w.level {
-			case levelFast:
-				n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
-			case levelBetter:
-				n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-			case levelBest:
-				n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
-			}
+			n2 := w.encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
 
 			// Check if we should use this, or store as uncompressed instead.
 			if n2 > 0 {
@@ -680,7 +784,11 @@ func (w *Writer) writeFull(inbuf []byte) (errRet error) {
 		w.wroteStreamHeader = true
 		hWriter := make(chan result)
 		w.output <- hWriter
-		hWriter <- []byte(magicChunk)
+		if w.snappy {
+			hWriter <- []byte(magicChunkSnappy)
+		} else {
+			hWriter <- []byte(magicChunk)
+		}
 	}
 
 	// Get an output buffer.
@@ -699,15 +807,7 @@ func (w *Writer) writeFull(inbuf []byte) (errRet error) {
 
 		// Attempt compressing.
 		n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
-		var n2 int
-		switch w.level {
-		case levelFast:
-			n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
-		case levelBetter:
-			n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-		case levelBest:
-			n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
-		}
+		n2 := w.encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
 
 		// Check if we should use this, or store as uncompressed instead.
 		if n2 > 0 {
@@ -744,7 +844,13 @@ func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
 	}
 	if !w.wroteStreamHeader {
 		w.wroteStreamHeader = true
-		n, err := w.writer.Write([]byte(magicChunk))
+		var n int
+		var err error
+		if w.snappy {
+			n, err = w.writer.Write([]byte(magicChunkSnappy))
+		} else {
+			n, err = w.writer.Write([]byte(magicChunk))
+		}
 		if err != nil {
 			return 0, w.err(err)
 		}
@@ -771,15 +877,7 @@ func (w *Writer) writeSync(p []byte) (nRet int, errRet error) {
 
 		// Attempt compressing.
 		n := binary.PutUvarint(obuf[obufHeaderLen:], uint64(len(uncompressed)))
-		var n2 int
-		switch w.level {
-		case levelFast:
-			n2 = encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
-		case levelBetter:
-			n2 = encodeBlockBetter(obuf[obufHeaderLen+n:], uncompressed)
-		case levelBest:
-			n2 = encodeBlockBest(obuf[obufHeaderLen+n:], uncompressed)
-		}
+		n2 := w.encodeBlock(obuf[obufHeaderLen+n:], uncompressed)
 
 		if n2 > 0 {
 			chunkType = uint8(chunkTypeCompressedData)
@@ -983,8 +1081,14 @@ func WriterUncompressed() WriterOption {
 // and will increase compression slightly, but it will limit the possible
 // concurrency for smaller payloads for both encoding and decoding.
 // Default block size is 1MB.
+//
+// When writing Snappy compatible output using WriterSnappyCompat,
+// the maximum block size is 64KB.
 func WriterBlockSize(n int) WriterOption {
 	return func(w *Writer) error {
+		if w.snappy && n > maxSnappyBlockSize || n < minBlockSize {
+			return errors.New("s2: block size too large. Must be <= 64K and >=4KB on for snappy compatible output")
+		}
 		if n > maxBlockSize || n < minBlockSize {
 			return errors.New("s2: block size too large. Must be <= 4MB and >=4KB")
 		}
@@ -1021,6 +1125,21 @@ func WriterPadding(n int) WriterOption {
 func WriterPaddingSrc(reader io.Reader) WriterOption {
 	return func(w *Writer) error {
 		w.randSrc = reader
+		return nil
+	}
+}
+
+// WriterSnappyCompat will write snappy compatible output.
+// The output can be decompressed using either snappy or s2.
+// If block size is more than 64KB it is set to that.
+func WriterSnappyCompat() WriterOption {
+	return func(w *Writer) error {
+		w.snappy = true
+		if w.blockSize > 64<<10 {
+			// We choose 8 bytes less than 64K, since that will make literal emits slightly more effective.
+			// And allows us to skip some size checks.
+			w.blockSize = (64 << 10) - 8
+		}
 		return nil
 	}
 }

--- a/s2/encode_all.go
+++ b/s2/encode_all.go
@@ -269,3 +269,188 @@ emitRemainder:
 	}
 	return d
 }
+
+func encodeBlockSnappyGo(dst, src []byte) (d int) {
+	// Initialize the hash table.
+	const (
+		tableBits    = 14
+		maxTableSize = 1 << tableBits
+	)
+
+	var table [maxTableSize]uint32
+
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := len(src) - inputMargin
+
+	// Bail if we can't compress to at least this.
+	dstLimit := len(src) - len(src)>>5 - 5
+
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := 0
+
+	// The encoded form must start with a literal, as there are no previous
+	// bytes to copy, so we start looking for hash matches at s == 1.
+	s := 1
+	cv := load64(src, s)
+
+	// We search for a repeat at -1, but don't output repeats when nextEmit == 0
+	repeat := 1
+
+	for {
+		candidate := 0
+		for {
+			// Next src position to check
+			nextS := s + (s-nextEmit)>>6 + 4
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			hash0 := hash6(cv, tableBits)
+			hash1 := hash6(cv>>8, tableBits)
+			candidate = int(table[hash0])
+			candidate2 := int(table[hash1])
+			table[hash0] = uint32(s)
+			table[hash1] = uint32(s + 1)
+			hash2 := hash6(cv>>16, tableBits)
+
+			// Check repeat at offset checkRep.
+			const checkRep = 1
+			if uint32(cv>>(checkRep*8)) == load32(src, s-repeat+checkRep) {
+				base := s + checkRep
+				// Extend back
+				for i := base - repeat; base > nextEmit && i > 0 && src[i-1] == src[base-1]; {
+					i--
+					base--
+				}
+				d += emitLiteral(dst[d:], src[nextEmit:base])
+
+				// Extend forward
+				candidate := s - repeat + 4 + checkRep
+				s += 4 + checkRep
+				for s <= sLimit {
+					if diff := load64(src, s) ^ load64(src, candidate); diff != 0 {
+						s += bits.TrailingZeros64(diff) >> 3
+						break
+					}
+					s += 8
+					candidate += 8
+				}
+
+				d += emitCopyNoRepeat(dst[d:], repeat, s-base)
+				nextEmit = s
+				if s >= sLimit {
+					goto emitRemainder
+				}
+
+				cv = load64(src, s)
+				continue
+			}
+
+			if uint32(cv) == load32(src, candidate) {
+				break
+			}
+			candidate = int(table[hash2])
+			if uint32(cv>>8) == load32(src, candidate2) {
+				table[hash2] = uint32(s + 2)
+				candidate = candidate2
+				s++
+				break
+			}
+			table[hash2] = uint32(s + 2)
+			if uint32(cv>>16) == load32(src, candidate) {
+				s += 2
+				break
+			}
+
+			cv = load64(src, nextS)
+			s = nextS
+		}
+
+		// Extend backwards
+		for candidate > 0 && s > nextEmit && src[candidate-1] == src[s-1] {
+			candidate--
+			s--
+		}
+
+		// Bail if we exceed the maximum size.
+		if d+(s-nextEmit) > dstLimit {
+			return 0
+		}
+
+		// A 4-byte match has been found. We'll later see if more than 4 bytes
+		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
+		// them as literal bytes.
+
+		d += emitLiteral(dst[d:], src[nextEmit:s])
+
+		// Call emitCopy, and then see if another emitCopy could be our next
+		// move. Repeat until we find no match for the input immediately after
+		// what was consumed by the last emitCopy call.
+		//
+		// If we exit this loop normally then we need to call emitLiteral next,
+		// though we don't yet know how big the literal will be. We handle that
+		// by proceeding to the next iteration of the main loop. We also can
+		// exit this loop via goto if we get close to exhausting the input.
+		for {
+			// Invariant: we have a 4-byte match at s, and no need to emit any
+			// literal bytes prior to s.
+			base := s
+			repeat = base - candidate
+
+			// Extend the 4-byte match as long as possible.
+			s += 4
+			candidate += 4
+			for s <= len(src)-8 {
+				if diff := load64(src, s) ^ load64(src, candidate); diff != 0 {
+					s += bits.TrailingZeros64(diff) >> 3
+					break
+				}
+				s += 8
+				candidate += 8
+			}
+
+			d += emitCopyNoRepeat(dst[d:], repeat, s-base)
+			if false {
+				// Validate match.
+				a := src[base:s]
+				b := src[base-repeat : base-repeat+(s-base)]
+				if !bytes.Equal(a, b) {
+					panic("mismatch")
+				}
+			}
+
+			nextEmit = s
+			if s >= sLimit {
+				goto emitRemainder
+			}
+
+			if d > dstLimit {
+				// Do we have space for more, if not bail.
+				return 0
+			}
+			// Check for an immediate match, otherwise start search at s+1
+			x := load64(src, s-2)
+			m2Hash := hash6(x, tableBits)
+			currHash := hash6(x>>16, tableBits)
+			candidate = int(table[currHash])
+			table[m2Hash] = uint32(s - 2)
+			table[currHash] = uint32(s)
+			if uint32(x>>16) != load32(src, candidate) {
+				cv = load64(src, s+1)
+				s++
+				break
+			}
+		}
+	}
+
+emitRemainder:
+	if nextEmit < len(src) {
+		// Bail if we exceed the maximum size.
+		if d+len(src)-nextEmit > dstLimit {
+			return 0
+		}
+		d += emitLiteral(dst[d:], src[nextEmit:])
+	}
+	return d
+}

--- a/s2/encode_amd64.go
+++ b/s2/encode_amd64.go
@@ -90,8 +90,11 @@ func encodeBlockSnappy(dst, src []byte) (d int) {
 		// Use 8 bit table when less than...
 		limit8B = 512
 	)
-	if len(src) >= limit12B {
+	if len(src) >= 64<<10 {
 		return encodeSnappyBlockAsm(dst, src)
+	}
+	if len(src) >= limit12B {
+		return encodeSnappyBlockAsm64K(dst, src)
 	}
 	if len(src) >= limit10B {
 		return encodeSnappyBlockAsm12B(dst, src)
@@ -103,4 +106,38 @@ func encodeBlockSnappy(dst, src []byte) (d int) {
 		return 0
 	}
 	return encodeSnappyBlockAsm8B(dst, src)
+}
+
+// encodeBlockSnappy encodes a non-empty src to a guaranteed-large-enough dst. It
+// assumes that the varint-encoded length of the decompressed bytes has already
+// been written.
+//
+// It also assumes that:
+//	len(dst) >= MaxEncodedLen(len(src)) &&
+// 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
+func encodeBlockBetterSnappy(dst, src []byte) (d int) {
+	const (
+		// Use 12 bit table when less than...
+		limit12B = 16 << 10
+		// Use 10 bit table when less than...
+		limit10B = 4 << 10
+		// Use 8 bit table when less than...
+		limit8B = 512
+	)
+	if len(src) >= 64<<10 {
+		return encodeSnappyBetterBlockAsm(dst, src)
+	}
+	if len(src) >= limit12B {
+		return encodeSnappyBetterBlockAsm64K(dst, src)
+	}
+	if len(src) >= limit10B {
+		return encodeSnappyBetterBlockAsm12B(dst, src)
+	}
+	if len(src) >= limit8B {
+		return encodeSnappyBetterBlockAsm10B(dst, src)
+	}
+	if len(src) < minNonLiteralBlockSize {
+		return 0
+	}
+	return encodeSnappyBetterBlockAsm8B(dst, src)
 }

--- a/s2/encode_best.go
+++ b/s2/encode_best.go
@@ -31,9 +31,6 @@ func encodeBlockBest(dst, src []byte) (d int) {
 		inputMargin = 8 + 2
 	)
 
-	var lTable [maxLTableSize]uint64
-	var sTable [maxSTableSize]uint64
-
 	// sLimit is when to stop looking for offset/length copies. The inputMargin
 	// lets us use a fast path for emitLiteral in the main loop, while we are
 	// looking for copies.
@@ -41,6 +38,9 @@ func encodeBlockBest(dst, src []byte) (d int) {
 	if len(src) < minNonLiteralBlockSize {
 		return 0
 	}
+
+	var lTable [maxLTableSize]uint64
+	var sTable [maxSTableSize]uint64
 
 	// Bail if we can't compress to at least this.
 	dstLimit := len(src) - 5
@@ -298,9 +298,6 @@ func encodeBlockBestSnappy(dst, src []byte) (d int) {
 		inputMargin = 8 + 2
 	)
 
-	var lTable [maxLTableSize]uint64
-	var sTable [maxSTableSize]uint64
-
 	// sLimit is when to stop looking for offset/length copies. The inputMargin
 	// lets us use a fast path for emitLiteral in the main loop, while we are
 	// looking for copies.
@@ -308,6 +305,9 @@ func encodeBlockBestSnappy(dst, src []byte) (d int) {
 	if len(src) < minNonLiteralBlockSize {
 		return 0
 	}
+
+	var lTable [maxLTableSize]uint64
+	var sTable [maxSTableSize]uint64
 
 	// Bail if we can't compress to at least this.
 	dstLimit := len(src) - 5

--- a/s2/encode_best.go
+++ b/s2/encode_best.go
@@ -277,6 +277,260 @@ emitRemainder:
 	return d
 }
 
+// encodeBlockBestSnappy encodes a non-empty src to a guaranteed-large-enough dst. It
+// assumes that the varint-encoded length of the decompressed bytes has already
+// been written.
+//
+// It also assumes that:
+//	len(dst) >= MaxEncodedLen(len(src)) &&
+// 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
+func encodeBlockBestSnappy(dst, src []byte) (d int) {
+	// Initialize the hash tables.
+	const (
+		// Long hash matches.
+		lTableBits    = 19
+		maxLTableSize = 1 << lTableBits
+
+		// Short hash matches.
+		sTableBits    = 16
+		maxSTableSize = 1 << sTableBits
+
+		inputMargin = 8 + 2
+	)
+
+	var lTable [maxLTableSize]uint64
+	var sTable [maxSTableSize]uint64
+
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := len(src) - inputMargin
+	if len(src) < minNonLiteralBlockSize {
+		return 0
+	}
+
+	// Bail if we can't compress to at least this.
+	dstLimit := len(src) - 5
+
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := 0
+
+	// The encoded form must start with a literal, as there are no previous
+	// bytes to copy, so we start looking for hash matches at s == 1.
+	s := 1
+	cv := load64(src, s)
+
+	// We search for a repeat at -1, but don't output repeats when nextEmit == 0
+	repeat := 1
+	const lowbitMask = 0xffffffff
+	getCur := func(x uint64) int {
+		return int(x & lowbitMask)
+	}
+	getPrev := func(x uint64) int {
+		return int(x >> 32)
+	}
+
+	for {
+		type match struct {
+			offset int
+			s      int
+			length int
+			score  int
+		}
+		var best match
+		for {
+			// Next src position to check
+			nextS := s + (s-nextEmit)>>8 + 1
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			hashL := hash8(cv, lTableBits)
+			hashS := hash4(cv, sTableBits)
+			candidateL := lTable[hashL]
+			candidateS := sTable[hashS]
+
+			score := func(m match) int {
+				// Matches that are longer forward are penalized since we must emit it as a literal.
+				score := m.length - m.s
+				if nextEmit == m.s {
+					// If we do not have to emit literals, we save 1 byte
+					score++
+				}
+				offset := m.s - m.offset
+
+				return score - emitCopySize(offset, m.length)
+			}
+
+			matchAt := func(offset, s int, first uint32) match {
+				if best.length != 0 && best.s-best.offset == s-offset {
+					// Don't retest if we have the same offset.
+					return match{offset: offset, s: s}
+				}
+				if load32(src, offset) != first {
+					return match{offset: offset, s: s}
+				}
+				m := match{offset: offset, s: s, length: 4 + offset}
+				s += 4
+				for s <= sLimit {
+					if diff := load64(src, s) ^ load64(src, m.length); diff != 0 {
+						m.length += bits.TrailingZeros64(diff) >> 3
+						break
+					}
+					s += 8
+					m.length += 8
+				}
+				m.length -= offset
+				m.score = score(m)
+				if m.score <= -m.s {
+					// Eliminate if no savings, we might find a better one.
+					m.length = 0
+				}
+				return m
+			}
+
+			bestOf := func(a, b match) match {
+				if b.length == 0 {
+					return a
+				}
+				if a.length == 0 {
+					return b
+				}
+				as := a.score + b.s
+				bs := b.score + a.s
+				if as >= bs {
+					return a
+				}
+				return b
+			}
+
+			best = bestOf(matchAt(getCur(candidateL), s, uint32(cv)), matchAt(getPrev(candidateL), s, uint32(cv)))
+			best = bestOf(best, matchAt(getCur(candidateS), s, uint32(cv)))
+			best = bestOf(best, matchAt(getPrev(candidateS), s, uint32(cv)))
+
+			{
+				best = bestOf(best, matchAt(s-repeat+1, s+1, uint32(cv>>8)))
+				if best.length > 0 {
+					// s+1
+					nextShort := sTable[hash4(cv>>8, sTableBits)]
+					s := s + 1
+					cv := load64(src, s)
+					nextLong := lTable[hash8(cv, lTableBits)]
+					best = bestOf(best, matchAt(getCur(nextShort), s, uint32(cv)))
+					best = bestOf(best, matchAt(getPrev(nextShort), s, uint32(cv)))
+					best = bestOf(best, matchAt(getCur(nextLong), s, uint32(cv)))
+					best = bestOf(best, matchAt(getPrev(nextLong), s, uint32(cv)))
+					// Repeat at + 2
+					best = bestOf(best, matchAt(s-repeat+1, s+1, uint32(cv>>8)))
+
+					// s+2
+					if true {
+						nextShort = sTable[hash4(cv>>8, sTableBits)]
+						s++
+						cv = load64(src, s)
+						nextLong = lTable[hash8(cv, lTableBits)]
+						best = bestOf(best, matchAt(getCur(nextShort), s, uint32(cv)))
+						best = bestOf(best, matchAt(getPrev(nextShort), s, uint32(cv)))
+						best = bestOf(best, matchAt(getCur(nextLong), s, uint32(cv)))
+						best = bestOf(best, matchAt(getPrev(nextLong), s, uint32(cv)))
+					}
+					// Search for a match at best match end, see if that is better.
+					if sAt := best.s + best.length; sAt < sLimit {
+						sBack := best.s
+						backL := best.length
+						// Load initial values
+						cv = load64(src, sBack)
+						// Search for mismatch
+						next := lTable[hash8(load64(src, sAt), lTableBits)]
+						//next := sTable[hash4(load64(src, sAt), sTableBits)]
+
+						if checkAt := getCur(next) - backL; checkAt > 0 {
+							best = bestOf(best, matchAt(checkAt, sBack, uint32(cv)))
+						}
+						if checkAt := getPrev(next) - backL; checkAt > 0 {
+							best = bestOf(best, matchAt(checkAt, sBack, uint32(cv)))
+						}
+					}
+				}
+			}
+
+			// Update table
+			lTable[hashL] = uint64(s) | candidateL<<32
+			sTable[hashS] = uint64(s) | candidateS<<32
+
+			if best.length > 0 {
+				break
+			}
+
+			cv = load64(src, nextS)
+			s = nextS
+		}
+
+		// Extend backwards, not needed for repeats...
+		s = best.s
+		if true {
+			for best.offset > 0 && s > nextEmit && src[best.offset-1] == src[s-1] {
+				best.offset--
+				best.length++
+				s--
+			}
+		}
+		if false && best.offset >= s {
+			panic(fmt.Errorf("t %d >= s %d", best.offset, s))
+		}
+		// Bail if we exceed the maximum size.
+		if d+(s-nextEmit) > dstLimit {
+			return 0
+		}
+
+		base := s
+		offset := s - best.offset
+
+		s += best.length
+
+		if offset > 65535 && s-base <= 5 {
+			// Bail if the match is equal or worse to the encoding.
+			s = best.s + 1
+			if s >= sLimit {
+				goto emitRemainder
+			}
+			cv = load64(src, s)
+			continue
+		}
+		d += emitLiteral(dst[d:], src[nextEmit:base])
+		d += emitCopyNoRepeat(dst[d:], offset, best.length)
+		repeat = offset
+
+		nextEmit = s
+		if s >= sLimit {
+			goto emitRemainder
+		}
+
+		if d > dstLimit {
+			// Do we have space for more, if not bail.
+			return 0
+		}
+		// Fill tables...
+		for i := best.s + 1; i < s; i++ {
+			cv0 := load64(src, i)
+			long0 := hash8(cv0, lTableBits)
+			short0 := hash4(cv0, sTableBits)
+			lTable[long0] = uint64(i) | lTable[long0]<<32
+			sTable[short0] = uint64(i) | sTable[short0]<<32
+		}
+		cv = load64(src, s)
+	}
+
+emitRemainder:
+	if nextEmit < len(src) {
+		// Bail if we exceed the maximum size.
+		if d+len(src)-nextEmit > dstLimit {
+			return 0
+		}
+		d += emitLiteral(dst[d:], src[nextEmit:])
+	}
+	return d
+}
+
 // emitCopySize returns the size to encode the offset+length
 //
 // It assumes that:

--- a/s2/encode_better.go
+++ b/s2/encode_better.go
@@ -238,3 +238,163 @@ emitRemainder:
 	}
 	return d
 }
+
+// encodeBlockBetterSnappyGo encodes a non-empty src to a guaranteed-large-enough dst. It
+// assumes that the varint-encoded length of the decompressed bytes has already
+// been written.
+//
+// It also assumes that:
+//	len(dst) >= MaxEncodedLen(len(src)) &&
+// 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
+func encodeBlockBetterSnappyGo(dst, src []byte) (d int) {
+	// Initialize the hash tables.
+	const (
+		// Long hash matches.
+		lTableBits    = 16
+		maxLTableSize = 1 << lTableBits
+
+		// Short hash matches.
+		sTableBits    = 14
+		maxSTableSize = 1 << sTableBits
+	)
+
+	var lTable [maxLTableSize]uint32
+	var sTable [maxSTableSize]uint32
+
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := len(src) - inputMargin
+	if len(src) < minNonLiteralBlockSize {
+		return 0
+	}
+
+	// Bail if we can't compress to at least this.
+	dstLimit := len(src) - len(src)>>5 - 6
+
+	// nextEmit is where in src the next emitLiteral should start from.
+	nextEmit := 0
+
+	// The encoded form must start with a literal, as there are no previous
+	// bytes to copy, so we start looking for hash matches at s == 1.
+	s := 1
+	cv := load64(src, s)
+
+	// We initialize repeat to 0, so we never match on first attempt
+	repeat := 0
+
+	for {
+		candidateL := 0
+		nextS := 0
+		for {
+			// Next src position to check
+			nextS = s + (s-nextEmit)>>7 + 1
+			if nextS > sLimit {
+				goto emitRemainder
+			}
+			hashL := hash7(cv, lTableBits)
+			hashS := hash4(cv, sTableBits)
+			candidateL = int(lTable[hashL])
+			candidateS := int(sTable[hashS])
+			lTable[hashL] = uint32(s)
+			sTable[hashS] = uint32(s)
+
+			if uint32(cv) == load32(src, candidateL) {
+				break
+			}
+
+			// Check our short candidate
+			if uint32(cv) == load32(src, candidateS) {
+				// Try a long candidate at s+1
+				hashL = hash7(cv>>8, lTableBits)
+				candidateL = int(lTable[hashL])
+				lTable[hashL] = uint32(s + 1)
+				if uint32(cv>>8) == load32(src, candidateL) {
+					s++
+					break
+				}
+				// Use our short candidate.
+				candidateL = candidateS
+				break
+			}
+
+			cv = load64(src, nextS)
+			s = nextS
+		}
+
+		// Extend backwards
+		for candidateL > 0 && s > nextEmit && src[candidateL-1] == src[s-1] {
+			candidateL--
+			s--
+		}
+
+		// Bail if we exceed the maximum size.
+		if d+(s-nextEmit) > dstLimit {
+			return 0
+		}
+
+		base := s
+		offset := base - candidateL
+
+		// Extend the 4-byte match as long as possible.
+		s += 4
+		candidateL += 4
+		for s <= len(src)-8 {
+			if diff := load64(src, s) ^ load64(src, candidateL); diff != 0 {
+				s += bits.TrailingZeros64(diff) >> 3
+				break
+			}
+			s += 8
+			candidateL += 8
+		}
+
+		if offset > 65535 && s-base <= 5 && repeat != offset {
+			// Bail if the match is equal or worse to the encoding.
+			s = nextS + 1
+			if s >= sLimit {
+				goto emitRemainder
+			}
+			cv = load64(src, s)
+			continue
+		}
+
+		d += emitLiteral(dst[d:], src[nextEmit:base])
+		d += emitCopyNoRepeat(dst[d:], offset, s-base)
+		repeat = offset
+
+		nextEmit = s
+		if s >= sLimit {
+			goto emitRemainder
+		}
+
+		if d > dstLimit {
+			// Do we have space for more, if not bail.
+			return 0
+		}
+		// Index match start+1 (long) and start+2 (short)
+		index0 := base + 1
+		// Index match end-2 (long) and end-1 (short)
+		index1 := s - 2
+
+		cv0 := load64(src, index0)
+		cv1 := load64(src, index1)
+		cv = load64(src, s)
+		lTable[hash7(cv0, lTableBits)] = uint32(index0)
+		lTable[hash7(cv0>>8, lTableBits)] = uint32(index0 + 1)
+		lTable[hash7(cv1, lTableBits)] = uint32(index1)
+		lTable[hash7(cv1>>8, lTableBits)] = uint32(index1 + 1)
+		sTable[hash4(cv0>>8, sTableBits)] = uint32(index0 + 1)
+		sTable[hash4(cv0>>16, sTableBits)] = uint32(index0 + 2)
+		sTable[hash4(cv1>>8, sTableBits)] = uint32(index1 + 1)
+	}
+
+emitRemainder:
+	if nextEmit < len(src) {
+		// Bail if we exceed the maximum size.
+		if d+len(src)-nextEmit > dstLimit {
+			return 0
+		}
+		d += emitLiteral(dst[d:], src[nextEmit:])
+	}
+	return d
+}

--- a/s2/encode_better.go
+++ b/s2/encode_better.go
@@ -45,6 +45,14 @@ func hash8(u uint64, h uint8) uint32 {
 //	len(dst) >= MaxEncodedLen(len(src)) &&
 // 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlockBetterGo(dst, src []byte) (d int) {
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := len(src) - inputMargin
+	if len(src) < minNonLiteralBlockSize {
+		return 0
+	}
+
 	// Initialize the hash tables.
 	const (
 		// Long hash matches.
@@ -58,14 +66,6 @@ func encodeBlockBetterGo(dst, src []byte) (d int) {
 
 	var lTable [maxLTableSize]uint32
 	var sTable [maxSTableSize]uint32
-
-	// sLimit is when to stop looking for offset/length copies. The inputMargin
-	// lets us use a fast path for emitLiteral in the main loop, while we are
-	// looking for copies.
-	sLimit := len(src) - inputMargin
-	if len(src) < minNonLiteralBlockSize {
-		return 0
-	}
 
 	// Bail if we can't compress to at least this.
 	dstLimit := len(src) - len(src)>>5 - 6
@@ -247,6 +247,14 @@ emitRemainder:
 //	len(dst) >= MaxEncodedLen(len(src)) &&
 // 	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlockBetterSnappyGo(dst, src []byte) (d int) {
+	// sLimit is when to stop looking for offset/length copies. The inputMargin
+	// lets us use a fast path for emitLiteral in the main loop, while we are
+	// looking for copies.
+	sLimit := len(src) - inputMargin
+	if len(src) < minNonLiteralBlockSize {
+		return 0
+	}
+
 	// Initialize the hash tables.
 	const (
 		// Long hash matches.
@@ -260,14 +268,6 @@ func encodeBlockBetterSnappyGo(dst, src []byte) (d int) {
 
 	var lTable [maxLTableSize]uint32
 	var sTable [maxSTableSize]uint32
-
-	// sLimit is when to stop looking for offset/length copies. The inputMargin
-	// lets us use a fast path for emitLiteral in the main loop, while we are
-	// looking for copies.
-	sLimit := len(src) - inputMargin
-	if len(src) < minNonLiteralBlockSize {
-		return 0
-	}
 
 	// Bail if we can't compress to at least this.
 	dstLimit := len(src) - len(src)>>5 - 6

--- a/s2/encode_go.go
+++ b/s2/encode_go.go
@@ -3,7 +3,6 @@
 package s2
 
 import (
-	"bytes"
 	"math/bits"
 )
 
@@ -38,6 +37,19 @@ func encodeBlockBetter(dst, src []byte) (d int) {
 //	len(dst) >= MaxEncodedLen(len(src))
 func encodeBlockBetterSnappy(dst, src []byte) (d int) {
 	return encodeBlockBetterSnappyGo(dst, src)
+}
+
+// encodeBlock encodes a non-empty src to a guaranteed-large-enough dst. It
+// assumes that the varint-encoded length of the decompressed bytes has already
+// been written.
+//
+// It also assumes that:
+//	len(dst) >= MaxEncodedLen(len(src))
+func encodeBlockSnappy(dst, src []byte) (d int) {
+	if len(src) < minNonLiteralBlockSize {
+		return 0
+	}
+	return encodeBlockSnappyGo(dst, src)
 }
 
 // emitLiteral writes a literal chunk and returns the number of bytes written.
@@ -282,189 +294,4 @@ func matchLen(a []byte, b []byte) int {
 		}
 	}
 	return len(a) + checked
-}
-
-func encodeBlockSnappy(dst, src []byte) (d int) {
-	// Initialize the hash table.
-	const (
-		tableBits    = 14
-		maxTableSize = 1 << tableBits
-	)
-
-	var table [maxTableSize]uint32
-
-	// sLimit is when to stop looking for offset/length copies. The inputMargin
-	// lets us use a fast path for emitLiteral in the main loop, while we are
-	// looking for copies.
-	sLimit := len(src) - inputMargin
-
-	// Bail if we can't compress to at least this.
-	dstLimit := len(src) - len(src)>>5 - 5
-
-	// nextEmit is where in src the next emitLiteral should start from.
-	nextEmit := 0
-
-	// The encoded form must start with a literal, as there are no previous
-	// bytes to copy, so we start looking for hash matches at s == 1.
-	s := 1
-	cv := load64(src, s)
-
-	// We search for a repeat at -1, but don't output repeats when nextEmit == 0
-	repeat := 1
-
-	for {
-		candidate := 0
-		for {
-			// Next src position to check
-			nextS := s + (s-nextEmit)>>6 + 4
-			if nextS > sLimit {
-				goto emitRemainder
-			}
-			hash0 := hash6(cv, tableBits)
-			hash1 := hash6(cv>>8, tableBits)
-			candidate = int(table[hash0])
-			candidate2 := int(table[hash1])
-			table[hash0] = uint32(s)
-			table[hash1] = uint32(s + 1)
-			hash2 := hash6(cv>>16, tableBits)
-
-			// Check repeat at offset checkRep.
-			const checkRep = 1
-			if uint32(cv>>(checkRep*8)) == load32(src, s-repeat+checkRep) {
-				base := s + checkRep
-				// Extend back
-				for i := base - repeat; base > nextEmit && i > 0 && src[i-1] == src[base-1]; {
-					i--
-					base--
-				}
-				d += emitLiteral(dst[d:], src[nextEmit:base])
-
-				// Extend forward
-				candidate := s - repeat + 4 + checkRep
-				s += 4 + checkRep
-				for s <= sLimit {
-					if diff := load64(src, s) ^ load64(src, candidate); diff != 0 {
-						s += bits.TrailingZeros64(diff) >> 3
-						break
-					}
-					s += 8
-					candidate += 8
-				}
-
-				d += emitCopyNoRepeat(dst[d:], repeat, s-base)
-				nextEmit = s
-				if s >= sLimit {
-					goto emitRemainder
-				}
-
-				cv = load64(src, s)
-				continue
-			}
-
-			if uint32(cv) == load32(src, candidate) {
-				break
-			}
-			candidate = int(table[hash2])
-			if uint32(cv>>8) == load32(src, candidate2) {
-				table[hash2] = uint32(s + 2)
-				candidate = candidate2
-				s++
-				break
-			}
-			table[hash2] = uint32(s + 2)
-			if uint32(cv>>16) == load32(src, candidate) {
-				s += 2
-				break
-			}
-
-			cv = load64(src, nextS)
-			s = nextS
-		}
-
-		// Extend backwards
-		for candidate > 0 && s > nextEmit && src[candidate-1] == src[s-1] {
-			candidate--
-			s--
-		}
-
-		// Bail if we exceed the maximum size.
-		if d+(s-nextEmit) > dstLimit {
-			return 0
-		}
-
-		// A 4-byte match has been found. We'll later see if more than 4 bytes
-		// match. But, prior to the match, src[nextEmit:s] are unmatched. Emit
-		// them as literal bytes.
-
-		d += emitLiteral(dst[d:], src[nextEmit:s])
-
-		// Call emitCopy, and then see if another emitCopy could be our next
-		// move. Repeat until we find no match for the input immediately after
-		// what was consumed by the last emitCopy call.
-		//
-		// If we exit this loop normally then we need to call emitLiteral next,
-		// though we don't yet know how big the literal will be. We handle that
-		// by proceeding to the next iteration of the main loop. We also can
-		// exit this loop via goto if we get close to exhausting the input.
-		for {
-			// Invariant: we have a 4-byte match at s, and no need to emit any
-			// literal bytes prior to s.
-			base := s
-			repeat = base - candidate
-
-			// Extend the 4-byte match as long as possible.
-			s += 4
-			candidate += 4
-			for s <= len(src)-8 {
-				if diff := load64(src, s) ^ load64(src, candidate); diff != 0 {
-					s += bits.TrailingZeros64(diff) >> 3
-					break
-				}
-				s += 8
-				candidate += 8
-			}
-
-			d += emitCopyNoRepeat(dst[d:], repeat, s-base)
-			if false {
-				// Validate match.
-				a := src[base:s]
-				b := src[base-repeat : base-repeat+(s-base)]
-				if !bytes.Equal(a, b) {
-					panic("mismatch")
-				}
-			}
-
-			nextEmit = s
-			if s >= sLimit {
-				goto emitRemainder
-			}
-
-			if d > dstLimit {
-				// Do we have space for more, if not bail.
-				return 0
-			}
-			// Check for an immediate match, otherwise start search at s+1
-			x := load64(src, s-2)
-			m2Hash := hash6(x, tableBits)
-			currHash := hash6(x>>16, tableBits)
-			candidate = int(table[currHash])
-			table[m2Hash] = uint32(s - 2)
-			table[currHash] = uint32(s)
-			if uint32(x>>16) != load32(src, candidate) {
-				cv = load64(src, s+1)
-				s++
-				break
-			}
-		}
-	}
-
-emitRemainder:
-	if nextEmit < len(src) {
-		// Bail if we exceed the maximum size.
-		if d+len(src)-nextEmit > dstLimit {
-			return 0
-		}
-		d += emitLiteral(dst[d:], src[nextEmit:])
-	}
-	return d
 }

--- a/s2/encode_go.go
+++ b/s2/encode_go.go
@@ -30,6 +30,16 @@ func encodeBlockBetter(dst, src []byte) (d int) {
 	return encodeBlockBetterGo(dst, src)
 }
 
+// encodeBlockBetter encodes a non-empty src to a guaranteed-large-enough dst. It
+// assumes that the varint-encoded length of the decompressed bytes has already
+// been written.
+//
+// It also assumes that:
+//	len(dst) >= MaxEncodedLen(len(src))
+func encodeBlockBetterSnappy(dst, src []byte) (d int) {
+	return encodeBlockBetterSnappyGo(dst, src)
+}
+
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 //
 // It assumes that:

--- a/s2/encodeblock_amd64.go
+++ b/s2/encodeblock_amd64.go
@@ -83,6 +83,13 @@ func encodeBetterBlockAsm8B(dst []byte, src []byte) int
 //go:noescape
 func encodeSnappyBlockAsm(dst []byte, src []byte) int
 
+// encodeSnappyBlockAsm64K encodes a non-empty src to a guaranteed-large-enough dst.
+// Maximum input 65535 bytes.
+// It assumes that the varint-encoded length of the decompressed bytes has already been written.
+//
+//go:noescape
+func encodeSnappyBlockAsm64K(dst []byte, src []byte) int
+
 // encodeSnappyBlockAsm12B encodes a non-empty src to a guaranteed-large-enough dst.
 // Maximum input 16383 bytes.
 // It assumes that the varint-encoded length of the decompressed bytes has already been written.
@@ -103,6 +110,41 @@ func encodeSnappyBlockAsm10B(dst []byte, src []byte) int
 //
 //go:noescape
 func encodeSnappyBlockAsm8B(dst []byte, src []byte) int
+
+// encodeSnappyBetterBlockAsm encodes a non-empty src to a guaranteed-large-enough dst.
+// Maximum input 4294967295 bytes.
+// It assumes that the varint-encoded length of the decompressed bytes has already been written.
+//
+//go:noescape
+func encodeSnappyBetterBlockAsm(dst []byte, src []byte) int
+
+// encodeSnappyBetterBlockAsm64K encodes a non-empty src to a guaranteed-large-enough dst.
+// Maximum input 65535 bytes.
+// It assumes that the varint-encoded length of the decompressed bytes has already been written.
+//
+//go:noescape
+func encodeSnappyBetterBlockAsm64K(dst []byte, src []byte) int
+
+// encodeSnappyBetterBlockAsm12B encodes a non-empty src to a guaranteed-large-enough dst.
+// Maximum input 16383 bytes.
+// It assumes that the varint-encoded length of the decompressed bytes has already been written.
+//
+//go:noescape
+func encodeSnappyBetterBlockAsm12B(dst []byte, src []byte) int
+
+// encodeSnappyBetterBlockAsm10B encodes a non-empty src to a guaranteed-large-enough dst.
+// Maximum input 4095 bytes.
+// It assumes that the varint-encoded length of the decompressed bytes has already been written.
+//
+//go:noescape
+func encodeSnappyBetterBlockAsm10B(dst []byte, src []byte) int
+
+// encodeSnappyBetterBlockAsm8B encodes a non-empty src to a guaranteed-large-enough dst.
+// Maximum input 511 bytes.
+// It assumes that the varint-encoded length of the decompressed bytes has already been written.
+//
+//go:noescape
+func encodeSnappyBetterBlockAsm8B(dst []byte, src []byte) int
 
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 //

--- a/s2/encodeblock_amd64.s
+++ b/s2/encodeblock_amd64.s
@@ -10135,6 +10135,775 @@ emit_literal_done_emit_remainder_encodeSnappyBlockAsm:
 	MOVQ AX, ret+48(FP)
 	RET
 
+// func encodeSnappyBlockAsm64K(dst []byte, src []byte) int
+// Requires: SSE2
+TEXT ·encodeSnappyBlockAsm64K(SB), $65560-56
+	MOVQ dst_base+0(FP), AX
+	MOVQ $0x00000200, CX
+	LEAQ 24(SP), DX
+	PXOR X0, X0
+
+zero_loop_encodeSnappyBlockAsm64K:
+	MOVOU X0, (DX)
+	MOVOU X0, 16(DX)
+	MOVOU X0, 32(DX)
+	MOVOU X0, 48(DX)
+	MOVOU X0, 64(DX)
+	MOVOU X0, 80(DX)
+	MOVOU X0, 96(DX)
+	MOVOU X0, 112(DX)
+	ADDQ  $0x80, DX
+	DECQ  CX
+	JNZ   zero_loop_encodeSnappyBlockAsm64K
+	MOVL  $0x00000000, 12(SP)
+	MOVQ  src_len+32(FP), CX
+	LEAQ  -5(CX), DX
+	LEAQ  -8(CX), SI
+	MOVL  SI, 8(SP)
+	SHRQ  $0x05, CX
+	SUBL  CX, DX
+	LEAQ  (AX)(DX*1), DX
+	MOVQ  DX, (SP)
+	MOVL  $0x00000001, CX
+	MOVL  CX, 16(SP)
+	MOVQ  src_base+24(FP), DX
+
+search_loop_encodeSnappyBlockAsm64K:
+	MOVL  CX, SI
+	SUBL  12(SP), SI
+	SHRL  $0x06, SI
+	LEAL  4(CX)(SI*1), SI
+	CMPL  SI, 8(SP)
+	JGE   emit_remainder_encodeSnappyBlockAsm64K
+	MOVQ  (DX)(CX*1), DI
+	MOVL  SI, 20(SP)
+	MOVQ  $0x0000cf1bbcdcbf9b, R9
+	MOVQ  DI, R10
+	MOVQ  DI, R11
+	SHRQ  $0x08, R11
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x32, R10
+	SHLQ  $0x10, R11
+	IMULQ R9, R11
+	SHRQ  $0x32, R11
+	MOVL  24(SP)(R10*4), SI
+	MOVL  24(SP)(R11*4), R8
+	MOVL  CX, 24(SP)(R10*4)
+	LEAL  1(CX), R10
+	MOVL  R10, 24(SP)(R11*4)
+	MOVQ  DI, R10
+	SHRQ  $0x10, R10
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x32, R10
+	MOVL  CX, R9
+	SUBL  16(SP), R9
+	MOVL  1(DX)(R9*1), R11
+	MOVQ  DI, R9
+	SHRQ  $0x08, R9
+	CMPL  R9, R11
+	JNE   no_repeat_found_encodeSnappyBlockAsm64K
+	LEAL  1(CX), DI
+	MOVL  12(SP), SI
+	MOVL  DI, R8
+	SUBL  16(SP), R8
+	JZ    repeat_extend_back_end_encodeSnappyBlockAsm64K
+
+repeat_extend_back_loop_encodeSnappyBlockAsm64K:
+	CMPL DI, SI
+	JLE  repeat_extend_back_end_encodeSnappyBlockAsm64K
+	MOVB -1(DX)(R8*1), BL
+	MOVB -1(DX)(DI*1), R9
+	CMPB BL, R9
+	JNE  repeat_extend_back_end_encodeSnappyBlockAsm64K
+	LEAL -1(DI), DI
+	DECL R8
+	JNZ  repeat_extend_back_loop_encodeSnappyBlockAsm64K
+
+repeat_extend_back_end_encodeSnappyBlockAsm64K:
+	MOVL 12(SP), SI
+	CMPL SI, DI
+	JEQ  emit_literal_done_repeat_emit_encodeSnappyBlockAsm64K
+	MOVL DI, R8
+	MOVL DI, 12(SP)
+	LEAQ (DX)(SI*1), R9
+	SUBL SI, R8
+	LEAL -1(R8), SI
+	CMPL SI, $0x3c
+	JLT  one_byte_repeat_emit_encodeSnappyBlockAsm64K
+	CMPL SI, $0x00000100
+	JLT  two_bytes_repeat_emit_encodeSnappyBlockAsm64K
+	MOVB $0xf4, (AX)
+	MOVW SI, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_repeat_emit_encodeSnappyBlockAsm64K
+
+two_bytes_repeat_emit_encodeSnappyBlockAsm64K:
+	MOVB $0xf0, (AX)
+	MOVB SI, 1(AX)
+	ADDQ $0x02, AX
+	CMPL SI, $0x40
+	JL   memmove_repeat_emit_encodeSnappyBlockAsm64K
+	JMP  memmove_long_repeat_emit_encodeSnappyBlockAsm64K
+
+one_byte_repeat_emit_encodeSnappyBlockAsm64K:
+	SHLB $0x02, SI
+	MOVB SI, (AX)
+	ADDQ $0x01, AX
+
+memmove_repeat_emit_encodeSnappyBlockAsm64K:
+	LEAQ (AX)(R8*1), SI
+
+	// genMemMoveShort
+	CMPQ R8, $0x03
+	JB   emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_1or2
+	JE   emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_3
+	CMPQ R8, $0x08
+	JB   emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_4through7
+	CMPQ R8, $0x10
+	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_8through16
+	CMPQ R8, $0x20
+	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_17through32
+	JMP  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_33through64
+
+emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_1or2:
+	MOVB (R9), R10
+	MOVB -1(R9)(R8*1), R9
+	MOVB R10, (AX)
+	MOVB R9, -1(AX)(R8*1)
+	JMP  memmove_end_copy_repeat_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_3:
+	MOVW (R9), R10
+	MOVB 2(R9), R9
+	MOVW R10, (AX)
+	MOVB R9, 2(AX)
+	JMP  memmove_end_copy_repeat_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_4through7:
+	MOVL (R9), R10
+	MOVL -4(R9)(R8*1), R9
+	MOVL R10, (AX)
+	MOVL R9, -4(AX)(R8*1)
+	JMP  memmove_end_copy_repeat_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_8through16:
+	MOVQ (R9), R10
+	MOVQ -8(R9)(R8*1), R9
+	MOVQ R10, (AX)
+	MOVQ R9, -8(AX)(R8*1)
+	JMP  memmove_end_copy_repeat_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_17through32:
+	MOVOU (R9), X0
+	MOVOU -16(R9)(R8*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(R8*1)
+	JMP   memmove_end_copy_repeat_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_33through64:
+	MOVOU (R9), X0
+	MOVOU 16(R9), X1
+	MOVOU -32(R9)(R8*1), X2
+	MOVOU -16(R9)(R8*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R8*1)
+	MOVOU X3, -16(AX)(R8*1)
+
+memmove_end_copy_repeat_emit_encodeSnappyBlockAsm64K:
+	MOVQ SI, AX
+	JMP  emit_literal_done_repeat_emit_encodeSnappyBlockAsm64K
+
+memmove_long_repeat_emit_encodeSnappyBlockAsm64K:
+	LEAQ (AX)(R8*1), SI
+
+	// genMemMoveLong
+	MOVOU (R9), X0
+	MOVOU 16(R9), X1
+	MOVOU -32(R9)(R8*1), X2
+	MOVOU -16(R9)(R8*1), X3
+	MOVQ  R8, R11
+	SHRQ  $0x05, R11
+	MOVQ  AX, R10
+	ANDL  $0x0000001f, R10
+	MOVQ  $0x00000040, R12
+	SUBQ  R10, R12
+	DECQ  R11
+	JA    emit_lit_memmove_long_repeat_emit_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32
+	LEAQ  -32(R9)(R12*1), R10
+	LEAQ  -32(AX)(R12*1), R13
+
+emit_lit_memmove_long_repeat_emit_encodeSnappyBlockAsm64Klarge_big_loop_back:
+	MOVOU (R10), X4
+	MOVOU 16(R10), X5
+	MOVOA X4, (R13)
+	MOVOA X5, 16(R13)
+	ADDQ  $0x20, R13
+	ADDQ  $0x20, R10
+	ADDQ  $0x20, R12
+	DECQ  R11
+	JNA   emit_lit_memmove_long_repeat_emit_encodeSnappyBlockAsm64Klarge_big_loop_back
+
+emit_lit_memmove_long_repeat_emit_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32:
+	MOVOU -32(R9)(R12*1), X4
+	MOVOU -16(R9)(R12*1), X5
+	MOVOA X4, -32(AX)(R12*1)
+	MOVOA X5, -16(AX)(R12*1)
+	ADDQ  $0x20, R12
+	CMPQ  R8, R12
+	JAE   emit_lit_memmove_long_repeat_emit_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R8*1)
+	MOVOU X3, -16(AX)(R8*1)
+	MOVQ  SI, AX
+
+emit_literal_done_repeat_emit_encodeSnappyBlockAsm64K:
+	ADDL $0x05, CX
+	MOVL CX, SI
+	SUBL 16(SP), SI
+	MOVQ src_len+32(FP), R8
+	SUBL CX, R8
+	LEAQ (DX)(CX*1), R9
+	LEAQ (DX)(SI*1), SI
+
+	// matchLen
+	XORL R11, R11
+	CMPL R8, $0x08
+	JL   matchlen_single_repeat_extend_encodeSnappyBlockAsm64K
+
+matchlen_loopback_repeat_extend_encodeSnappyBlockAsm64K:
+	MOVQ  (R9)(R11*1), R10
+	XORQ  (SI)(R11*1), R10
+	TESTQ R10, R10
+	JZ    matchlen_loop_repeat_extend_encodeSnappyBlockAsm64K
+	BSFQ  R10, R10
+	SARQ  $0x03, R10
+	LEAL  (R11)(R10*1), R11
+	JMP   repeat_extend_forward_end_encodeSnappyBlockAsm64K
+
+matchlen_loop_repeat_extend_encodeSnappyBlockAsm64K:
+	LEAL -8(R8), R8
+	LEAL 8(R11), R11
+	CMPL R8, $0x08
+	JGE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm64K
+
+matchlen_single_repeat_extend_encodeSnappyBlockAsm64K:
+	TESTL R8, R8
+	JZ    repeat_extend_forward_end_encodeSnappyBlockAsm64K
+
+matchlen_single_loopback_repeat_extend_encodeSnappyBlockAsm64K:
+	MOVB (R9)(R11*1), R10
+	CMPB (SI)(R11*1), R10
+	JNE  repeat_extend_forward_end_encodeSnappyBlockAsm64K
+	LEAL 1(R11), R11
+	DECL R8
+	JNZ  matchlen_single_loopback_repeat_extend_encodeSnappyBlockAsm64K
+
+repeat_extend_forward_end_encodeSnappyBlockAsm64K:
+	ADDL R11, CX
+	MOVL CX, SI
+	SUBL DI, SI
+	MOVL 16(SP), DI
+
+	// emitCopy
+two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm64K:
+	CMPL SI, $0x40
+	JLE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm64K
+	MOVB $0xee, (AX)
+	MOVW DI, 1(AX)
+	LEAL -60(SI), SI
+	ADDQ $0x03, AX
+	JMP  two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm64K
+
+two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm64K:
+	CMPL SI, $0x0c
+	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm64K
+	CMPL DI, $0x00000800
+	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm64K
+	MOVB $0x01, BL
+	LEAL -16(BX)(SI*4), SI
+	MOVB DI, 1(AX)
+	SHRL $0x08, DI
+	SHLL $0x05, DI
+	ORL  DI, SI
+	MOVB SI, (AX)
+	ADDQ $0x02, AX
+	JMP  repeat_end_emit_encodeSnappyBlockAsm64K
+
+emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm64K:
+	MOVB $0x02, BL
+	LEAL -4(BX)(SI*4), SI
+	MOVB SI, (AX)
+	MOVW DI, 1(AX)
+	ADDQ $0x03, AX
+
+repeat_end_emit_encodeSnappyBlockAsm64K:
+	MOVL CX, 12(SP)
+	JMP  search_loop_encodeSnappyBlockAsm64K
+
+no_repeat_found_encodeSnappyBlockAsm64K:
+	CMPL (DX)(SI*1), DI
+	JEQ  candidate_match_encodeSnappyBlockAsm64K
+	SHRQ $0x08, DI
+	MOVL 24(SP)(R10*4), SI
+	LEAL 2(CX), R9
+	CMPL (DX)(R8*1), DI
+	JEQ  candidate2_match_encodeSnappyBlockAsm64K
+	MOVL R9, 24(SP)(R10*4)
+	SHRQ $0x08, DI
+	CMPL (DX)(SI*1), DI
+	JEQ  candidate3_match_encodeSnappyBlockAsm64K
+	MOVL 20(SP), CX
+	JMP  search_loop_encodeSnappyBlockAsm64K
+
+candidate3_match_encodeSnappyBlockAsm64K:
+	ADDL $0x02, CX
+	JMP  candidate_match_encodeSnappyBlockAsm64K
+
+candidate2_match_encodeSnappyBlockAsm64K:
+	MOVL R9, 24(SP)(R10*4)
+	INCL CX
+	MOVL R8, SI
+
+candidate_match_encodeSnappyBlockAsm64K:
+	MOVL  12(SP), DI
+	TESTL SI, SI
+	JZ    match_extend_back_end_encodeSnappyBlockAsm64K
+
+match_extend_back_loop_encodeSnappyBlockAsm64K:
+	CMPL CX, DI
+	JLE  match_extend_back_end_encodeSnappyBlockAsm64K
+	MOVB -1(DX)(SI*1), BL
+	MOVB -1(DX)(CX*1), R8
+	CMPB BL, R8
+	JNE  match_extend_back_end_encodeSnappyBlockAsm64K
+	LEAL -1(CX), CX
+	DECL SI
+	JZ   match_extend_back_end_encodeSnappyBlockAsm64K
+	JMP  match_extend_back_loop_encodeSnappyBlockAsm64K
+
+match_extend_back_end_encodeSnappyBlockAsm64K:
+	MOVL CX, DI
+	SUBL 12(SP), DI
+	LEAQ 3(AX)(DI*1), DI
+	CMPQ DI, (SP)
+	JL   match_dst_size_check_encodeSnappyBlockAsm64K
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_dst_size_check_encodeSnappyBlockAsm64K:
+	MOVL CX, DI
+	MOVL 12(SP), R8
+	CMPL R8, DI
+	JEQ  emit_literal_done_match_emit_encodeSnappyBlockAsm64K
+	MOVL DI, R9
+	MOVL DI, 12(SP)
+	LEAQ (DX)(R8*1), DI
+	SUBL R8, R9
+	LEAL -1(R9), R8
+	CMPL R8, $0x3c
+	JLT  one_byte_match_emit_encodeSnappyBlockAsm64K
+	CMPL R8, $0x00000100
+	JLT  two_bytes_match_emit_encodeSnappyBlockAsm64K
+	MOVB $0xf4, (AX)
+	MOVW R8, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_match_emit_encodeSnappyBlockAsm64K
+
+two_bytes_match_emit_encodeSnappyBlockAsm64K:
+	MOVB $0xf0, (AX)
+	MOVB R8, 1(AX)
+	ADDQ $0x02, AX
+	CMPL R8, $0x40
+	JL   memmove_match_emit_encodeSnappyBlockAsm64K
+	JMP  memmove_long_match_emit_encodeSnappyBlockAsm64K
+
+one_byte_match_emit_encodeSnappyBlockAsm64K:
+	SHLB $0x02, R8
+	MOVB R8, (AX)
+	ADDQ $0x01, AX
+
+memmove_match_emit_encodeSnappyBlockAsm64K:
+	LEAQ (AX)(R9*1), R8
+
+	// genMemMoveShort
+	CMPQ R9, $0x03
+	JB   emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_1or2
+	JE   emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_3
+	CMPQ R9, $0x08
+	JB   emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_4through7
+	CMPQ R9, $0x10
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_8through16
+	CMPQ R9, $0x20
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_17through32
+	JMP  emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_33through64
+
+emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_1or2:
+	MOVB (DI), R10
+	MOVB -1(DI)(R9*1), DI
+	MOVB R10, (AX)
+	MOVB DI, -1(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_3:
+	MOVW (DI), R10
+	MOVB 2(DI), DI
+	MOVW R10, (AX)
+	MOVB DI, 2(AX)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_4through7:
+	MOVL (DI), R10
+	MOVL -4(DI)(R9*1), DI
+	MOVL R10, (AX)
+	MOVL DI, -4(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_8through16:
+	MOVQ (DI), R10
+	MOVQ -8(DI)(R9*1), DI
+	MOVQ R10, (AX)
+	MOVQ DI, -8(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_17through32:
+	MOVOU (DI), X0
+	MOVOU -16(DI)(R9*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(R9*1)
+	JMP   memmove_end_copy_match_emit_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_33through64:
+	MOVOU (DI), X0
+	MOVOU 16(DI), X1
+	MOVOU -32(DI)(R9*1), X2
+	MOVOU -16(DI)(R9*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+
+memmove_end_copy_match_emit_encodeSnappyBlockAsm64K:
+	MOVQ R8, AX
+	JMP  emit_literal_done_match_emit_encodeSnappyBlockAsm64K
+
+memmove_long_match_emit_encodeSnappyBlockAsm64K:
+	LEAQ (AX)(R9*1), R8
+
+	// genMemMoveLong
+	MOVOU (DI), X0
+	MOVOU 16(DI), X1
+	MOVOU -32(DI)(R9*1), X2
+	MOVOU -16(DI)(R9*1), X3
+	MOVQ  R9, R11
+	SHRQ  $0x05, R11
+	MOVQ  AX, R10
+	ANDL  $0x0000001f, R10
+	MOVQ  $0x00000040, R12
+	SUBQ  R10, R12
+	DECQ  R11
+	JA    emit_lit_memmove_long_match_emit_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32
+	LEAQ  -32(DI)(R12*1), R10
+	LEAQ  -32(AX)(R12*1), R13
+
+emit_lit_memmove_long_match_emit_encodeSnappyBlockAsm64Klarge_big_loop_back:
+	MOVOU (R10), X4
+	MOVOU 16(R10), X5
+	MOVOA X4, (R13)
+	MOVOA X5, 16(R13)
+	ADDQ  $0x20, R13
+	ADDQ  $0x20, R10
+	ADDQ  $0x20, R12
+	DECQ  R11
+	JNA   emit_lit_memmove_long_match_emit_encodeSnappyBlockAsm64Klarge_big_loop_back
+
+emit_lit_memmove_long_match_emit_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32:
+	MOVOU -32(DI)(R12*1), X4
+	MOVOU -16(DI)(R12*1), X5
+	MOVOA X4, -32(AX)(R12*1)
+	MOVOA X5, -16(AX)(R12*1)
+	ADDQ  $0x20, R12
+	CMPQ  R9, R12
+	JAE   emit_lit_memmove_long_match_emit_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+	MOVQ  R8, AX
+
+emit_literal_done_match_emit_encodeSnappyBlockAsm64K:
+match_nolit_loop_encodeSnappyBlockAsm64K:
+	MOVL CX, DI
+	SUBL SI, DI
+	MOVL DI, 16(SP)
+	ADDL $0x04, CX
+	ADDL $0x04, SI
+	MOVQ src_len+32(FP), DI
+	SUBL CX, DI
+	LEAQ (DX)(CX*1), R8
+	LEAQ (DX)(SI*1), SI
+
+	// matchLen
+	XORL R10, R10
+	CMPL DI, $0x08
+	JL   matchlen_single_match_nolit_encodeSnappyBlockAsm64K
+
+matchlen_loopback_match_nolit_encodeSnappyBlockAsm64K:
+	MOVQ  (R8)(R10*1), R9
+	XORQ  (SI)(R10*1), R9
+	TESTQ R9, R9
+	JZ    matchlen_loop_match_nolit_encodeSnappyBlockAsm64K
+	BSFQ  R9, R9
+	SARQ  $0x03, R9
+	LEAL  (R10)(R9*1), R10
+	JMP   match_nolit_end_encodeSnappyBlockAsm64K
+
+matchlen_loop_match_nolit_encodeSnappyBlockAsm64K:
+	LEAL -8(DI), DI
+	LEAL 8(R10), R10
+	CMPL DI, $0x08
+	JGE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm64K
+
+matchlen_single_match_nolit_encodeSnappyBlockAsm64K:
+	TESTL DI, DI
+	JZ    match_nolit_end_encodeSnappyBlockAsm64K
+
+matchlen_single_loopback_match_nolit_encodeSnappyBlockAsm64K:
+	MOVB (R8)(R10*1), R9
+	CMPB (SI)(R10*1), R9
+	JNE  match_nolit_end_encodeSnappyBlockAsm64K
+	LEAL 1(R10), R10
+	DECL DI
+	JNZ  matchlen_single_loopback_match_nolit_encodeSnappyBlockAsm64K
+
+match_nolit_end_encodeSnappyBlockAsm64K:
+	ADDL R10, CX
+	MOVL 16(SP), SI
+	ADDL $0x04, R10
+	MOVL CX, 12(SP)
+
+	// emitCopy
+two_byte_offset_match_nolit_encodeSnappyBlockAsm64K:
+	CMPL R10, $0x40
+	JLE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm64K
+	MOVB $0xee, (AX)
+	MOVW SI, 1(AX)
+	LEAL -60(R10), R10
+	ADDQ $0x03, AX
+	JMP  two_byte_offset_match_nolit_encodeSnappyBlockAsm64K
+
+two_byte_offset_short_match_nolit_encodeSnappyBlockAsm64K:
+	CMPL R10, $0x0c
+	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm64K
+	CMPL SI, $0x00000800
+	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm64K
+	MOVB $0x01, BL
+	LEAL -16(BX)(R10*4), R10
+	MOVB SI, 1(AX)
+	SHRL $0x08, SI
+	SHLL $0x05, SI
+	ORL  SI, R10
+	MOVB R10, (AX)
+	ADDQ $0x02, AX
+	JMP  match_nolit_emitcopy_end_encodeSnappyBlockAsm64K
+
+emit_copy_three_match_nolit_encodeSnappyBlockAsm64K:
+	MOVB $0x02, BL
+	LEAL -4(BX)(R10*4), R10
+	MOVB R10, (AX)
+	MOVW SI, 1(AX)
+	ADDQ $0x03, AX
+
+match_nolit_emitcopy_end_encodeSnappyBlockAsm64K:
+	CMPL CX, 8(SP)
+	JGE  emit_remainder_encodeSnappyBlockAsm64K
+	MOVQ -2(DX)(CX*1), DI
+	CMPQ AX, (SP)
+	JL   match_nolit_dst_ok_encodeSnappyBlockAsm64K
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_nolit_dst_ok_encodeSnappyBlockAsm64K:
+	MOVQ  $0x0000cf1bbcdcbf9b, R9
+	MOVQ  DI, R8
+	SHRQ  $0x10, DI
+	MOVQ  DI, SI
+	SHLQ  $0x10, R8
+	IMULQ R9, R8
+	SHRQ  $0x32, R8
+	SHLQ  $0x10, SI
+	IMULQ R9, SI
+	SHRQ  $0x32, SI
+	LEAL  -2(CX), R9
+	LEAQ  24(SP)(SI*4), R10
+	MOVL  (R10), SI
+	MOVL  R9, 24(SP)(R8*4)
+	MOVL  CX, (R10)
+	CMPL  (DX)(SI*1), DI
+	JEQ   match_nolit_loop_encodeSnappyBlockAsm64K
+	INCL  CX
+	JMP   search_loop_encodeSnappyBlockAsm64K
+
+emit_remainder_encodeSnappyBlockAsm64K:
+	MOVQ src_len+32(FP), CX
+	SUBL 12(SP), CX
+	LEAQ 3(AX)(CX*1), CX
+	CMPQ CX, (SP)
+	JL   emit_remainder_ok_encodeSnappyBlockAsm64K
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+emit_remainder_ok_encodeSnappyBlockAsm64K:
+	MOVQ src_len+32(FP), CX
+	MOVL 12(SP), BX
+	CMPL BX, CX
+	JEQ  emit_literal_done_emit_remainder_encodeSnappyBlockAsm64K
+	MOVL CX, SI
+	MOVL CX, 12(SP)
+	LEAQ (DX)(BX*1), CX
+	SUBL BX, SI
+	LEAL -1(SI), DX
+	CMPL DX, $0x3c
+	JLT  one_byte_emit_remainder_encodeSnappyBlockAsm64K
+	CMPL DX, $0x00000100
+	JLT  two_bytes_emit_remainder_encodeSnappyBlockAsm64K
+	MOVB $0xf4, (AX)
+	MOVW DX, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBlockAsm64K
+
+two_bytes_emit_remainder_encodeSnappyBlockAsm64K:
+	MOVB $0xf0, (AX)
+	MOVB DL, 1(AX)
+	ADDQ $0x02, AX
+	CMPL DX, $0x40
+	JL   memmove_emit_remainder_encodeSnappyBlockAsm64K
+	JMP  memmove_long_emit_remainder_encodeSnappyBlockAsm64K
+
+one_byte_emit_remainder_encodeSnappyBlockAsm64K:
+	SHLB $0x02, DL
+	MOVB DL, (AX)
+	ADDQ $0x01, AX
+
+memmove_emit_remainder_encodeSnappyBlockAsm64K:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveShort
+	CMPQ BX, $0x03
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_1or2
+	JE   emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_3
+	CMPQ BX, $0x08
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_4through7
+	CMPQ BX, $0x10
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_8through16
+	CMPQ BX, $0x20
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_17through32
+	JMP  emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_33through64
+
+emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_1or2:
+	MOVB (CX), SI
+	MOVB -1(CX)(BX*1), CL
+	MOVB SI, (AX)
+	MOVB CL, -1(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_3:
+	MOVW (CX), SI
+	MOVB 2(CX), CL
+	MOVW SI, (AX)
+	MOVB CL, 2(AX)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_4through7:
+	MOVL (CX), SI
+	MOVL -4(CX)(BX*1), CX
+	MOVL SI, (AX)
+	MOVL CX, -4(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_8through16:
+	MOVQ (CX), SI
+	MOVQ -8(CX)(BX*1), CX
+	MOVQ SI, (AX)
+	MOVQ CX, -8(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_17through32:
+	MOVOU (CX), X0
+	MOVOU -16(CX)(BX*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(BX*1)
+	JMP   memmove_end_copy_emit_remainder_encodeSnappyBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBlockAsm64K_memmove_move_33through64:
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+
+memmove_end_copy_emit_remainder_encodeSnappyBlockAsm64K:
+	MOVQ DX, AX
+	JMP  emit_literal_done_emit_remainder_encodeSnappyBlockAsm64K
+
+memmove_long_emit_remainder_encodeSnappyBlockAsm64K:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveLong
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVQ  BX, DI
+	SHRQ  $0x05, DI
+	MOVQ  AX, SI
+	ANDL  $0x0000001f, SI
+	MOVQ  $0x00000040, R8
+	SUBQ  SI, R8
+	DECQ  DI
+	JA    emit_lit_memmove_long_emit_remainder_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32
+	LEAQ  -32(CX)(R8*1), SI
+	LEAQ  -32(AX)(R8*1), R9
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBlockAsm64Klarge_big_loop_back:
+	MOVOU (SI), X4
+	MOVOU 16(SI), X5
+	MOVOA X4, (R9)
+	MOVOA X5, 16(R9)
+	ADDQ  $0x20, R9
+	ADDQ  $0x20, SI
+	ADDQ  $0x20, R8
+	DECQ  DI
+	JNA   emit_lit_memmove_long_emit_remainder_encodeSnappyBlockAsm64Klarge_big_loop_back
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32:
+	MOVOU -32(CX)(R8*1), X4
+	MOVOU -16(CX)(R8*1), X5
+	MOVOA X4, -32(AX)(R8*1)
+	MOVOA X5, -16(AX)(R8*1)
+	ADDQ  $0x20, R8
+	CMPQ  BX, R8
+	JAE   emit_lit_memmove_long_emit_remainder_encodeSnappyBlockAsm64Klarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+	MOVQ  DX, AX
+
+emit_literal_done_emit_remainder_encodeSnappyBlockAsm64K:
+	MOVQ dst_base+0(FP), CX
+	SUBQ CX, AX
+	MOVQ AX, ret+48(FP)
+	RET
+
 // func encodeSnappyBlockAsm12B(dst []byte, src []byte) int
 // Requires: SSE2
 TEXT ·encodeSnappyBlockAsm12B(SB), $16408-56
@@ -12433,6 +13202,2780 @@ emit_lit_memmove_long_emit_remainder_encodeSnappyBlockAsm8Blarge_forward_sse_loo
 	MOVQ  DX, AX
 
 emit_literal_done_emit_remainder_encodeSnappyBlockAsm8B:
+	MOVQ dst_base+0(FP), CX
+	SUBQ CX, AX
+	MOVQ AX, ret+48(FP)
+	RET
+
+// func encodeSnappyBetterBlockAsm(dst []byte, src []byte) int
+// Requires: SSE2
+TEXT ·encodeSnappyBetterBlockAsm(SB), $327704-56
+	MOVQ dst_base+0(FP), AX
+	MOVQ $0x00000a00, CX
+	LEAQ 24(SP), DX
+	PXOR X0, X0
+
+zero_loop_encodeSnappyBetterBlockAsm:
+	MOVOU X0, (DX)
+	MOVOU X0, 16(DX)
+	MOVOU X0, 32(DX)
+	MOVOU X0, 48(DX)
+	MOVOU X0, 64(DX)
+	MOVOU X0, 80(DX)
+	MOVOU X0, 96(DX)
+	MOVOU X0, 112(DX)
+	ADDQ  $0x80, DX
+	DECQ  CX
+	JNZ   zero_loop_encodeSnappyBetterBlockAsm
+	MOVL  $0x00000000, 12(SP)
+	MOVQ  src_len+32(FP), CX
+	LEAQ  -6(CX), DX
+	LEAQ  -8(CX), SI
+	MOVL  SI, 8(SP)
+	SHRQ  $0x05, CX
+	SUBL  CX, DX
+	LEAQ  (AX)(DX*1), DX
+	MOVQ  DX, (SP)
+	MOVL  $0x00000001, CX
+	MOVL  $0x00000000, 16(SP)
+	MOVQ  src_base+24(FP), DX
+
+search_loop_encodeSnappyBetterBlockAsm:
+	MOVL  CX, SI
+	SUBL  12(SP), SI
+	SHRL  $0x07, SI
+	LEAL  1(CX)(SI*1), SI
+	CMPL  SI, 8(SP)
+	JGE   emit_remainder_encodeSnappyBetterBlockAsm
+	MOVQ  (DX)(CX*1), DI
+	MOVL  SI, 20(SP)
+	MOVQ  $0x00cf1bbcdcbfa563, R9
+	MOVQ  $0x9e3779b1, SI
+	MOVQ  DI, R10
+	MOVQ  DI, R11
+	SHLQ  $0x08, R10
+	IMULQ R9, R10
+	SHRQ  $0x30, R10
+	SHLQ  $0x20, R11
+	IMULQ SI, R11
+	SHRQ  $0x32, R11
+	MOVL  24(SP)(R10*4), SI
+	MOVL  262168(SP)(R11*4), R8
+	MOVL  CX, 24(SP)(R10*4)
+	MOVL  CX, 262168(SP)(R11*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm
+	CMPL  (DX)(R8*1), DI
+	JEQ   candidateS_match_encodeSnappyBetterBlockAsm
+	MOVL  20(SP), CX
+	JMP   search_loop_encodeSnappyBetterBlockAsm
+
+candidateS_match_encodeSnappyBetterBlockAsm:
+	SHRQ  $0x08, DI
+	MOVQ  DI, R10
+	SHLQ  $0x08, R10
+	IMULQ R9, R10
+	SHRQ  $0x30, R10
+	MOVL  24(SP)(R10*4), SI
+	INCL  CX
+	MOVL  CX, 24(SP)(R10*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm
+	DECL  CX
+	MOVL  R8, SI
+
+candidate_match_encodeSnappyBetterBlockAsm:
+	MOVL  12(SP), DI
+	TESTL SI, SI
+	JZ    match_extend_back_end_encodeSnappyBetterBlockAsm
+
+match_extend_back_loop_encodeSnappyBetterBlockAsm:
+	CMPL CX, DI
+	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm
+	MOVB -1(DX)(SI*1), BL
+	MOVB -1(DX)(CX*1), R8
+	CMPB BL, R8
+	JNE  match_extend_back_end_encodeSnappyBetterBlockAsm
+	LEAL -1(CX), CX
+	DECL SI
+	JZ   match_extend_back_end_encodeSnappyBetterBlockAsm
+	JMP  match_extend_back_loop_encodeSnappyBetterBlockAsm
+
+match_extend_back_end_encodeSnappyBetterBlockAsm:
+	MOVL CX, DI
+	SUBL 12(SP), DI
+	LEAQ 5(AX)(DI*1), DI
+	CMPQ DI, (SP)
+	JL   match_dst_size_check_encodeSnappyBetterBlockAsm
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_dst_size_check_encodeSnappyBetterBlockAsm:
+	MOVL CX, DI
+	ADDL $0x04, CX
+	ADDL $0x04, SI
+	MOVQ src_len+32(FP), R8
+	SUBL CX, R8
+	LEAQ (DX)(CX*1), R9
+	LEAQ (DX)(SI*1), R10
+
+	// matchLen
+	XORL R12, R12
+	CMPL R8, $0x08
+	JL   matchlen_single_match_nolit_encodeSnappyBetterBlockAsm
+
+matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm:
+	MOVQ  (R9)(R12*1), R11
+	XORQ  (R10)(R12*1), R11
+	TESTQ R11, R11
+	JZ    matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm
+	BSFQ  R11, R11
+	SARQ  $0x03, R11
+	LEAL  (R12)(R11*1), R12
+	JMP   match_nolit_end_encodeSnappyBetterBlockAsm
+
+matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm:
+	LEAL -8(R8), R8
+	LEAL 8(R12), R12
+	CMPL R8, $0x08
+	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm
+
+matchlen_single_match_nolit_encodeSnappyBetterBlockAsm:
+	TESTL R8, R8
+	JZ    match_nolit_end_encodeSnappyBetterBlockAsm
+
+matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm:
+	MOVB (R9)(R12*1), R11
+	CMPB (R10)(R12*1), R11
+	JNE  match_nolit_end_encodeSnappyBetterBlockAsm
+	LEAL 1(R12), R12
+	DECL R8
+	JNZ  matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm
+
+match_nolit_end_encodeSnappyBetterBlockAsm:
+	MOVL CX, R8
+	SUBL SI, R8
+
+	// Check if repeat
+	CMPL R12, $0x01
+	JG   match_length_ok_encodeSnappyBetterBlockAsm
+	CMPL R8, $0x0000ffff
+	JLE  match_length_ok_encodeSnappyBetterBlockAsm
+	MOVL 20(SP), CX
+	INCL CX
+	JMP  search_loop_encodeSnappyBetterBlockAsm
+
+match_length_ok_encodeSnappyBetterBlockAsm:
+	MOVL R8, 16(SP)
+	MOVL 12(SP), SI
+	CMPL SI, DI
+	JEQ  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm
+	MOVL DI, R9
+	MOVL DI, 12(SP)
+	LEAQ (DX)(SI*1), R10
+	SUBL SI, R9
+	LEAL -1(R9), SI
+	CMPL SI, $0x3c
+	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm
+	CMPL SI, $0x00000100
+	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm
+	CMPL SI, $0x00010000
+	JLT  three_bytes_match_emit_encodeSnappyBetterBlockAsm
+	CMPL SI, $0x01000000
+	JLT  four_bytes_match_emit_encodeSnappyBetterBlockAsm
+	MOVB $0xfc, (AX)
+	MOVL SI, 1(AX)
+	ADDQ $0x05, AX
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm
+
+four_bytes_match_emit_encodeSnappyBetterBlockAsm:
+	MOVL SI, R11
+	SHRL $0x10, R11
+	MOVB $0xf8, (AX)
+	MOVW SI, 1(AX)
+	MOVB R11, 3(AX)
+	ADDQ $0x04, AX
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm
+
+three_bytes_match_emit_encodeSnappyBetterBlockAsm:
+	MOVB $0xf4, (AX)
+	MOVW SI, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm
+
+two_bytes_match_emit_encodeSnappyBetterBlockAsm:
+	MOVB $0xf0, (AX)
+	MOVB SI, 1(AX)
+	ADDQ $0x02, AX
+	CMPL SI, $0x40
+	JL   memmove_match_emit_encodeSnappyBetterBlockAsm
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm
+
+one_byte_match_emit_encodeSnappyBetterBlockAsm:
+	SHLB $0x02, SI
+	MOVB SI, (AX)
+	ADDQ $0x01, AX
+
+memmove_match_emit_encodeSnappyBetterBlockAsm:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveShort
+	CMPQ R9, $0x03
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_1or2
+	JE   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_3
+	CMPQ R9, $0x08
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_4through7
+	CMPQ R9, $0x10
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_8through16
+	CMPQ R9, $0x20
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_17through32
+	JMP  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_33through64
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_1or2:
+	MOVB (R10), R11
+	MOVB -1(R10)(R9*1), R10
+	MOVB R11, (AX)
+	MOVB R10, -1(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_3:
+	MOVW (R10), R11
+	MOVB 2(R10), R10
+	MOVW R11, (AX)
+	MOVB R10, 2(AX)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_4through7:
+	MOVL (R10), R11
+	MOVL -4(R10)(R9*1), R10
+	MOVL R11, (AX)
+	MOVL R10, -4(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_8through16:
+	MOVQ (R10), R11
+	MOVQ -8(R10)(R9*1), R10
+	MOVQ R11, (AX)
+	MOVQ R10, -8(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_17through32:
+	MOVOU (R10), X0
+	MOVOU -16(R10)(R9*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(R9*1)
+	JMP   memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_33through64:
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+
+memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm:
+	MOVQ SI, AX
+	JMP  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm
+
+memmove_long_match_emit_encodeSnappyBetterBlockAsm:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveLong
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVQ  R9, R13
+	SHRQ  $0x05, R13
+	MOVQ  AX, R11
+	ANDL  $0x0000001f, R11
+	MOVQ  $0x00000040, R14
+	SUBQ  R11, R14
+	DECQ  R13
+	JA    emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsmlarge_forward_sse_loop_32
+	LEAQ  -32(R10)(R14*1), R11
+	LEAQ  -32(AX)(R14*1), R15
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsmlarge_big_loop_back:
+	MOVOU (R11), X4
+	MOVOU 16(R11), X5
+	MOVOA X4, (R15)
+	MOVOA X5, 16(R15)
+	ADDQ  $0x20, R15
+	ADDQ  $0x20, R11
+	ADDQ  $0x20, R14
+	DECQ  R13
+	JNA   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsmlarge_big_loop_back
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsmlarge_forward_sse_loop_32:
+	MOVOU -32(R10)(R14*1), X4
+	MOVOU -16(R10)(R14*1), X5
+	MOVOA X4, -32(AX)(R14*1)
+	MOVOA X5, -16(AX)(R14*1)
+	ADDQ  $0x20, R14
+	CMPQ  R9, R14
+	JAE   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsmlarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+	MOVQ  SI, AX
+
+emit_literal_done_match_emit_encodeSnappyBetterBlockAsm:
+	ADDL R12, CX
+	ADDL $0x04, R12
+	MOVL CX, 12(SP)
+
+	// emitCopy
+	CMPL R8, $0x00010000
+	JL   two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm
+
+four_bytes_loop_back_match_nolit_encodeSnappyBetterBlockAsm:
+	CMPL R12, $0x40
+	JLE  four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm
+	MOVB $0xff, (AX)
+	MOVL R8, 1(AX)
+	LEAL -64(R12), R12
+	ADDQ $0x05, AX
+	CMPL R12, $0x04
+	JL   four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm
+	JMP  four_bytes_loop_back_match_nolit_encodeSnappyBetterBlockAsm
+
+four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm:
+	TESTL R12, R12
+	JZ    match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm
+	MOVB  $0x03, BL
+	LEAL  -4(BX)(R12*4), R12
+	MOVB  R12, (AX)
+	MOVL  R8, 1(AX)
+	ADDQ  $0x05, AX
+	JMP   match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm
+
+two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm:
+	CMPL R12, $0x40
+	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm
+	MOVB $0xee, (AX)
+	MOVW R8, 1(AX)
+	LEAL -60(R12), R12
+	ADDQ $0x03, AX
+	JMP  two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm
+
+two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm:
+	CMPL R12, $0x0c
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm
+	CMPL R8, $0x00000800
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm
+	MOVB $0x01, BL
+	LEAL -16(BX)(R12*4), R12
+	MOVB R8, 1(AX)
+	SHRL $0x08, R8
+	SHLL $0x05, R8
+	ORL  R8, R12
+	MOVB R12, (AX)
+	ADDQ $0x02, AX
+	JMP  match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm
+
+emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm:
+	MOVB $0x02, BL
+	LEAL -4(BX)(R12*4), R12
+	MOVB R12, (AX)
+	MOVW R8, 1(AX)
+	ADDQ $0x03, AX
+
+match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm:
+	CMPL CX, 8(SP)
+	JGE  emit_remainder_encodeSnappyBetterBlockAsm
+	CMPQ AX, (SP)
+	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_nolit_dst_ok_encodeSnappyBetterBlockAsm:
+	MOVQ  $0x00cf1bbcdcbfa563, SI
+	MOVQ  $0x9e3779b1, R8
+	INCL  DI
+	MOVQ  (DX)(DI*1), R9
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	MOVQ  R9, R12
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	SHRQ  $0x10, R12
+	LEAL  1(DI), R14
+	LEAL  2(DI), R15
+	MOVQ  -2(DX)(CX*1), R9
+	SHLQ  $0x08, R10
+	IMULQ SI, R10
+	SHRQ  $0x30, R10
+	SHLQ  $0x08, R13
+	IMULQ SI, R13
+	SHRQ  $0x30, R13
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x32, R11
+	SHLQ  $0x20, R12
+	IMULQ R8, R12
+	SHRQ  $0x32, R12
+	MOVL  DI, 24(SP)(R10*4)
+	MOVL  R14, 24(SP)(R13*4)
+	MOVL  R14, 262168(SP)(R11*4)
+	MOVL  R15, 262168(SP)(R12*4)
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	LEAL  -2(CX), R9
+	LEAL  -1(CX), DI
+	SHLQ  $0x08, R10
+	IMULQ SI, R10
+	SHRQ  $0x30, R10
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x32, R11
+	SHLQ  $0x08, R13
+	IMULQ SI, R13
+	SHRQ  $0x30, R13
+	MOVL  R9, 24(SP)(R10*4)
+	MOVL  DI, 262168(SP)(R11*4)
+	MOVL  DI, 24(SP)(R13*4)
+	JMP   search_loop_encodeSnappyBetterBlockAsm
+
+emit_remainder_encodeSnappyBetterBlockAsm:
+	MOVQ src_len+32(FP), CX
+	SUBL 12(SP), CX
+	LEAQ 5(AX)(CX*1), CX
+	CMPQ CX, (SP)
+	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+emit_remainder_ok_encodeSnappyBetterBlockAsm:
+	MOVQ src_len+32(FP), CX
+	MOVL 12(SP), BX
+	CMPL BX, CX
+	JEQ  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm
+	MOVL CX, SI
+	MOVL CX, 12(SP)
+	LEAQ (DX)(BX*1), CX
+	SUBL BX, SI
+	LEAL -1(SI), DX
+	CMPL DX, $0x3c
+	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm
+	CMPL DX, $0x00000100
+	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm
+	CMPL DX, $0x00010000
+	JLT  three_bytes_emit_remainder_encodeSnappyBetterBlockAsm
+	CMPL DX, $0x01000000
+	JLT  four_bytes_emit_remainder_encodeSnappyBetterBlockAsm
+	MOVB $0xfc, (AX)
+	MOVL DX, 1(AX)
+	ADDQ $0x05, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm
+
+four_bytes_emit_remainder_encodeSnappyBetterBlockAsm:
+	MOVL DX, BX
+	SHRL $0x10, BX
+	MOVB $0xf8, (AX)
+	MOVW DX, 1(AX)
+	MOVB BL, 3(AX)
+	ADDQ $0x04, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm
+
+three_bytes_emit_remainder_encodeSnappyBetterBlockAsm:
+	MOVB $0xf4, (AX)
+	MOVW DX, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm
+
+two_bytes_emit_remainder_encodeSnappyBetterBlockAsm:
+	MOVB $0xf0, (AX)
+	MOVB DL, 1(AX)
+	ADDQ $0x02, AX
+	CMPL DX, $0x40
+	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm
+
+one_byte_emit_remainder_encodeSnappyBetterBlockAsm:
+	SHLB $0x02, DL
+	MOVB DL, (AX)
+	ADDQ $0x01, AX
+
+memmove_emit_remainder_encodeSnappyBetterBlockAsm:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveShort
+	CMPQ BX, $0x03
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_1or2
+	JE   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_3
+	CMPQ BX, $0x08
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_4through7
+	CMPQ BX, $0x10
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_8through16
+	CMPQ BX, $0x20
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_17through32
+	JMP  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_33through64
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_1or2:
+	MOVB (CX), SI
+	MOVB -1(CX)(BX*1), CL
+	MOVB SI, (AX)
+	MOVB CL, -1(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_3:
+	MOVW (CX), SI
+	MOVB 2(CX), CL
+	MOVW SI, (AX)
+	MOVB CL, 2(AX)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_4through7:
+	MOVL (CX), SI
+	MOVL -4(CX)(BX*1), CX
+	MOVL SI, (AX)
+	MOVL CX, -4(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_8through16:
+	MOVQ (CX), SI
+	MOVQ -8(CX)(BX*1), CX
+	MOVQ SI, (AX)
+	MOVQ CX, -8(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_17through32:
+	MOVOU (CX), X0
+	MOVOU -16(CX)(BX*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(BX*1)
+	JMP   memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm_memmove_move_33through64:
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+
+memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm:
+	MOVQ DX, AX
+	JMP  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm
+
+memmove_long_emit_remainder_encodeSnappyBetterBlockAsm:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveLong
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVQ  BX, DI
+	SHRQ  $0x05, DI
+	MOVQ  AX, SI
+	ANDL  $0x0000001f, SI
+	MOVQ  $0x00000040, R8
+	SUBQ  SI, R8
+	DECQ  DI
+	JA    emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsmlarge_forward_sse_loop_32
+	LEAQ  -32(CX)(R8*1), SI
+	LEAQ  -32(AX)(R8*1), R9
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsmlarge_big_loop_back:
+	MOVOU (SI), X4
+	MOVOU 16(SI), X5
+	MOVOA X4, (R9)
+	MOVOA X5, 16(R9)
+	ADDQ  $0x20, R9
+	ADDQ  $0x20, SI
+	ADDQ  $0x20, R8
+	DECQ  DI
+	JNA   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsmlarge_big_loop_back
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsmlarge_forward_sse_loop_32:
+	MOVOU -32(CX)(R8*1), X4
+	MOVOU -16(CX)(R8*1), X5
+	MOVOA X4, -32(AX)(R8*1)
+	MOVOA X5, -16(AX)(R8*1)
+	ADDQ  $0x20, R8
+	CMPQ  BX, R8
+	JAE   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsmlarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+	MOVQ  DX, AX
+
+emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm:
+	MOVQ dst_base+0(FP), CX
+	SUBQ CX, AX
+	MOVQ AX, ret+48(FP)
+	RET
+
+// func encodeSnappyBetterBlockAsm64K(dst []byte, src []byte) int
+// Requires: SSE2
+TEXT ·encodeSnappyBetterBlockAsm64K(SB), $327704-56
+	MOVQ dst_base+0(FP), AX
+	MOVQ $0x00000a00, CX
+	LEAQ 24(SP), DX
+	PXOR X0, X0
+
+zero_loop_encodeSnappyBetterBlockAsm64K:
+	MOVOU X0, (DX)
+	MOVOU X0, 16(DX)
+	MOVOU X0, 32(DX)
+	MOVOU X0, 48(DX)
+	MOVOU X0, 64(DX)
+	MOVOU X0, 80(DX)
+	MOVOU X0, 96(DX)
+	MOVOU X0, 112(DX)
+	ADDQ  $0x80, DX
+	DECQ  CX
+	JNZ   zero_loop_encodeSnappyBetterBlockAsm64K
+	MOVL  $0x00000000, 12(SP)
+	MOVQ  src_len+32(FP), CX
+	LEAQ  -6(CX), DX
+	LEAQ  -8(CX), SI
+	MOVL  SI, 8(SP)
+	SHRQ  $0x05, CX
+	SUBL  CX, DX
+	LEAQ  (AX)(DX*1), DX
+	MOVQ  DX, (SP)
+	MOVL  $0x00000001, CX
+	MOVL  $0x00000000, 16(SP)
+	MOVQ  src_base+24(FP), DX
+
+search_loop_encodeSnappyBetterBlockAsm64K:
+	MOVL  CX, SI
+	SUBL  12(SP), SI
+	SHRL  $0x07, SI
+	LEAL  1(CX)(SI*1), SI
+	CMPL  SI, 8(SP)
+	JGE   emit_remainder_encodeSnappyBetterBlockAsm64K
+	MOVQ  (DX)(CX*1), DI
+	MOVL  SI, 20(SP)
+	MOVQ  $0x00cf1bbcdcbfa563, R9
+	MOVQ  $0x9e3779b1, SI
+	MOVQ  DI, R10
+	MOVQ  DI, R11
+	SHLQ  $0x08, R10
+	IMULQ R9, R10
+	SHRQ  $0x30, R10
+	SHLQ  $0x20, R11
+	IMULQ SI, R11
+	SHRQ  $0x32, R11
+	MOVL  24(SP)(R10*4), SI
+	MOVL  262168(SP)(R11*4), R8
+	MOVL  CX, 24(SP)(R10*4)
+	MOVL  CX, 262168(SP)(R11*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm64K
+	CMPL  (DX)(R8*1), DI
+	JEQ   candidateS_match_encodeSnappyBetterBlockAsm64K
+	MOVL  20(SP), CX
+	JMP   search_loop_encodeSnappyBetterBlockAsm64K
+
+candidateS_match_encodeSnappyBetterBlockAsm64K:
+	SHRQ  $0x08, DI
+	MOVQ  DI, R10
+	SHLQ  $0x08, R10
+	IMULQ R9, R10
+	SHRQ  $0x30, R10
+	MOVL  24(SP)(R10*4), SI
+	INCL  CX
+	MOVL  CX, 24(SP)(R10*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm64K
+	DECL  CX
+	MOVL  R8, SI
+
+candidate_match_encodeSnappyBetterBlockAsm64K:
+	MOVL  12(SP), DI
+	TESTL SI, SI
+	JZ    match_extend_back_end_encodeSnappyBetterBlockAsm64K
+
+match_extend_back_loop_encodeSnappyBetterBlockAsm64K:
+	CMPL CX, DI
+	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm64K
+	MOVB -1(DX)(SI*1), BL
+	MOVB -1(DX)(CX*1), R8
+	CMPB BL, R8
+	JNE  match_extend_back_end_encodeSnappyBetterBlockAsm64K
+	LEAL -1(CX), CX
+	DECL SI
+	JZ   match_extend_back_end_encodeSnappyBetterBlockAsm64K
+	JMP  match_extend_back_loop_encodeSnappyBetterBlockAsm64K
+
+match_extend_back_end_encodeSnappyBetterBlockAsm64K:
+	MOVL CX, DI
+	SUBL 12(SP), DI
+	LEAQ 3(AX)(DI*1), DI
+	CMPQ DI, (SP)
+	JL   match_dst_size_check_encodeSnappyBetterBlockAsm64K
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_dst_size_check_encodeSnappyBetterBlockAsm64K:
+	MOVL CX, DI
+	ADDL $0x04, CX
+	ADDL $0x04, SI
+	MOVQ src_len+32(FP), R8
+	SUBL CX, R8
+	LEAQ (DX)(CX*1), R9
+	LEAQ (DX)(SI*1), R10
+
+	// matchLen
+	XORL R12, R12
+	CMPL R8, $0x08
+	JL   matchlen_single_match_nolit_encodeSnappyBetterBlockAsm64K
+
+matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm64K:
+	MOVQ  (R9)(R12*1), R11
+	XORQ  (R10)(R12*1), R11
+	TESTQ R11, R11
+	JZ    matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm64K
+	BSFQ  R11, R11
+	SARQ  $0x03, R11
+	LEAL  (R12)(R11*1), R12
+	JMP   match_nolit_end_encodeSnappyBetterBlockAsm64K
+
+matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm64K:
+	LEAL -8(R8), R8
+	LEAL 8(R12), R12
+	CMPL R8, $0x08
+	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm64K
+
+matchlen_single_match_nolit_encodeSnappyBetterBlockAsm64K:
+	TESTL R8, R8
+	JZ    match_nolit_end_encodeSnappyBetterBlockAsm64K
+
+matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm64K:
+	MOVB (R9)(R12*1), R11
+	CMPB (R10)(R12*1), R11
+	JNE  match_nolit_end_encodeSnappyBetterBlockAsm64K
+	LEAL 1(R12), R12
+	DECL R8
+	JNZ  matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm64K
+
+match_nolit_end_encodeSnappyBetterBlockAsm64K:
+	MOVL CX, R8
+	SUBL SI, R8
+
+	// Check if repeat
+	MOVL R8, 16(SP)
+	MOVL 12(SP), SI
+	CMPL SI, DI
+	JEQ  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm64K
+	MOVL DI, R9
+	MOVL DI, 12(SP)
+	LEAQ (DX)(SI*1), R10
+	SUBL SI, R9
+	LEAL -1(R9), SI
+	CMPL SI, $0x3c
+	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm64K
+	CMPL SI, $0x00000100
+	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm64K
+	MOVB $0xf4, (AX)
+	MOVW SI, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm64K
+
+two_bytes_match_emit_encodeSnappyBetterBlockAsm64K:
+	MOVB $0xf0, (AX)
+	MOVB SI, 1(AX)
+	ADDQ $0x02, AX
+	CMPL SI, $0x40
+	JL   memmove_match_emit_encodeSnappyBetterBlockAsm64K
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm64K
+
+one_byte_match_emit_encodeSnappyBetterBlockAsm64K:
+	SHLB $0x02, SI
+	MOVB SI, (AX)
+	ADDQ $0x01, AX
+
+memmove_match_emit_encodeSnappyBetterBlockAsm64K:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveShort
+	CMPQ R9, $0x03
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_1or2
+	JE   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_3
+	CMPQ R9, $0x08
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_4through7
+	CMPQ R9, $0x10
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_8through16
+	CMPQ R9, $0x20
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_17through32
+	JMP  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_33through64
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_1or2:
+	MOVB (R10), R11
+	MOVB -1(R10)(R9*1), R10
+	MOVB R11, (AX)
+	MOVB R10, -1(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_3:
+	MOVW (R10), R11
+	MOVB 2(R10), R10
+	MOVW R11, (AX)
+	MOVB R10, 2(AX)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_4through7:
+	MOVL (R10), R11
+	MOVL -4(R10)(R9*1), R10
+	MOVL R11, (AX)
+	MOVL R10, -4(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_8through16:
+	MOVQ (R10), R11
+	MOVQ -8(R10)(R9*1), R10
+	MOVQ R11, (AX)
+	MOVQ R10, -8(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_17through32:
+	MOVOU (R10), X0
+	MOVOU -16(R10)(R9*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(R9*1)
+	JMP   memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_33through64:
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+
+memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm64K:
+	MOVQ SI, AX
+	JMP  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm64K
+
+memmove_long_match_emit_encodeSnappyBetterBlockAsm64K:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveLong
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVQ  R9, R13
+	SHRQ  $0x05, R13
+	MOVQ  AX, R11
+	ANDL  $0x0000001f, R11
+	MOVQ  $0x00000040, R14
+	SUBQ  R11, R14
+	DECQ  R13
+	JA    emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm64Klarge_forward_sse_loop_32
+	LEAQ  -32(R10)(R14*1), R11
+	LEAQ  -32(AX)(R14*1), R15
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm64Klarge_big_loop_back:
+	MOVOU (R11), X4
+	MOVOU 16(R11), X5
+	MOVOA X4, (R15)
+	MOVOA X5, 16(R15)
+	ADDQ  $0x20, R15
+	ADDQ  $0x20, R11
+	ADDQ  $0x20, R14
+	DECQ  R13
+	JNA   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm64Klarge_big_loop_back
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm64Klarge_forward_sse_loop_32:
+	MOVOU -32(R10)(R14*1), X4
+	MOVOU -16(R10)(R14*1), X5
+	MOVOA X4, -32(AX)(R14*1)
+	MOVOA X5, -16(AX)(R14*1)
+	ADDQ  $0x20, R14
+	CMPQ  R9, R14
+	JAE   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm64Klarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+	MOVQ  SI, AX
+
+emit_literal_done_match_emit_encodeSnappyBetterBlockAsm64K:
+	ADDL R12, CX
+	ADDL $0x04, R12
+	MOVL CX, 12(SP)
+
+	// emitCopy
+two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm64K:
+	CMPL R12, $0x40
+	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm64K
+	MOVB $0xee, (AX)
+	MOVW R8, 1(AX)
+	LEAL -60(R12), R12
+	ADDQ $0x03, AX
+	JMP  two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm64K
+
+two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm64K:
+	CMPL R12, $0x0c
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K
+	CMPL R8, $0x00000800
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K
+	MOVB $0x01, BL
+	LEAL -16(BX)(R12*4), R12
+	MOVB R8, 1(AX)
+	SHRL $0x08, R8
+	SHLL $0x05, R8
+	ORL  R8, R12
+	MOVB R12, (AX)
+	ADDQ $0x02, AX
+	JMP  match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm64K
+
+emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K:
+	MOVB $0x02, BL
+	LEAL -4(BX)(R12*4), R12
+	MOVB R12, (AX)
+	MOVW R8, 1(AX)
+	ADDQ $0x03, AX
+
+match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm64K:
+	CMPL CX, 8(SP)
+	JGE  emit_remainder_encodeSnappyBetterBlockAsm64K
+	CMPQ AX, (SP)
+	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm64K
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_nolit_dst_ok_encodeSnappyBetterBlockAsm64K:
+	MOVQ  $0x00cf1bbcdcbfa563, SI
+	MOVQ  $0x9e3779b1, R8
+	INCL  DI
+	MOVQ  (DX)(DI*1), R9
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	MOVQ  R9, R12
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	SHRQ  $0x10, R12
+	LEAL  1(DI), R14
+	LEAL  2(DI), R15
+	MOVQ  -2(DX)(CX*1), R9
+	SHLQ  $0x08, R10
+	IMULQ SI, R10
+	SHRQ  $0x30, R10
+	SHLQ  $0x08, R13
+	IMULQ SI, R13
+	SHRQ  $0x30, R13
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x32, R11
+	SHLQ  $0x20, R12
+	IMULQ R8, R12
+	SHRQ  $0x32, R12
+	MOVL  DI, 24(SP)(R10*4)
+	MOVL  R14, 24(SP)(R13*4)
+	MOVL  R14, 262168(SP)(R11*4)
+	MOVL  R15, 262168(SP)(R12*4)
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	LEAL  -2(CX), R9
+	LEAL  -1(CX), DI
+	SHLQ  $0x08, R10
+	IMULQ SI, R10
+	SHRQ  $0x30, R10
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x32, R11
+	SHLQ  $0x08, R13
+	IMULQ SI, R13
+	SHRQ  $0x30, R13
+	MOVL  R9, 24(SP)(R10*4)
+	MOVL  DI, 262168(SP)(R11*4)
+	MOVL  DI, 24(SP)(R13*4)
+	JMP   search_loop_encodeSnappyBetterBlockAsm64K
+
+emit_remainder_encodeSnappyBetterBlockAsm64K:
+	MOVQ src_len+32(FP), CX
+	SUBL 12(SP), CX
+	LEAQ 3(AX)(CX*1), CX
+	CMPQ CX, (SP)
+	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm64K
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+emit_remainder_ok_encodeSnappyBetterBlockAsm64K:
+	MOVQ src_len+32(FP), CX
+	MOVL 12(SP), BX
+	CMPL BX, CX
+	JEQ  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm64K
+	MOVL CX, SI
+	MOVL CX, 12(SP)
+	LEAQ (DX)(BX*1), CX
+	SUBL BX, SI
+	LEAL -1(SI), DX
+	CMPL DX, $0x3c
+	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm64K
+	CMPL DX, $0x00000100
+	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm64K
+	MOVB $0xf4, (AX)
+	MOVW DX, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+two_bytes_emit_remainder_encodeSnappyBetterBlockAsm64K:
+	MOVB $0xf0, (AX)
+	MOVB DL, 1(AX)
+	ADDQ $0x02, AX
+	CMPL DX, $0x40
+	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm64K
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+one_byte_emit_remainder_encodeSnappyBetterBlockAsm64K:
+	SHLB $0x02, DL
+	MOVB DL, (AX)
+	ADDQ $0x01, AX
+
+memmove_emit_remainder_encodeSnappyBetterBlockAsm64K:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveShort
+	CMPQ BX, $0x03
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_1or2
+	JE   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_3
+	CMPQ BX, $0x08
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_4through7
+	CMPQ BX, $0x10
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_8through16
+	CMPQ BX, $0x20
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_17through32
+	JMP  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_33through64
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_1or2:
+	MOVB (CX), SI
+	MOVB -1(CX)(BX*1), CL
+	MOVB SI, (AX)
+	MOVB CL, -1(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_3:
+	MOVW (CX), SI
+	MOVB 2(CX), CL
+	MOVW SI, (AX)
+	MOVB CL, 2(AX)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_4through7:
+	MOVL (CX), SI
+	MOVL -4(CX)(BX*1), CX
+	MOVL SI, (AX)
+	MOVL CX, -4(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_8through16:
+	MOVQ (CX), SI
+	MOVQ -8(CX)(BX*1), CX
+	MOVQ SI, (AX)
+	MOVQ CX, -8(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_17through32:
+	MOVOU (CX), X0
+	MOVOU -16(CX)(BX*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(BX*1)
+	JMP   memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm64K_memmove_move_33through64:
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+
+memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm64K:
+	MOVQ DX, AX
+	JMP  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64K:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveLong
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVQ  BX, DI
+	SHRQ  $0x05, DI
+	MOVQ  AX, SI
+	ANDL  $0x0000001f, SI
+	MOVQ  $0x00000040, R8
+	SUBQ  SI, R8
+	DECQ  DI
+	JA    emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64Klarge_forward_sse_loop_32
+	LEAQ  -32(CX)(R8*1), SI
+	LEAQ  -32(AX)(R8*1), R9
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64Klarge_big_loop_back:
+	MOVOU (SI), X4
+	MOVOU 16(SI), X5
+	MOVOA X4, (R9)
+	MOVOA X5, 16(R9)
+	ADDQ  $0x20, R9
+	ADDQ  $0x20, SI
+	ADDQ  $0x20, R8
+	DECQ  DI
+	JNA   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64Klarge_big_loop_back
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64Klarge_forward_sse_loop_32:
+	MOVOU -32(CX)(R8*1), X4
+	MOVOU -16(CX)(R8*1), X5
+	MOVOA X4, -32(AX)(R8*1)
+	MOVOA X5, -16(AX)(R8*1)
+	ADDQ  $0x20, R8
+	CMPQ  BX, R8
+	JAE   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64Klarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+	MOVQ  DX, AX
+
+emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm64K:
+	MOVQ dst_base+0(FP), CX
+	SUBQ CX, AX
+	MOVQ AX, ret+48(FP)
+	RET
+
+// func encodeSnappyBetterBlockAsm12B(dst []byte, src []byte) int
+// Requires: SSE2
+TEXT ·encodeSnappyBetterBlockAsm12B(SB), $81944-56
+	MOVQ dst_base+0(FP), AX
+	MOVQ $0x00000280, CX
+	LEAQ 24(SP), DX
+	PXOR X0, X0
+
+zero_loop_encodeSnappyBetterBlockAsm12B:
+	MOVOU X0, (DX)
+	MOVOU X0, 16(DX)
+	MOVOU X0, 32(DX)
+	MOVOU X0, 48(DX)
+	MOVOU X0, 64(DX)
+	MOVOU X0, 80(DX)
+	MOVOU X0, 96(DX)
+	MOVOU X0, 112(DX)
+	ADDQ  $0x80, DX
+	DECQ  CX
+	JNZ   zero_loop_encodeSnappyBetterBlockAsm12B
+	MOVL  $0x00000000, 12(SP)
+	MOVQ  src_len+32(FP), CX
+	LEAQ  -6(CX), DX
+	LEAQ  -8(CX), SI
+	MOVL  SI, 8(SP)
+	SHRQ  $0x05, CX
+	SUBL  CX, DX
+	LEAQ  (AX)(DX*1), DX
+	MOVQ  DX, (SP)
+	MOVL  $0x00000001, CX
+	MOVL  $0x00000000, 16(SP)
+	MOVQ  src_base+24(FP), DX
+
+search_loop_encodeSnappyBetterBlockAsm12B:
+	MOVL  CX, SI
+	SUBL  12(SP), SI
+	SHRL  $0x06, SI
+	LEAL  1(CX)(SI*1), SI
+	CMPL  SI, 8(SP)
+	JGE   emit_remainder_encodeSnappyBetterBlockAsm12B
+	MOVQ  (DX)(CX*1), DI
+	MOVL  SI, 20(SP)
+	MOVQ  $0x0000cf1bbcdcbf9b, R9
+	MOVQ  $0x9e3779b1, SI
+	MOVQ  DI, R10
+	MOVQ  DI, R11
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x32, R10
+	SHLQ  $0x20, R11
+	IMULQ SI, R11
+	SHRQ  $0x34, R11
+	MOVL  24(SP)(R10*4), SI
+	MOVL  65560(SP)(R11*4), R8
+	MOVL  CX, 24(SP)(R10*4)
+	MOVL  CX, 65560(SP)(R11*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm12B
+	CMPL  (DX)(R8*1), DI
+	JEQ   candidateS_match_encodeSnappyBetterBlockAsm12B
+	MOVL  20(SP), CX
+	JMP   search_loop_encodeSnappyBetterBlockAsm12B
+
+candidateS_match_encodeSnappyBetterBlockAsm12B:
+	SHRQ  $0x08, DI
+	MOVQ  DI, R10
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x32, R10
+	MOVL  24(SP)(R10*4), SI
+	INCL  CX
+	MOVL  CX, 24(SP)(R10*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm12B
+	DECL  CX
+	MOVL  R8, SI
+
+candidate_match_encodeSnappyBetterBlockAsm12B:
+	MOVL  12(SP), DI
+	TESTL SI, SI
+	JZ    match_extend_back_end_encodeSnappyBetterBlockAsm12B
+
+match_extend_back_loop_encodeSnappyBetterBlockAsm12B:
+	CMPL CX, DI
+	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm12B
+	MOVB -1(DX)(SI*1), BL
+	MOVB -1(DX)(CX*1), R8
+	CMPB BL, R8
+	JNE  match_extend_back_end_encodeSnappyBetterBlockAsm12B
+	LEAL -1(CX), CX
+	DECL SI
+	JZ   match_extend_back_end_encodeSnappyBetterBlockAsm12B
+	JMP  match_extend_back_loop_encodeSnappyBetterBlockAsm12B
+
+match_extend_back_end_encodeSnappyBetterBlockAsm12B:
+	MOVL CX, DI
+	SUBL 12(SP), DI
+	LEAQ 3(AX)(DI*1), DI
+	CMPQ DI, (SP)
+	JL   match_dst_size_check_encodeSnappyBetterBlockAsm12B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_dst_size_check_encodeSnappyBetterBlockAsm12B:
+	MOVL CX, DI
+	ADDL $0x04, CX
+	ADDL $0x04, SI
+	MOVQ src_len+32(FP), R8
+	SUBL CX, R8
+	LEAQ (DX)(CX*1), R9
+	LEAQ (DX)(SI*1), R10
+
+	// matchLen
+	XORL R12, R12
+	CMPL R8, $0x08
+	JL   matchlen_single_match_nolit_encodeSnappyBetterBlockAsm12B
+
+matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm12B:
+	MOVQ  (R9)(R12*1), R11
+	XORQ  (R10)(R12*1), R11
+	TESTQ R11, R11
+	JZ    matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm12B
+	BSFQ  R11, R11
+	SARQ  $0x03, R11
+	LEAL  (R12)(R11*1), R12
+	JMP   match_nolit_end_encodeSnappyBetterBlockAsm12B
+
+matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm12B:
+	LEAL -8(R8), R8
+	LEAL 8(R12), R12
+	CMPL R8, $0x08
+	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm12B
+
+matchlen_single_match_nolit_encodeSnappyBetterBlockAsm12B:
+	TESTL R8, R8
+	JZ    match_nolit_end_encodeSnappyBetterBlockAsm12B
+
+matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm12B:
+	MOVB (R9)(R12*1), R11
+	CMPB (R10)(R12*1), R11
+	JNE  match_nolit_end_encodeSnappyBetterBlockAsm12B
+	LEAL 1(R12), R12
+	DECL R8
+	JNZ  matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm12B
+
+match_nolit_end_encodeSnappyBetterBlockAsm12B:
+	MOVL CX, R8
+	SUBL SI, R8
+
+	// Check if repeat
+	MOVL R8, 16(SP)
+	MOVL 12(SP), SI
+	CMPL SI, DI
+	JEQ  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm12B
+	MOVL DI, R9
+	MOVL DI, 12(SP)
+	LEAQ (DX)(SI*1), R10
+	SUBL SI, R9
+	LEAL -1(R9), SI
+	CMPL SI, $0x3c
+	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm12B
+	CMPL SI, $0x00000100
+	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm12B
+	MOVB $0xf4, (AX)
+	MOVW SI, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm12B
+
+two_bytes_match_emit_encodeSnappyBetterBlockAsm12B:
+	MOVB $0xf0, (AX)
+	MOVB SI, 1(AX)
+	ADDQ $0x02, AX
+	CMPL SI, $0x40
+	JL   memmove_match_emit_encodeSnappyBetterBlockAsm12B
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm12B
+
+one_byte_match_emit_encodeSnappyBetterBlockAsm12B:
+	SHLB $0x02, SI
+	MOVB SI, (AX)
+	ADDQ $0x01, AX
+
+memmove_match_emit_encodeSnappyBetterBlockAsm12B:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveShort
+	CMPQ R9, $0x03
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_1or2
+	JE   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_3
+	CMPQ R9, $0x08
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_4through7
+	CMPQ R9, $0x10
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_8through16
+	CMPQ R9, $0x20
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_17through32
+	JMP  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_33through64
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_1or2:
+	MOVB (R10), R11
+	MOVB -1(R10)(R9*1), R10
+	MOVB R11, (AX)
+	MOVB R10, -1(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_3:
+	MOVW (R10), R11
+	MOVB 2(R10), R10
+	MOVW R11, (AX)
+	MOVB R10, 2(AX)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_4through7:
+	MOVL (R10), R11
+	MOVL -4(R10)(R9*1), R10
+	MOVL R11, (AX)
+	MOVL R10, -4(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_8through16:
+	MOVQ (R10), R11
+	MOVQ -8(R10)(R9*1), R10
+	MOVQ R11, (AX)
+	MOVQ R10, -8(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_17through32:
+	MOVOU (R10), X0
+	MOVOU -16(R10)(R9*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(R9*1)
+	JMP   memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_33through64:
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+
+memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm12B:
+	MOVQ SI, AX
+	JMP  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm12B
+
+memmove_long_match_emit_encodeSnappyBetterBlockAsm12B:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveLong
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVQ  R9, R13
+	SHRQ  $0x05, R13
+	MOVQ  AX, R11
+	ANDL  $0x0000001f, R11
+	MOVQ  $0x00000040, R14
+	SUBQ  R11, R14
+	DECQ  R13
+	JA    emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm12Blarge_forward_sse_loop_32
+	LEAQ  -32(R10)(R14*1), R11
+	LEAQ  -32(AX)(R14*1), R15
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm12Blarge_big_loop_back:
+	MOVOU (R11), X4
+	MOVOU 16(R11), X5
+	MOVOA X4, (R15)
+	MOVOA X5, 16(R15)
+	ADDQ  $0x20, R15
+	ADDQ  $0x20, R11
+	ADDQ  $0x20, R14
+	DECQ  R13
+	JNA   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm12Blarge_big_loop_back
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm12Blarge_forward_sse_loop_32:
+	MOVOU -32(R10)(R14*1), X4
+	MOVOU -16(R10)(R14*1), X5
+	MOVOA X4, -32(AX)(R14*1)
+	MOVOA X5, -16(AX)(R14*1)
+	ADDQ  $0x20, R14
+	CMPQ  R9, R14
+	JAE   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm12Blarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+	MOVQ  SI, AX
+
+emit_literal_done_match_emit_encodeSnappyBetterBlockAsm12B:
+	ADDL R12, CX
+	ADDL $0x04, R12
+	MOVL CX, 12(SP)
+
+	// emitCopy
+two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm12B:
+	CMPL R12, $0x40
+	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm12B
+	MOVB $0xee, (AX)
+	MOVW R8, 1(AX)
+	LEAL -60(R12), R12
+	ADDQ $0x03, AX
+	JMP  two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm12B
+
+two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm12B:
+	CMPL R12, $0x0c
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B
+	CMPL R8, $0x00000800
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B
+	MOVB $0x01, BL
+	LEAL -16(BX)(R12*4), R12
+	MOVB R8, 1(AX)
+	SHRL $0x08, R8
+	SHLL $0x05, R8
+	ORL  R8, R12
+	MOVB R12, (AX)
+	ADDQ $0x02, AX
+	JMP  match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm12B
+
+emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B:
+	MOVB $0x02, BL
+	LEAL -4(BX)(R12*4), R12
+	MOVB R12, (AX)
+	MOVW R8, 1(AX)
+	ADDQ $0x03, AX
+
+match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm12B:
+	CMPL CX, 8(SP)
+	JGE  emit_remainder_encodeSnappyBetterBlockAsm12B
+	CMPQ AX, (SP)
+	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm12B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_nolit_dst_ok_encodeSnappyBetterBlockAsm12B:
+	MOVQ  $0x0000cf1bbcdcbf9b, SI
+	MOVQ  $0x9e3779b1, R8
+	INCL  DI
+	MOVQ  (DX)(DI*1), R9
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	MOVQ  R9, R12
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	SHRQ  $0x10, R12
+	LEAL  1(DI), R14
+	LEAL  2(DI), R15
+	MOVQ  -2(DX)(CX*1), R9
+	SHLQ  $0x10, R10
+	IMULQ SI, R10
+	SHRQ  $0x32, R10
+	SHLQ  $0x10, R13
+	IMULQ SI, R13
+	SHRQ  $0x32, R13
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x34, R11
+	SHLQ  $0x20, R12
+	IMULQ R8, R12
+	SHRQ  $0x34, R12
+	MOVL  DI, 24(SP)(R10*4)
+	MOVL  R14, 24(SP)(R13*4)
+	MOVL  R14, 65560(SP)(R11*4)
+	MOVL  R15, 65560(SP)(R12*4)
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	LEAL  -2(CX), R9
+	LEAL  -1(CX), DI
+	SHLQ  $0x10, R10
+	IMULQ SI, R10
+	SHRQ  $0x32, R10
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x34, R11
+	SHLQ  $0x10, R13
+	IMULQ SI, R13
+	SHRQ  $0x32, R13
+	MOVL  R9, 24(SP)(R10*4)
+	MOVL  DI, 65560(SP)(R11*4)
+	MOVL  DI, 24(SP)(R13*4)
+	JMP   search_loop_encodeSnappyBetterBlockAsm12B
+
+emit_remainder_encodeSnappyBetterBlockAsm12B:
+	MOVQ src_len+32(FP), CX
+	SUBL 12(SP), CX
+	LEAQ 3(AX)(CX*1), CX
+	CMPQ CX, (SP)
+	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm12B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+emit_remainder_ok_encodeSnappyBetterBlockAsm12B:
+	MOVQ src_len+32(FP), CX
+	MOVL 12(SP), BX
+	CMPL BX, CX
+	JEQ  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm12B
+	MOVL CX, SI
+	MOVL CX, 12(SP)
+	LEAQ (DX)(BX*1), CX
+	SUBL BX, SI
+	LEAL -1(SI), DX
+	CMPL DX, $0x3c
+	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm12B
+	CMPL DX, $0x00000100
+	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm12B
+	MOVB $0xf4, (AX)
+	MOVW DX, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+two_bytes_emit_remainder_encodeSnappyBetterBlockAsm12B:
+	MOVB $0xf0, (AX)
+	MOVB DL, 1(AX)
+	ADDQ $0x02, AX
+	CMPL DX, $0x40
+	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm12B
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+one_byte_emit_remainder_encodeSnappyBetterBlockAsm12B:
+	SHLB $0x02, DL
+	MOVB DL, (AX)
+	ADDQ $0x01, AX
+
+memmove_emit_remainder_encodeSnappyBetterBlockAsm12B:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveShort
+	CMPQ BX, $0x03
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_1or2
+	JE   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_3
+	CMPQ BX, $0x08
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_4through7
+	CMPQ BX, $0x10
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_8through16
+	CMPQ BX, $0x20
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_17through32
+	JMP  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_33through64
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_1or2:
+	MOVB (CX), SI
+	MOVB -1(CX)(BX*1), CL
+	MOVB SI, (AX)
+	MOVB CL, -1(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_3:
+	MOVW (CX), SI
+	MOVB 2(CX), CL
+	MOVW SI, (AX)
+	MOVB CL, 2(AX)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_4through7:
+	MOVL (CX), SI
+	MOVL -4(CX)(BX*1), CX
+	MOVL SI, (AX)
+	MOVL CX, -4(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_8through16:
+	MOVQ (CX), SI
+	MOVQ -8(CX)(BX*1), CX
+	MOVQ SI, (AX)
+	MOVQ CX, -8(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_17through32:
+	MOVOU (CX), X0
+	MOVOU -16(CX)(BX*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(BX*1)
+	JMP   memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm12B_memmove_move_33through64:
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+
+memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm12B:
+	MOVQ DX, AX
+	JMP  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12B:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveLong
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVQ  BX, DI
+	SHRQ  $0x05, DI
+	MOVQ  AX, SI
+	ANDL  $0x0000001f, SI
+	MOVQ  $0x00000040, R8
+	SUBQ  SI, R8
+	DECQ  DI
+	JA    emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12Blarge_forward_sse_loop_32
+	LEAQ  -32(CX)(R8*1), SI
+	LEAQ  -32(AX)(R8*1), R9
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12Blarge_big_loop_back:
+	MOVOU (SI), X4
+	MOVOU 16(SI), X5
+	MOVOA X4, (R9)
+	MOVOA X5, 16(R9)
+	ADDQ  $0x20, R9
+	ADDQ  $0x20, SI
+	ADDQ  $0x20, R8
+	DECQ  DI
+	JNA   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12Blarge_big_loop_back
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12Blarge_forward_sse_loop_32:
+	MOVOU -32(CX)(R8*1), X4
+	MOVOU -16(CX)(R8*1), X5
+	MOVOA X4, -32(AX)(R8*1)
+	MOVOA X5, -16(AX)(R8*1)
+	ADDQ  $0x20, R8
+	CMPQ  BX, R8
+	JAE   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12Blarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+	MOVQ  DX, AX
+
+emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm12B:
+	MOVQ dst_base+0(FP), CX
+	SUBQ CX, AX
+	MOVQ AX, ret+48(FP)
+	RET
+
+// func encodeSnappyBetterBlockAsm10B(dst []byte, src []byte) int
+// Requires: SSE2
+TEXT ·encodeSnappyBetterBlockAsm10B(SB), $20504-56
+	MOVQ dst_base+0(FP), AX
+	MOVQ $0x000000a0, CX
+	LEAQ 24(SP), DX
+	PXOR X0, X0
+
+zero_loop_encodeSnappyBetterBlockAsm10B:
+	MOVOU X0, (DX)
+	MOVOU X0, 16(DX)
+	MOVOU X0, 32(DX)
+	MOVOU X0, 48(DX)
+	MOVOU X0, 64(DX)
+	MOVOU X0, 80(DX)
+	MOVOU X0, 96(DX)
+	MOVOU X0, 112(DX)
+	ADDQ  $0x80, DX
+	DECQ  CX
+	JNZ   zero_loop_encodeSnappyBetterBlockAsm10B
+	MOVL  $0x00000000, 12(SP)
+	MOVQ  src_len+32(FP), CX
+	LEAQ  -6(CX), DX
+	LEAQ  -8(CX), SI
+	MOVL  SI, 8(SP)
+	SHRQ  $0x05, CX
+	SUBL  CX, DX
+	LEAQ  (AX)(DX*1), DX
+	MOVQ  DX, (SP)
+	MOVL  $0x00000001, CX
+	MOVL  $0x00000000, 16(SP)
+	MOVQ  src_base+24(FP), DX
+
+search_loop_encodeSnappyBetterBlockAsm10B:
+	MOVL  CX, SI
+	SUBL  12(SP), SI
+	SHRL  $0x05, SI
+	LEAL  1(CX)(SI*1), SI
+	CMPL  SI, 8(SP)
+	JGE   emit_remainder_encodeSnappyBetterBlockAsm10B
+	MOVQ  (DX)(CX*1), DI
+	MOVL  SI, 20(SP)
+	MOVQ  $0x0000cf1bbcdcbf9b, R9
+	MOVQ  $0x9e3779b1, SI
+	MOVQ  DI, R10
+	MOVQ  DI, R11
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x34, R10
+	SHLQ  $0x20, R11
+	IMULQ SI, R11
+	SHRQ  $0x36, R11
+	MOVL  24(SP)(R10*4), SI
+	MOVL  16408(SP)(R11*4), R8
+	MOVL  CX, 24(SP)(R10*4)
+	MOVL  CX, 16408(SP)(R11*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm10B
+	CMPL  (DX)(R8*1), DI
+	JEQ   candidateS_match_encodeSnappyBetterBlockAsm10B
+	MOVL  20(SP), CX
+	JMP   search_loop_encodeSnappyBetterBlockAsm10B
+
+candidateS_match_encodeSnappyBetterBlockAsm10B:
+	SHRQ  $0x08, DI
+	MOVQ  DI, R10
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x34, R10
+	MOVL  24(SP)(R10*4), SI
+	INCL  CX
+	MOVL  CX, 24(SP)(R10*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm10B
+	DECL  CX
+	MOVL  R8, SI
+
+candidate_match_encodeSnappyBetterBlockAsm10B:
+	MOVL  12(SP), DI
+	TESTL SI, SI
+	JZ    match_extend_back_end_encodeSnappyBetterBlockAsm10B
+
+match_extend_back_loop_encodeSnappyBetterBlockAsm10B:
+	CMPL CX, DI
+	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm10B
+	MOVB -1(DX)(SI*1), BL
+	MOVB -1(DX)(CX*1), R8
+	CMPB BL, R8
+	JNE  match_extend_back_end_encodeSnappyBetterBlockAsm10B
+	LEAL -1(CX), CX
+	DECL SI
+	JZ   match_extend_back_end_encodeSnappyBetterBlockAsm10B
+	JMP  match_extend_back_loop_encodeSnappyBetterBlockAsm10B
+
+match_extend_back_end_encodeSnappyBetterBlockAsm10B:
+	MOVL CX, DI
+	SUBL 12(SP), DI
+	LEAQ 3(AX)(DI*1), DI
+	CMPQ DI, (SP)
+	JL   match_dst_size_check_encodeSnappyBetterBlockAsm10B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_dst_size_check_encodeSnappyBetterBlockAsm10B:
+	MOVL CX, DI
+	ADDL $0x04, CX
+	ADDL $0x04, SI
+	MOVQ src_len+32(FP), R8
+	SUBL CX, R8
+	LEAQ (DX)(CX*1), R9
+	LEAQ (DX)(SI*1), R10
+
+	// matchLen
+	XORL R12, R12
+	CMPL R8, $0x08
+	JL   matchlen_single_match_nolit_encodeSnappyBetterBlockAsm10B
+
+matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm10B:
+	MOVQ  (R9)(R12*1), R11
+	XORQ  (R10)(R12*1), R11
+	TESTQ R11, R11
+	JZ    matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm10B
+	BSFQ  R11, R11
+	SARQ  $0x03, R11
+	LEAL  (R12)(R11*1), R12
+	JMP   match_nolit_end_encodeSnappyBetterBlockAsm10B
+
+matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm10B:
+	LEAL -8(R8), R8
+	LEAL 8(R12), R12
+	CMPL R8, $0x08
+	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm10B
+
+matchlen_single_match_nolit_encodeSnappyBetterBlockAsm10B:
+	TESTL R8, R8
+	JZ    match_nolit_end_encodeSnappyBetterBlockAsm10B
+
+matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm10B:
+	MOVB (R9)(R12*1), R11
+	CMPB (R10)(R12*1), R11
+	JNE  match_nolit_end_encodeSnappyBetterBlockAsm10B
+	LEAL 1(R12), R12
+	DECL R8
+	JNZ  matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm10B
+
+match_nolit_end_encodeSnappyBetterBlockAsm10B:
+	MOVL CX, R8
+	SUBL SI, R8
+
+	// Check if repeat
+	MOVL R8, 16(SP)
+	MOVL 12(SP), SI
+	CMPL SI, DI
+	JEQ  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm10B
+	MOVL DI, R9
+	MOVL DI, 12(SP)
+	LEAQ (DX)(SI*1), R10
+	SUBL SI, R9
+	LEAL -1(R9), SI
+	CMPL SI, $0x3c
+	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm10B
+	CMPL SI, $0x00000100
+	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm10B
+	MOVB $0xf4, (AX)
+	MOVW SI, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm10B
+
+two_bytes_match_emit_encodeSnappyBetterBlockAsm10B:
+	MOVB $0xf0, (AX)
+	MOVB SI, 1(AX)
+	ADDQ $0x02, AX
+	CMPL SI, $0x40
+	JL   memmove_match_emit_encodeSnappyBetterBlockAsm10B
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm10B
+
+one_byte_match_emit_encodeSnappyBetterBlockAsm10B:
+	SHLB $0x02, SI
+	MOVB SI, (AX)
+	ADDQ $0x01, AX
+
+memmove_match_emit_encodeSnappyBetterBlockAsm10B:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveShort
+	CMPQ R9, $0x03
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_1or2
+	JE   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_3
+	CMPQ R9, $0x08
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_4through7
+	CMPQ R9, $0x10
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_8through16
+	CMPQ R9, $0x20
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_17through32
+	JMP  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_33through64
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_1or2:
+	MOVB (R10), R11
+	MOVB -1(R10)(R9*1), R10
+	MOVB R11, (AX)
+	MOVB R10, -1(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_3:
+	MOVW (R10), R11
+	MOVB 2(R10), R10
+	MOVW R11, (AX)
+	MOVB R10, 2(AX)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_4through7:
+	MOVL (R10), R11
+	MOVL -4(R10)(R9*1), R10
+	MOVL R11, (AX)
+	MOVL R10, -4(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_8through16:
+	MOVQ (R10), R11
+	MOVQ -8(R10)(R9*1), R10
+	MOVQ R11, (AX)
+	MOVQ R10, -8(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_17through32:
+	MOVOU (R10), X0
+	MOVOU -16(R10)(R9*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(R9*1)
+	JMP   memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_33through64:
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+
+memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm10B:
+	MOVQ SI, AX
+	JMP  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm10B
+
+memmove_long_match_emit_encodeSnappyBetterBlockAsm10B:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveLong
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVQ  R9, R13
+	SHRQ  $0x05, R13
+	MOVQ  AX, R11
+	ANDL  $0x0000001f, R11
+	MOVQ  $0x00000040, R14
+	SUBQ  R11, R14
+	DECQ  R13
+	JA    emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm10Blarge_forward_sse_loop_32
+	LEAQ  -32(R10)(R14*1), R11
+	LEAQ  -32(AX)(R14*1), R15
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm10Blarge_big_loop_back:
+	MOVOU (R11), X4
+	MOVOU 16(R11), X5
+	MOVOA X4, (R15)
+	MOVOA X5, 16(R15)
+	ADDQ  $0x20, R15
+	ADDQ  $0x20, R11
+	ADDQ  $0x20, R14
+	DECQ  R13
+	JNA   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm10Blarge_big_loop_back
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm10Blarge_forward_sse_loop_32:
+	MOVOU -32(R10)(R14*1), X4
+	MOVOU -16(R10)(R14*1), X5
+	MOVOA X4, -32(AX)(R14*1)
+	MOVOA X5, -16(AX)(R14*1)
+	ADDQ  $0x20, R14
+	CMPQ  R9, R14
+	JAE   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm10Blarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+	MOVQ  SI, AX
+
+emit_literal_done_match_emit_encodeSnappyBetterBlockAsm10B:
+	ADDL R12, CX
+	ADDL $0x04, R12
+	MOVL CX, 12(SP)
+
+	// emitCopy
+two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm10B:
+	CMPL R12, $0x40
+	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm10B
+	MOVB $0xee, (AX)
+	MOVW R8, 1(AX)
+	LEAL -60(R12), R12
+	ADDQ $0x03, AX
+	JMP  two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm10B
+
+two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm10B:
+	CMPL R12, $0x0c
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B
+	CMPL R8, $0x00000800
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B
+	MOVB $0x01, BL
+	LEAL -16(BX)(R12*4), R12
+	MOVB R8, 1(AX)
+	SHRL $0x08, R8
+	SHLL $0x05, R8
+	ORL  R8, R12
+	MOVB R12, (AX)
+	ADDQ $0x02, AX
+	JMP  match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm10B
+
+emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B:
+	MOVB $0x02, BL
+	LEAL -4(BX)(R12*4), R12
+	MOVB R12, (AX)
+	MOVW R8, 1(AX)
+	ADDQ $0x03, AX
+
+match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm10B:
+	CMPL CX, 8(SP)
+	JGE  emit_remainder_encodeSnappyBetterBlockAsm10B
+	CMPQ AX, (SP)
+	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm10B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_nolit_dst_ok_encodeSnappyBetterBlockAsm10B:
+	MOVQ  $0x0000cf1bbcdcbf9b, SI
+	MOVQ  $0x9e3779b1, R8
+	INCL  DI
+	MOVQ  (DX)(DI*1), R9
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	MOVQ  R9, R12
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	SHRQ  $0x10, R12
+	LEAL  1(DI), R14
+	LEAL  2(DI), R15
+	MOVQ  -2(DX)(CX*1), R9
+	SHLQ  $0x10, R10
+	IMULQ SI, R10
+	SHRQ  $0x34, R10
+	SHLQ  $0x10, R13
+	IMULQ SI, R13
+	SHRQ  $0x34, R13
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x36, R11
+	SHLQ  $0x20, R12
+	IMULQ R8, R12
+	SHRQ  $0x36, R12
+	MOVL  DI, 24(SP)(R10*4)
+	MOVL  R14, 24(SP)(R13*4)
+	MOVL  R14, 16408(SP)(R11*4)
+	MOVL  R15, 16408(SP)(R12*4)
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	LEAL  -2(CX), R9
+	LEAL  -1(CX), DI
+	SHLQ  $0x10, R10
+	IMULQ SI, R10
+	SHRQ  $0x34, R10
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x36, R11
+	SHLQ  $0x10, R13
+	IMULQ SI, R13
+	SHRQ  $0x34, R13
+	MOVL  R9, 24(SP)(R10*4)
+	MOVL  DI, 16408(SP)(R11*4)
+	MOVL  DI, 24(SP)(R13*4)
+	JMP   search_loop_encodeSnappyBetterBlockAsm10B
+
+emit_remainder_encodeSnappyBetterBlockAsm10B:
+	MOVQ src_len+32(FP), CX
+	SUBL 12(SP), CX
+	LEAQ 3(AX)(CX*1), CX
+	CMPQ CX, (SP)
+	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm10B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+emit_remainder_ok_encodeSnappyBetterBlockAsm10B:
+	MOVQ src_len+32(FP), CX
+	MOVL 12(SP), BX
+	CMPL BX, CX
+	JEQ  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm10B
+	MOVL CX, SI
+	MOVL CX, 12(SP)
+	LEAQ (DX)(BX*1), CX
+	SUBL BX, SI
+	LEAL -1(SI), DX
+	CMPL DX, $0x3c
+	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm10B
+	CMPL DX, $0x00000100
+	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm10B
+	MOVB $0xf4, (AX)
+	MOVW DX, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+two_bytes_emit_remainder_encodeSnappyBetterBlockAsm10B:
+	MOVB $0xf0, (AX)
+	MOVB DL, 1(AX)
+	ADDQ $0x02, AX
+	CMPL DX, $0x40
+	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm10B
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+one_byte_emit_remainder_encodeSnappyBetterBlockAsm10B:
+	SHLB $0x02, DL
+	MOVB DL, (AX)
+	ADDQ $0x01, AX
+
+memmove_emit_remainder_encodeSnappyBetterBlockAsm10B:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveShort
+	CMPQ BX, $0x03
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_1or2
+	JE   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_3
+	CMPQ BX, $0x08
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_4through7
+	CMPQ BX, $0x10
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_8through16
+	CMPQ BX, $0x20
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_17through32
+	JMP  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_33through64
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_1or2:
+	MOVB (CX), SI
+	MOVB -1(CX)(BX*1), CL
+	MOVB SI, (AX)
+	MOVB CL, -1(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_3:
+	MOVW (CX), SI
+	MOVB 2(CX), CL
+	MOVW SI, (AX)
+	MOVB CL, 2(AX)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_4through7:
+	MOVL (CX), SI
+	MOVL -4(CX)(BX*1), CX
+	MOVL SI, (AX)
+	MOVL CX, -4(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_8through16:
+	MOVQ (CX), SI
+	MOVQ -8(CX)(BX*1), CX
+	MOVQ SI, (AX)
+	MOVQ CX, -8(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_17through32:
+	MOVOU (CX), X0
+	MOVOU -16(CX)(BX*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(BX*1)
+	JMP   memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm10B_memmove_move_33through64:
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+
+memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm10B:
+	MOVQ DX, AX
+	JMP  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10B:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveLong
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVQ  BX, DI
+	SHRQ  $0x05, DI
+	MOVQ  AX, SI
+	ANDL  $0x0000001f, SI
+	MOVQ  $0x00000040, R8
+	SUBQ  SI, R8
+	DECQ  DI
+	JA    emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10Blarge_forward_sse_loop_32
+	LEAQ  -32(CX)(R8*1), SI
+	LEAQ  -32(AX)(R8*1), R9
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10Blarge_big_loop_back:
+	MOVOU (SI), X4
+	MOVOU 16(SI), X5
+	MOVOA X4, (R9)
+	MOVOA X5, 16(R9)
+	ADDQ  $0x20, R9
+	ADDQ  $0x20, SI
+	ADDQ  $0x20, R8
+	DECQ  DI
+	JNA   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10Blarge_big_loop_back
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10Blarge_forward_sse_loop_32:
+	MOVOU -32(CX)(R8*1), X4
+	MOVOU -16(CX)(R8*1), X5
+	MOVOA X4, -32(AX)(R8*1)
+	MOVOA X5, -16(AX)(R8*1)
+	ADDQ  $0x20, R8
+	CMPQ  BX, R8
+	JAE   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10Blarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+	MOVQ  DX, AX
+
+emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm10B:
+	MOVQ dst_base+0(FP), CX
+	SUBQ CX, AX
+	MOVQ AX, ret+48(FP)
+	RET
+
+// func encodeSnappyBetterBlockAsm8B(dst []byte, src []byte) int
+// Requires: SSE2
+TEXT ·encodeSnappyBetterBlockAsm8B(SB), $5144-56
+	MOVQ dst_base+0(FP), AX
+	MOVQ $0x00000028, CX
+	LEAQ 24(SP), DX
+	PXOR X0, X0
+
+zero_loop_encodeSnappyBetterBlockAsm8B:
+	MOVOU X0, (DX)
+	MOVOU X0, 16(DX)
+	MOVOU X0, 32(DX)
+	MOVOU X0, 48(DX)
+	MOVOU X0, 64(DX)
+	MOVOU X0, 80(DX)
+	MOVOU X0, 96(DX)
+	MOVOU X0, 112(DX)
+	ADDQ  $0x80, DX
+	DECQ  CX
+	JNZ   zero_loop_encodeSnappyBetterBlockAsm8B
+	MOVL  $0x00000000, 12(SP)
+	MOVQ  src_len+32(FP), CX
+	LEAQ  -6(CX), DX
+	LEAQ  -8(CX), SI
+	MOVL  SI, 8(SP)
+	SHRQ  $0x05, CX
+	SUBL  CX, DX
+	LEAQ  (AX)(DX*1), DX
+	MOVQ  DX, (SP)
+	MOVL  $0x00000001, CX
+	MOVL  $0x00000000, 16(SP)
+	MOVQ  src_base+24(FP), DX
+
+search_loop_encodeSnappyBetterBlockAsm8B:
+	MOVL  CX, SI
+	SUBL  12(SP), SI
+	SHRL  $0x04, SI
+	LEAL  1(CX)(SI*1), SI
+	CMPL  SI, 8(SP)
+	JGE   emit_remainder_encodeSnappyBetterBlockAsm8B
+	MOVQ  (DX)(CX*1), DI
+	MOVL  SI, 20(SP)
+	MOVQ  $0x0000cf1bbcdcbf9b, R9
+	MOVQ  $0x9e3779b1, SI
+	MOVQ  DI, R10
+	MOVQ  DI, R11
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x36, R10
+	SHLQ  $0x20, R11
+	IMULQ SI, R11
+	SHRQ  $0x38, R11
+	MOVL  24(SP)(R10*4), SI
+	MOVL  4120(SP)(R11*4), R8
+	MOVL  CX, 24(SP)(R10*4)
+	MOVL  CX, 4120(SP)(R11*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm8B
+	CMPL  (DX)(R8*1), DI
+	JEQ   candidateS_match_encodeSnappyBetterBlockAsm8B
+	MOVL  20(SP), CX
+	JMP   search_loop_encodeSnappyBetterBlockAsm8B
+
+candidateS_match_encodeSnappyBetterBlockAsm8B:
+	SHRQ  $0x08, DI
+	MOVQ  DI, R10
+	SHLQ  $0x10, R10
+	IMULQ R9, R10
+	SHRQ  $0x36, R10
+	MOVL  24(SP)(R10*4), SI
+	INCL  CX
+	MOVL  CX, 24(SP)(R10*4)
+	CMPL  (DX)(SI*1), DI
+	JEQ   candidate_match_encodeSnappyBetterBlockAsm8B
+	DECL  CX
+	MOVL  R8, SI
+
+candidate_match_encodeSnappyBetterBlockAsm8B:
+	MOVL  12(SP), DI
+	TESTL SI, SI
+	JZ    match_extend_back_end_encodeSnappyBetterBlockAsm8B
+
+match_extend_back_loop_encodeSnappyBetterBlockAsm8B:
+	CMPL CX, DI
+	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm8B
+	MOVB -1(DX)(SI*1), BL
+	MOVB -1(DX)(CX*1), R8
+	CMPB BL, R8
+	JNE  match_extend_back_end_encodeSnappyBetterBlockAsm8B
+	LEAL -1(CX), CX
+	DECL SI
+	JZ   match_extend_back_end_encodeSnappyBetterBlockAsm8B
+	JMP  match_extend_back_loop_encodeSnappyBetterBlockAsm8B
+
+match_extend_back_end_encodeSnappyBetterBlockAsm8B:
+	MOVL CX, DI
+	SUBL 12(SP), DI
+	LEAQ 3(AX)(DI*1), DI
+	CMPQ DI, (SP)
+	JL   match_dst_size_check_encodeSnappyBetterBlockAsm8B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_dst_size_check_encodeSnappyBetterBlockAsm8B:
+	MOVL CX, DI
+	ADDL $0x04, CX
+	ADDL $0x04, SI
+	MOVQ src_len+32(FP), R8
+	SUBL CX, R8
+	LEAQ (DX)(CX*1), R9
+	LEAQ (DX)(SI*1), R10
+
+	// matchLen
+	XORL R12, R12
+	CMPL R8, $0x08
+	JL   matchlen_single_match_nolit_encodeSnappyBetterBlockAsm8B
+
+matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm8B:
+	MOVQ  (R9)(R12*1), R11
+	XORQ  (R10)(R12*1), R11
+	TESTQ R11, R11
+	JZ    matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm8B
+	BSFQ  R11, R11
+	SARQ  $0x03, R11
+	LEAL  (R12)(R11*1), R12
+	JMP   match_nolit_end_encodeSnappyBetterBlockAsm8B
+
+matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm8B:
+	LEAL -8(R8), R8
+	LEAL 8(R12), R12
+	CMPL R8, $0x08
+	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm8B
+
+matchlen_single_match_nolit_encodeSnappyBetterBlockAsm8B:
+	TESTL R8, R8
+	JZ    match_nolit_end_encodeSnappyBetterBlockAsm8B
+
+matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm8B:
+	MOVB (R9)(R12*1), R11
+	CMPB (R10)(R12*1), R11
+	JNE  match_nolit_end_encodeSnappyBetterBlockAsm8B
+	LEAL 1(R12), R12
+	DECL R8
+	JNZ  matchlen_single_loopback_match_nolit_encodeSnappyBetterBlockAsm8B
+
+match_nolit_end_encodeSnappyBetterBlockAsm8B:
+	MOVL CX, R8
+	SUBL SI, R8
+
+	// Check if repeat
+	MOVL R8, 16(SP)
+	MOVL 12(SP), SI
+	CMPL SI, DI
+	JEQ  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm8B
+	MOVL DI, R9
+	MOVL DI, 12(SP)
+	LEAQ (DX)(SI*1), R10
+	SUBL SI, R9
+	LEAL -1(R9), SI
+	CMPL SI, $0x3c
+	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm8B
+	CMPL SI, $0x00000100
+	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm8B
+	MOVB $0xf4, (AX)
+	MOVW SI, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm8B
+
+two_bytes_match_emit_encodeSnappyBetterBlockAsm8B:
+	MOVB $0xf0, (AX)
+	MOVB SI, 1(AX)
+	ADDQ $0x02, AX
+	CMPL SI, $0x40
+	JL   memmove_match_emit_encodeSnappyBetterBlockAsm8B
+	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm8B
+
+one_byte_match_emit_encodeSnappyBetterBlockAsm8B:
+	SHLB $0x02, SI
+	MOVB SI, (AX)
+	ADDQ $0x01, AX
+
+memmove_match_emit_encodeSnappyBetterBlockAsm8B:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveShort
+	CMPQ R9, $0x03
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_1or2
+	JE   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_3
+	CMPQ R9, $0x08
+	JB   emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_4through7
+	CMPQ R9, $0x10
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_8through16
+	CMPQ R9, $0x20
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_17through32
+	JMP  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_33through64
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_1or2:
+	MOVB (R10), R11
+	MOVB -1(R10)(R9*1), R10
+	MOVB R11, (AX)
+	MOVB R10, -1(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_3:
+	MOVW (R10), R11
+	MOVB 2(R10), R10
+	MOVW R11, (AX)
+	MOVB R10, 2(AX)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_4through7:
+	MOVL (R10), R11
+	MOVL -4(R10)(R9*1), R10
+	MOVL R11, (AX)
+	MOVL R10, -4(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_8through16:
+	MOVQ (R10), R11
+	MOVQ -8(R10)(R9*1), R10
+	MOVQ R11, (AX)
+	MOVQ R10, -8(AX)(R9*1)
+	JMP  memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_17through32:
+	MOVOU (R10), X0
+	MOVOU -16(R10)(R9*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(R9*1)
+	JMP   memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_33through64:
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+
+memmove_end_copy_match_emit_encodeSnappyBetterBlockAsm8B:
+	MOVQ SI, AX
+	JMP  emit_literal_done_match_emit_encodeSnappyBetterBlockAsm8B
+
+memmove_long_match_emit_encodeSnappyBetterBlockAsm8B:
+	LEAQ (AX)(R9*1), SI
+
+	// genMemMoveLong
+	MOVOU (R10), X0
+	MOVOU 16(R10), X1
+	MOVOU -32(R10)(R9*1), X2
+	MOVOU -16(R10)(R9*1), X3
+	MOVQ  R9, R13
+	SHRQ  $0x05, R13
+	MOVQ  AX, R11
+	ANDL  $0x0000001f, R11
+	MOVQ  $0x00000040, R14
+	SUBQ  R11, R14
+	DECQ  R13
+	JA    emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm8Blarge_forward_sse_loop_32
+	LEAQ  -32(R10)(R14*1), R11
+	LEAQ  -32(AX)(R14*1), R15
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm8Blarge_big_loop_back:
+	MOVOU (R11), X4
+	MOVOU 16(R11), X5
+	MOVOA X4, (R15)
+	MOVOA X5, 16(R15)
+	ADDQ  $0x20, R15
+	ADDQ  $0x20, R11
+	ADDQ  $0x20, R14
+	DECQ  R13
+	JNA   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm8Blarge_big_loop_back
+
+emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm8Blarge_forward_sse_loop_32:
+	MOVOU -32(R10)(R14*1), X4
+	MOVOU -16(R10)(R14*1), X5
+	MOVOA X4, -32(AX)(R14*1)
+	MOVOA X5, -16(AX)(R14*1)
+	ADDQ  $0x20, R14
+	CMPQ  R9, R14
+	JAE   emit_lit_memmove_long_match_emit_encodeSnappyBetterBlockAsm8Blarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(R9*1)
+	MOVOU X3, -16(AX)(R9*1)
+	MOVQ  SI, AX
+
+emit_literal_done_match_emit_encodeSnappyBetterBlockAsm8B:
+	ADDL R12, CX
+	ADDL $0x04, R12
+	MOVL CX, 12(SP)
+
+	// emitCopy
+two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm8B:
+	CMPL R12, $0x40
+	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm8B
+	MOVB $0xee, (AX)
+	MOVW R8, 1(AX)
+	LEAL -60(R12), R12
+	ADDQ $0x03, AX
+	JMP  two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm8B
+
+two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm8B:
+	CMPL R12, $0x0c
+	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm8B
+	MOVB $0x01, BL
+	LEAL -16(BX)(R12*4), R12
+	MOVB R8, 1(AX)
+	SHRL $0x08, R8
+	SHLL $0x05, R8
+	ORL  R8, R12
+	MOVB R12, (AX)
+	ADDQ $0x02, AX
+	JMP  match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm8B
+
+emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm8B:
+	MOVB $0x02, BL
+	LEAL -4(BX)(R12*4), R12
+	MOVB R12, (AX)
+	MOVW R8, 1(AX)
+	ADDQ $0x03, AX
+
+match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm8B:
+	CMPL CX, 8(SP)
+	JGE  emit_remainder_encodeSnappyBetterBlockAsm8B
+	CMPQ AX, (SP)
+	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm8B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+match_nolit_dst_ok_encodeSnappyBetterBlockAsm8B:
+	MOVQ  $0x0000cf1bbcdcbf9b, SI
+	MOVQ  $0x9e3779b1, R8
+	INCL  DI
+	MOVQ  (DX)(DI*1), R9
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	MOVQ  R9, R12
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	SHRQ  $0x10, R12
+	LEAL  1(DI), R14
+	LEAL  2(DI), R15
+	MOVQ  -2(DX)(CX*1), R9
+	SHLQ  $0x10, R10
+	IMULQ SI, R10
+	SHRQ  $0x36, R10
+	SHLQ  $0x10, R13
+	IMULQ SI, R13
+	SHRQ  $0x36, R13
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x38, R11
+	SHLQ  $0x20, R12
+	IMULQ R8, R12
+	SHRQ  $0x38, R12
+	MOVL  DI, 24(SP)(R10*4)
+	MOVL  R14, 24(SP)(R13*4)
+	MOVL  R14, 4120(SP)(R11*4)
+	MOVL  R15, 4120(SP)(R12*4)
+	MOVQ  R9, R10
+	MOVQ  R9, R11
+	SHRQ  $0x08, R11
+	MOVQ  R11, R13
+	LEAL  -2(CX), R9
+	LEAL  -1(CX), DI
+	SHLQ  $0x10, R10
+	IMULQ SI, R10
+	SHRQ  $0x36, R10
+	SHLQ  $0x20, R11
+	IMULQ R8, R11
+	SHRQ  $0x38, R11
+	SHLQ  $0x10, R13
+	IMULQ SI, R13
+	SHRQ  $0x36, R13
+	MOVL  R9, 24(SP)(R10*4)
+	MOVL  DI, 4120(SP)(R11*4)
+	MOVL  DI, 24(SP)(R13*4)
+	JMP   search_loop_encodeSnappyBetterBlockAsm8B
+
+emit_remainder_encodeSnappyBetterBlockAsm8B:
+	MOVQ src_len+32(FP), CX
+	SUBL 12(SP), CX
+	LEAQ 3(AX)(CX*1), CX
+	CMPQ CX, (SP)
+	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm8B
+	MOVQ $0x00000000, ret+48(FP)
+	RET
+
+emit_remainder_ok_encodeSnappyBetterBlockAsm8B:
+	MOVQ src_len+32(FP), CX
+	MOVL 12(SP), BX
+	CMPL BX, CX
+	JEQ  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm8B
+	MOVL CX, SI
+	MOVL CX, 12(SP)
+	LEAQ (DX)(BX*1), CX
+	SUBL BX, SI
+	LEAL -1(SI), DX
+	CMPL DX, $0x3c
+	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm8B
+	CMPL DX, $0x00000100
+	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm8B
+	MOVB $0xf4, (AX)
+	MOVW DX, 1(AX)
+	ADDQ $0x03, AX
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+two_bytes_emit_remainder_encodeSnappyBetterBlockAsm8B:
+	MOVB $0xf0, (AX)
+	MOVB DL, 1(AX)
+	ADDQ $0x02, AX
+	CMPL DX, $0x40
+	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm8B
+	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+one_byte_emit_remainder_encodeSnappyBetterBlockAsm8B:
+	SHLB $0x02, DL
+	MOVB DL, (AX)
+	ADDQ $0x01, AX
+
+memmove_emit_remainder_encodeSnappyBetterBlockAsm8B:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveShort
+	CMPQ BX, $0x03
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_1or2
+	JE   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_3
+	CMPQ BX, $0x08
+	JB   emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_4through7
+	CMPQ BX, $0x10
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_8through16
+	CMPQ BX, $0x20
+	JBE  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_17through32
+	JMP  emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_33through64
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_1or2:
+	MOVB (CX), SI
+	MOVB -1(CX)(BX*1), CL
+	MOVB SI, (AX)
+	MOVB CL, -1(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_3:
+	MOVW (CX), SI
+	MOVB 2(CX), CL
+	MOVW SI, (AX)
+	MOVB CL, 2(AX)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_4through7:
+	MOVL (CX), SI
+	MOVL -4(CX)(BX*1), CX
+	MOVL SI, (AX)
+	MOVL CX, -4(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_8through16:
+	MOVQ (CX), SI
+	MOVQ -8(CX)(BX*1), CX
+	MOVQ SI, (AX)
+	MOVQ CX, -8(AX)(BX*1)
+	JMP  memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_17through32:
+	MOVOU (CX), X0
+	MOVOU -16(CX)(BX*1), X1
+	MOVOU X0, (AX)
+	MOVOU X1, -16(AX)(BX*1)
+	JMP   memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+emit_lit_memmove_emit_remainder_encodeSnappyBetterBlockAsm8B_memmove_move_33through64:
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+
+memmove_end_copy_emit_remainder_encodeSnappyBetterBlockAsm8B:
+	MOVQ DX, AX
+	JMP  emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8B:
+	LEAQ (AX)(SI*1), DX
+	MOVL SI, BX
+
+	// genMemMoveLong
+	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU -32(CX)(BX*1), X2
+	MOVOU -16(CX)(BX*1), X3
+	MOVQ  BX, DI
+	SHRQ  $0x05, DI
+	MOVQ  AX, SI
+	ANDL  $0x0000001f, SI
+	MOVQ  $0x00000040, R8
+	SUBQ  SI, R8
+	DECQ  DI
+	JA    emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8Blarge_forward_sse_loop_32
+	LEAQ  -32(CX)(R8*1), SI
+	LEAQ  -32(AX)(R8*1), R9
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8Blarge_big_loop_back:
+	MOVOU (SI), X4
+	MOVOU 16(SI), X5
+	MOVOA X4, (R9)
+	MOVOA X5, 16(R9)
+	ADDQ  $0x20, R9
+	ADDQ  $0x20, SI
+	ADDQ  $0x20, R8
+	DECQ  DI
+	JNA   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8Blarge_big_loop_back
+
+emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8Blarge_forward_sse_loop_32:
+	MOVOU -32(CX)(R8*1), X4
+	MOVOU -16(CX)(R8*1), X5
+	MOVOA X4, -32(AX)(R8*1)
+	MOVOA X5, -16(AX)(R8*1)
+	ADDQ  $0x20, R8
+	CMPQ  BX, R8
+	JAE   emit_lit_memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8Blarge_forward_sse_loop_32
+	MOVOU X0, (AX)
+	MOVOU X1, 16(AX)
+	MOVOU X2, -32(AX)(BX*1)
+	MOVOU X3, -16(AX)(BX*1)
+	MOVQ  DX, AX
+
+emit_literal_done_emit_remainder_encodeSnappyBetterBlockAsm8B:
 	MOVQ dst_base+0(FP), CX
 	SUBQ CX, AX
 	MOVQ AX, ret+48(FP)

--- a/s2/s2.go
+++ b/s2/s2.go
@@ -90,6 +90,9 @@ const (
 	// Default block size
 	defaultBlockSize = 1 << 20
 
+	// maxSnappyBlockSize is the maximum snappy block size.
+	maxSnappyBlockSize = 1 << 16
+
 	obufHeaderLen = checksumSize + chunkHeaderSize
 )
 


### PR DESCRIPTION
S2 can now fully replace snappy and generate snappy output at all compression levels, including streaming.

Comparison of [`webdevdata.org-2015-01-07-subset`](https://files.klauspost.com/compress/webdevdata.org-2015-01-07-4GB-subset.7z),
53927 files, total input size: 4,014,735,833 bytes. amd64, single goroutine used:

| Encoder               | Size       | MB/s   |
|-----------------------|------------|--------|
| snappy.Encode         | 1128706759 | 725.59 |
| s2.EncodeSnappy       | 1093823291 | 899.16 |
| s2.EncodeSnappyBetter | 1001158548 | 578.49 |
| s2.EncodeSnappyBest   | 944507998  | 66.00  |


Comparison of different streams, AMD Ryzen 3950x, 16 cores. Size and throughput: 

| File                        | snappy.NewWriter         | S2 Snappy                 | S2 Snappy, Better        | S2 Snappy, Best         |
|-----------------------------|--------------------------|---------------------------|--------------------------|-------------------------|
| nyc-taxi-data-10M.csv       | 1316042016 - 517.54MB/s  | 1307003093 - 8406.29MB/s  | 1174534014 - 4984.35MB/s | 1115904679 - 177.81MB/s |
| enwik10                     | 5088294643 - 433.45MB/s  | 5175840939 - 8454.52MB/s  | 4560784526 - 4403.10MB/s | 4340299103 - 159.71MB/s |
| 10gb.tar                    | 6056946612 - 703.25MB/s  | 6208571995 - 9035.75MB/s  | 5741646126 - 2402.08MB/s | 5548973895 - 171.17MB/s |
| github-june-2days-2019.json | 1525176492 - 908.11MB/s  | 1476519054 - 12625.93MB/s | 1400547532 - 6163.61MB/s | 1321887137 - 200.71MB/s |
| consensus.db.10gb           | 5412897703 - 1054.38MB/s | 5354073487 - 12634.82MB/s | 5335069899 - 2472.23MB/s | 5201000954 - 166.32MB/s |
