### PR TITLE
s2sx: Fix max size error

### DIFF
--- a/s2/cmd/_s2sx/main.go
+++ b/s2/cmd/_s2sx/main.go
@@ -296,7 +296,7 @@ func toSize(size string) (int64, error) {
 
 	switch multiple {
 	case "G", "GB", "GIB":
-		return bytes * 1 << 20, nil
+		return bytes * 1 << 30, nil
 	case "M", "MB", "MIB":
 		return bytes * 1 << 20, nil
 	case "K", "KB", "KIB":


### PR DESCRIPTION
Fixes `ERROR: max size less than unpacker. Max size must be at least 2170369 bytes`.

Use `s2sx -max=1024MB` as a workaround.