### PR TITLE
s2: Add stream index

### DIFF
--- a/s2/README.md
+++ b/s2/README.md
@@ -141,7 +141,7 @@ Binaries can be downloaded on the [Releases Page](https://github.com/klauspost/c
 
 Installing then requires Go to be installed. To install them, use:
 
-`go install github.com/klauspost/compress/s2/cmd/s2c && go install github.com/klauspost/compress/s2/cmd/s2d`
+`go install github.com/klauspost/compress/s2/cmd/s2c@latest && go install github.com/klauspost/compress/s2/cmd/s2d@latest`
 
 To build binaries to the current folder use:
 
@@ -176,6 +176,8 @@ Options:
     	Compress faster, but with a minor compression loss
   -help
     	Display help
+  -index
+        Add seek index (default true)    	
   -o string
         Write output to another file. Single input file only
   -pad string
@@ -217,11 +219,15 @@ Options:
     	Display help
   -o string
         Write output to another file. Single input file only
-  -q	Don't write any output to terminal, except errors
+  -offset string
+        Start at offset. Examples: 92, 64K, 256K, 1M, 4M. Requires Index
+  -q    Don't write any output to terminal, except errors
   -rm
-    	Delete source file(s) after successful decompression
+        Delete source file(s) after successful decompression
   -safe
-    	Do not overwrite output files
+        Do not overwrite output files
+  -tail string
+        Return last of compressed file. Examples: 92, 64K, 256K, 1M, 4M. Requires Index
   -verify
     	Verify files, but do not write output                                      
 ```
@@ -730,7 +736,7 @@ with un-encoded value length of 64 bits, unless other limits are specified.
 | ID, `[1]byte`                                                           | Always 0x99.                                                                                                                  |
 | Data Length, `[3]byte`                                                  | 3 byte little-endian length of the chunk in bytes, following this.                                                            |
 | Header `[6]byte`                                                        | Header, must be `[115, 50, 105, 100, 120, 0]` or in text: "s2idx\x00".                                                        |
-| UncompressedSize, Varint                                                | Total Uncompressed size if known. Should be -1 if unknown.                                                                    |
+| UncompressedSize, Varint                                                | Total Uncompressed size.                                                                                                      |
 | CompressedSize, Varint                                                  | Total Compressed size if known. Should be -1 if unknown.                                                                      |
 | EstBlockSize, Varint                                                    | Block Size, used for guessing uncompressed offsets. Must be >= 0.                                                             |
 | Entries, Varint                                                         | Number of Entries in index, must be < 65536 and >=0.                                                                          |
@@ -755,9 +761,6 @@ In fact there is a maximum of 65536 block entries in an index.
 
 The writer can use any method to reduce the number of entries.
 An implicit block start at 0,0 can be assumed.
-
-It is strongly recommended adding `UncompressedSize`, 
-otherwise seeking from end-of-file (tailing for example) will not be possible. 
 
 ### Decoding entries:
 

--- a/s2/README.md
+++ b/s2/README.md
@@ -723,6 +723,8 @@ The `index` can then be used needing to read from the stream.
 This means the index can be used without needing to seek to the end of the stream 
 or for manually forwarding streams. See below.
 
+Finally, an existing S2/Snappy stream can be indexed using the `s2.IndexStream(r io.Reader)` function.
+
 ## Using Indexes
 
 To use indexes there is a `ReadSeeker(random bool, index []byte) (*ReadSeeker, error)` function available.
@@ -763,6 +765,8 @@ Finally, since we specify that we want to do random seeking `r` must be an io.Se
 The returned [ReadSeeker](https://pkg.go.dev/github.com/klauspost/compress/s2#ReadSeeker) contains a shallow reference to the existing Reader,
 meaning changes performed to one is reflected in the other.
 
+To check if a stream contains an index at the end, the `(*Index).LoadStream(rs io.ReadSeeker) error` can be used.
+
 ## Manually Forwarding Streams
 
 Indexes can also be read outside the decoder using the [Index](https://pkg.go.dev/github.com/klauspost/compress/s2#Index) type.
@@ -792,12 +796,12 @@ from the beginning of the compressed file.
 The `uncompressedOffset` will then be offset of the uncompressed bytes returned
 when decoding from that position. This will always be <= wantOffset.
 
-When creating a decoder it must be specified that it should *not* expect a frame header
+When creating a decoder it must be specified that it should *not* expect a stream identifier
 at the beginning of the stream. Assuming the io.Reader `r` has been forwarded to `compressedOffset`
 we create the decoder like this:
 
 ```
-	dec := s2.NewReader(r, s2.ReaderIgnoreFrameHeader())
+	dec := s2.NewReader(r, s2.ReaderIgnoreStreamIdentifier())
 ```
 
 We are not completely done. We still need to forward the stream the uncompressed bytes we didn't want.

--- a/s2/README.md
+++ b/s2/README.md
@@ -640,12 +640,12 @@ Compression and speed is typically a bit better `MaxEncodedLen` is also smaller 
 Comparison of [`webdevdata.org-2015-01-07-subset`](https://files.klauspost.com/compress/webdevdata.org-2015-01-07-4GB-subset.7z),
 53927 files, total input size: 4,014,735,833 bytes. amd64, single goroutine used:
 
-| Encoder               | Size       | MB/s   | Reduction |
-|-----------------------|------------|--------|------------
-| snappy.Encode         | 1128706759 | 725.59 | 71.89%    |
-| s2.EncodeSnappy       | 1093823291 | 899.16 | 72.75%    |
-| s2.EncodeSnappyBetter | 1001158548 | 578.49 | 75.06%    |
-| s2.EncodeSnappyBest   | 944507998  | 66.00  | 76.47%    |
+| Encoder               | Size       | MB/s       | Reduction |
+|-----------------------|------------|------------|------------
+| snappy.Encode         | 1128706759 | 725.59     | 71.89%    |
+| s2.EncodeSnappy       | 1093823291 | **899.16** | 72.75%    |
+| s2.EncodeSnappyBetter | 1001158548 | 578.49     | 75.06%    |
+| s2.EncodeSnappyBest   | 944507998  | 66.00      | **76.47%**|
 
 ## Streams
 
@@ -657,7 +657,7 @@ Comparison of different streams, AMD Ryzen 3950x, 16 cores. Size and throughput:
 | File                        | snappy.NewWriter         | S2 Snappy                 | S2 Snappy, Better        | S2 Snappy, Best         |
 |-----------------------------|--------------------------|---------------------------|--------------------------|-------------------------|
 | nyc-taxi-data-10M.csv       | 1316042016 - 539.47MB/s  | 1307003093 - 10132.73MB/s | 1174534014 - 5002.44MB/s | 1115904679 - 177.97MB/s |
-| enwik10 (xml)               | 5088294643 - 433.45MB/s  | 5175840939 -  8454.52MB/s | 4560784526 - 4403.10MB/s | 4340299103 - 159.71MB/s |
+| enwik10 (xml)               | 5088294643 - 451.13MB/s  | 5175840939 -  9440.69MB/s | 4560784526 - 4487.21MB/s | 4340299103 - 158.92MB/s |
 | 10gb.tar (mixed)            | 6056946612 - 729.73MB/s  | 6208571995 -  9978.05MB/s | 5741646126 - 4919.98MB/s | 5548973895 - 180.44MB/s |
 | github-june-2days-2019.json | 1525176492 - 933.00MB/s  | 1476519054 - 13150.12MB/s | 1400547532 - 5803.40MB/s | 1321887137 - 204.29MB/s |
 | consensus.db.10gb (db)      | 5412897703 - 1102.14MB/s | 5354073487 - 13562.91MB/s | 5335069899 - 5294.73MB/s | 5201000954 - 175.72MB/s |

--- a/s2/cmd/s2c/main.go
+++ b/s2/cmd/s2c/main.go
@@ -35,7 +35,7 @@ var (
 	blockSize = flag.String("blocksize", "4M", "Max  block size. Examples: 64K, 256K, 1M, 4M. Must be power of two and <= 4MB")
 	block     = flag.Bool("block", false, "Compress as a single block. Will load content into memory.")
 	safe      = flag.Bool("safe", false, "Do not overwrite output files")
-	index     = flag.Bool("index", false, "Add seek index")
+	index     = flag.Bool("index", true, "Add seek index")
 	padding   = flag.String("pad", "1", "Pad size to a multiple of this value, Examples: 500, 64K, 256K, 1M, 4M, etc")
 	stdout    = flag.Bool("c", false, "Write all output to stdout. Multiple input files will be concatenated")
 	out       = flag.String("o", "", "Write output to another file. Single input file only")

--- a/s2/cmd/s2c/main.go
+++ b/s2/cmd/s2c/main.go
@@ -35,6 +35,7 @@ var (
 	blockSize = flag.String("blocksize", "4M", "Max  block size. Examples: 64K, 256K, 1M, 4M. Must be power of two and <= 4MB")
 	block     = flag.Bool("block", false, "Compress as a single block. Will load content into memory.")
 	safe      = flag.Bool("safe", false, "Do not overwrite output files")
+	index     = flag.Bool("index", false, "Add seek index")
 	padding   = flag.String("pad", "1", "Pad size to a multiple of this value, Examples: 500, 64K, 256K, 1M, 4M, etc")
 	stdout    = flag.Bool("c", false, "Write all output to stdout. Multiple input files will be concatenated")
 	out       = flag.String("o", "", "Write output to another file. Single input file only")
@@ -85,6 +86,9 @@ Options:`)
 		os.Exit(0)
 	}
 	opts := []s2.WriterOption{s2.WriterBlockSize(int(sz)), s2.WriterConcurrency(*cpu), s2.WriterPadding(int(pad))}
+	if *index {
+		opts = append(opts, s2.WriterAddIndex())
+	}
 	if !*faster {
 		opts = append(opts, s2.WriterBetterCompression())
 	}

--- a/s2/decode.go
+++ b/s2/decode.go
@@ -100,7 +100,7 @@ func NewReader(r io.Reader, opts ...ReaderOption) *Reader {
 	} else {
 		nr.buf = make([]byte, MaxEncodedLen(defaultBlockSize)+checksumSize)
 	}
-	nr.readHeader = nr.ignoreFrameHeader
+	nr.readHeader = nr.ignoreStreamID
 	nr.paramsOK = true
 	return &nr
 }
@@ -144,12 +144,12 @@ func ReaderAllocBlock(blockSize int) ReaderOption {
 	}
 }
 
-// ReaderIgnoreFrameHeader will make the reader skip the expected
-// frame header at the beginning of the stream.
+// ReaderIgnoreStreamIdentifier will make the reader skip the expected
+// stream identifier at the beginning of the stream.
 // This can be used when serving a stream that has been forwarded to a specific point.
-func ReaderIgnoreFrameHeader() ReaderOption {
+func ReaderIgnoreStreamIdentifier() ReaderOption {
 	return func(r *Reader) error {
-		r.ignoreFrameHeader = true
+		r.ignoreStreamID = true
 		return nil
 	}
 }
@@ -186,11 +186,11 @@ type Reader struct {
 	// maximum expected buffer size.
 	maxBufSize int
 	// alloc a buffer this size if > 0.
-	lazyBuf           int
-	readHeader        bool
-	paramsOK          bool
-	snappyFrame       bool
-	ignoreFrameHeader bool
+	lazyBuf        int
+	readHeader     bool
+	paramsOK       bool
+	snappyFrame    bool
+	ignoreStreamID bool
 }
 
 // ensureBufferSize will ensure that the buffer can take at least n bytes.
@@ -220,7 +220,7 @@ func (r *Reader) Reset(reader io.Reader) {
 	r.err = nil
 	r.i = 0
 	r.j = 0
-	r.readHeader = r.ignoreFrameHeader
+	r.readHeader = r.ignoreStreamID
 }
 
 func (r *Reader) readFull(p []byte, allowEOF bool) (ok bool) {

--- a/s2/decode.go
+++ b/s2/decode.go
@@ -674,7 +674,7 @@ func (r *ReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	if r.err != nil {
 		return 0, r.err
 	}
-	if offset == 0 {
+	if offset == 0 && whence == io.SeekCurrent {
 		return r.blockStart + int64(r.i), nil
 	}
 	if !r.readHeader {

--- a/s2/encode.go
+++ b/s2/encode.go
@@ -1095,7 +1095,7 @@ func (w *Writer) Close() error {
 // CloseIndex calls Close and returns an index on first call.
 // This is not required if you are only adding index to a stream.
 func (w *Writer) CloseIndex() ([]byte, error) {
-	return w.closeIndex(false)
+	return w.closeIndex(true)
 }
 
 func (w *Writer) closeIndex(idx bool) ([]byte, error) {

--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -251,7 +251,10 @@ func TestIndex(t *testing.T) {
 	todo := input
 	for len(todo) > 0 {
 		// Write random sized inputs..
-		x := todo[:rng.Intn((len(todo)&65535)+2)]
+		x := todo[:rng.Intn(1+len(todo)&65535)]
+		if len(x) == 0 {
+			x = todo[:1]
+		}
 		_, err := enc.Write(x)
 		fatalErr(t, err)
 		// Flush once in a while

--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -219,6 +220,113 @@ func TestEncoderRegression(t *testing.T) {
 				return
 			}
 			test(t, b[:len(b):len(b)])
+		})
+	}
+}
+
+func TestIndex(t *testing.T) {
+	fatalErr := func(t testing.TB, err error) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create a test corpus
+	var input []byte
+	if !testing.Short() {
+		input = make([]byte, 10<<20)
+	} else {
+		input = make([]byte, 500<<10)
+	}
+	rng := rand.New(rand.NewSource(0xabeefcafe))
+	rng.Read(input)
+	// Make it compressible...
+	for i, v := range input {
+		input[i] = '0' + v&3
+	}
+	// Compress it...
+	var buf bytes.Buffer
+	// We use smaller blocks just for the example...
+	enc := NewWriter(&buf, WriterBlockSize(100<<10), WriterAddIndex(), WriterBetterCompression(), WriterConcurrency(runtime.GOMAXPROCS(0)))
+	_, err := enc.Write(input)
+	fatalErr(t, err)
+
+	// Close and also get index...
+	idxBytes, err := enc.CloseIndex()
+	fatalErr(t, err)
+
+	// This is our compressed stream...
+	compressed := buf.Bytes()
+	for wantOffset := int64(0); wantOffset < int64(len(input)); wantOffset += 65531 {
+		t.Run(fmt.Sprintf("offset-%d", wantOffset), func(t *testing.T) {
+			// Let's assume we want to read from uncompressed offset 'i'
+			// and we cannot seek in input, but we have the index.
+			want := input[wantOffset:]
+
+			// Load the index.
+			var index Index
+			_, err = index.Load(idxBytes)
+			fatalErr(t, err)
+
+			// Find offset in file:
+			compressedOffset, uncompressedOffset, err := index.Find(wantOffset)
+			fatalErr(t, err)
+
+			// Offset the input to the compressed offset.
+			// Notice how we do not provide any bytes before the offset.
+			in := io.Reader(bytes.NewBuffer(compressed[compressedOffset:]))
+
+			// When creating the decoder we must specify that it should not
+			// expect a stream identifier at the beginning og the frame.
+			dec := NewReader(in, ReaderIgnoreStreamIdentifier())
+
+			// We now have a reader, but it will start outputting at uncompressedOffset,
+			// and not the actual offset we want, so skip forward to that.
+			toSkip := wantOffset - uncompressedOffset
+			err = dec.Skip(toSkip)
+			fatalErr(t, err)
+
+			// Read the rest of the stream...
+			got, err := ioutil.ReadAll(dec)
+			fatalErr(t, err)
+			if !bytes.Equal(got, want) {
+				t.Error("Result mismatch", wantOffset)
+			}
+
+			// Test with stream index...
+			for i := io.SeekStart; i <= io.SeekEnd; i++ {
+				t.Run(fmt.Sprintf("seek-%d", i), func(t *testing.T) {
+					// Read it from a seekable stream
+					dec = NewReader(bytes.NewReader(compressed))
+
+					rs, err := dec.ReadSeeker(true, nil)
+					fatalErr(t, err)
+
+					// Read a little...
+					var tmp = make([]byte, len(input)/2)
+					_, err = io.ReadFull(rs, tmp[:])
+					fatalErr(t, err)
+
+					toSkip := wantOffset
+					switch i {
+					case io.SeekStart:
+					case io.SeekCurrent:
+						toSkip = wantOffset - int64(len(input)/2)
+					case io.SeekEnd:
+						toSkip = int64(len(input)) - wantOffset
+					}
+					gotOffset, err := rs.Seek(toSkip, i)
+					if gotOffset != wantOffset {
+						t.Errorf("got offset %d, want %d", gotOffset, wantOffset)
+					}
+					// Read the rest of the stream...
+					got, err := ioutil.ReadAll(dec)
+					fatalErr(t, err)
+					if !bytes.Equal(got, want) {
+						t.Error("Result mismatch", wantOffset)
+					}
+				})
+			}
 		})
 	}
 }

--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -19,7 +19,7 @@ import (
 
 func testOptions(t testing.TB) map[string][]WriterOption {
 	var testOptions = map[string][]WriterOption{
-		"default": {},
+		"default": {WriterAddIndex()},
 		"better":  {WriterBetterCompression()},
 		"best":    {WriterBestCompression()},
 		"none":    {WriterUncompressed()},

--- a/s2/index.go
+++ b/s2/index.go
@@ -76,21 +76,21 @@ func (i *index) Add(compressedOffset, uncompressedOffset int64) error {
 }
 
 func (i *index) Reduce() {
-	fmt.Println("entries:", len(i.info))
 	if len(i.info) < maxIndexEntries {
 		return
 	}
 	// Algorithm, keep 1, remove removeN entries...
-	removeN := (len(i.info) + maxIndexEntries - 1) / maxIndexEntries
+	removeN := (len(i.info) + 1) / maxIndexEntries
 	src := i.info
-	i.AllocInfos(len(i.info) / removeN)
+	j := 0
 	for idx := 0; idx < len(src); idx++ {
-		i.info = append(i.info, src[idx])
+		i.info[j] = src[idx]
+		j++
 		idx += removeN
 	}
+	i.info = i.info[:j]
 	// Update maxblock estimate.
 	i.estBlockUncomp += i.estBlockUncomp * int64(removeN)
-	fmt.Println("entries after:", len(i.info))
 }
 
 func (i *index) AppendTo(b []byte, uncompTotal, compTotal int64) []byte {
@@ -126,7 +126,7 @@ func (i *index) AppendTo(b []byte, uncompTotal, compTotal int64) []byte {
 			// Update compressed size prediction, with half the error.
 			cPredict += cOff / 2
 		}
-		fmt.Println(info.uncompressedOffset, "->", info.compressedOffset, "encoded:", uOff, cOff)
+		//fmt.Println(info.uncompressedOffset, "->", info.compressedOffset, "encoded:", uOff, cOff)
 		n = binary.PutVarint(tmp[:], uOff)
 		b = append(b, tmp[:n]...)
 		n = binary.PutVarint(tmp[:], cOff)
@@ -144,7 +144,7 @@ func (i *index) AppendTo(b []byte, uncompTotal, compTotal int64) []byte {
 	b[initSize+1] = uint8(chunkLen >> 0)
 	b[initSize+2] = uint8(chunkLen >> 8)
 	b[initSize+3] = uint8(chunkLen >> 16)
-	fmt.Printf("chunklen: 0x%x Uncomp:%d, Comp:%d\n", chunkLen, uncompTotal, compTotal)
+	//fmt.Printf("chunklen: 0x%x Uncomp:%d, Comp:%d\n", chunkLen, uncompTotal, compTotal)
 	return b
 }
 
@@ -242,7 +242,7 @@ func (i *index) Load(b []byte) ([]byte, error) {
 			cOff += prev.compressedOffset + cPredict
 			cPredict = cPredictNew
 		}
-		fmt.Println(uOff, "->", cOff)
+		//fmt.Println(uOff, "->", cOff)
 		i.info[idx] = struct {
 			compressedOffset   int64
 			uncompressedOffset int64

--- a/s2/index.go
+++ b/s2/index.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2022+ Klaus Post. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package s2
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const (
+	S2IndexHeader   = "s2idx\x00"
+	S2IndexTrailer  = "\x00xdi2s"
+	maxIndexEntries = 1 << 16
+)
+
+type index struct {
+	info []struct {
+		compressedOffset   int64
+		uncompressedOffset int64
+	}
+	estBlockUncomp    int64
+	totalUncompressed int64
+	totalCompressed   int64
+}
+
+func (i *index) Reset(maxBlock int) {
+	i.estBlockUncomp = int64(maxBlock)
+	// We do not write the first.
+	if len(i.info) > 0 {
+		i.info = i.info[:0]
+	}
+}
+
+func (i *index) Close() {
+	i.Reset(0)
+}
+
+// AllocInfos will allocate an empty slice of infos.
+func (i *index) AllocInfos(n int) {
+	if n > maxIndexEntries {
+		panic("n > maxIndexEntries")
+	}
+	i.info = make([]struct {
+		compressedOffset   int64
+		uncompressedOffset int64
+	}, 0, n)
+}
+
+func (i *index) Add(compressedOffset, uncompressedOffset int64) error {
+	if i == nil {
+		return nil
+	}
+	lastIdx := len(i.info) - 1
+	if lastIdx >= 0 {
+		latest := i.info[lastIdx]
+		if latest.uncompressedOffset == uncompressedOffset {
+			// Uncompressed didn't change, don't add entry,
+			// but update start index.
+			latest.compressedOffset = compressedOffset
+			i.info[lastIdx] = latest
+			return nil
+		}
+		if latest.uncompressedOffset > uncompressedOffset {
+			return fmt.Errorf("internal error: Earlier uncompressed received (%d > %d)", latest.uncompressedOffset, uncompressedOffset)
+		}
+	}
+	i.info = append(i.info, struct {
+		compressedOffset   int64
+		uncompressedOffset int64
+	}{compressedOffset: compressedOffset, uncompressedOffset: uncompressedOffset})
+	return nil
+}
+
+func (i *index) Reduce() {
+	fmt.Println("entries:", len(i.info))
+	if len(i.info) < maxIndexEntries {
+		return
+	}
+	// Algorithm, keep 1, remove removeN entries...
+	removeN := (len(i.info) + maxIndexEntries - 1) / maxIndexEntries
+	src := i.info
+	i.AllocInfos(len(i.info) / removeN)
+	for idx := 0; idx < len(src); idx++ {
+		i.info = append(i.info, src[idx])
+		idx += removeN
+	}
+	// Update maxblock estimate.
+	i.estBlockUncomp += i.estBlockUncomp * int64(removeN)
+	fmt.Println("entries after:", len(i.info))
+}
+
+func (i *index) AppendTo(b []byte, uncompTotal, compTotal int64) []byte {
+	i.Reduce()
+	var tmp [binary.MaxVarintLen64]byte
+
+	initSize := len(b)
+	// We make the start a skippable header+size.
+	b = append(b, ChunkTypeIndex, 0, 0, 0)
+	b = append(b, []byte(S2IndexHeader)...)
+	// Total Uncompressed size
+	n := binary.PutVarint(tmp[:], uncompTotal)
+	b = append(b, tmp[:n]...)
+	// Total Compressed size
+	n = binary.PutVarint(tmp[:], compTotal)
+	b = append(b, tmp[:n]...)
+	// Put EstBlockUncomp size
+	n = binary.PutVarint(tmp[:], i.estBlockUncomp)
+	b = append(b, tmp[:n]...)
+	// Put length
+	n = binary.PutVarint(tmp[:], int64(len(i.info)))
+	b = append(b, tmp[:n]...)
+	// Initial compressed size estimate.
+	cPredict := i.estBlockUncomp / 2
+	// Add each entry
+	for idx, info := range i.info {
+		uOff := info.uncompressedOffset
+		cOff := info.compressedOffset
+		if idx > 0 {
+			prev := i.info[idx-1]
+			uOff -= prev.uncompressedOffset + (i.estBlockUncomp)
+			cOff -= prev.compressedOffset + cPredict
+			// Update compressed size prediction, with half the error.
+			cPredict += cOff / 2
+		}
+		fmt.Println(info.uncompressedOffset, "->", info.compressedOffset, "encoded:", uOff, cOff)
+		n = binary.PutVarint(tmp[:], uOff)
+		b = append(b, tmp[:n]...)
+		n = binary.PutVarint(tmp[:], cOff)
+		b = append(b, tmp[:n]...)
+	}
+	// Add Total Size.
+	// Stored as fixed size for easier reading.
+	binary.LittleEndian.PutUint32(tmp[:], uint32(len(b)-initSize+4+len(S2IndexTrailer)))
+	b = append(b, tmp[:4]...)
+	// Trailer
+	b = append(b, []byte(S2IndexTrailer)...)
+
+	// Update size
+	chunkLen := len(b) - initSize - skippableFrameHeader
+	b[initSize+1] = uint8(chunkLen >> 0)
+	b[initSize+2] = uint8(chunkLen >> 8)
+	b[initSize+3] = uint8(chunkLen >> 16)
+	fmt.Printf("chunklen: 0x%x Uncomp:%d, Comp:%d\n", chunkLen, uncompTotal, compTotal)
+	return b
+}
+
+func (i *index) Load(b []byte) ([]byte, error) {
+	if len(b) <= 4+len(S2IndexHeader)+len(S2IndexTrailer) {
+		return b, io.ErrUnexpectedEOF
+	}
+	if b[0] != ChunkTypeIndex {
+		return b, ErrCorrupt
+	}
+	chunkLen := int(b[1]) | int(b[2])<<8 | int(b[3])<<16
+	b = b[4:]
+
+	// Validate we have enough...
+	if len(b) < chunkLen {
+		return b, io.ErrUnexpectedEOF
+	}
+	if !bytes.Equal(b[:len(S2IndexHeader)], []byte(S2IndexHeader)) {
+		return b, ErrUnsupported
+	}
+	b = b[len(S2IndexHeader):]
+
+	// Total Uncompressed
+	if v, n := binary.Varint(b); n <= 0 {
+		return b, ErrCorrupt
+	} else {
+		i.totalUncompressed = v
+		b = b[n:]
+	}
+
+	// Total Uncompressed
+	if v, n := binary.Varint(b); n <= 0 {
+		return b, ErrCorrupt
+	} else {
+		i.totalUncompressed = v
+		b = b[n:]
+	}
+
+	// Read EstBlockUncomp
+	if v, n := binary.Varint(b); n <= 0 {
+		return b, ErrCorrupt
+	} else {
+		if v < 0 {
+			return b, ErrUnsupported
+		}
+		i.estBlockUncomp = v
+		b = b[n:]
+	}
+
+	var entries int
+	if v, n := binary.Varint(b); n <= 0 {
+		return b, ErrCorrupt
+	} else {
+		if v < 0 || v > maxIndexEntries {
+			return b, ErrUnsupported
+		}
+		entries = int(v)
+		b = b[n:]
+	}
+	if cap(i.info) < entries {
+		i.AllocInfos(entries)
+	}
+	i.info = i.info[:entries]
+
+	// Initial compressed size estimate.
+	cPredict := i.estBlockUncomp / 2
+	// Add each entry
+	for idx := range i.info {
+		var uOff, cOff int64
+		if v, n := binary.Varint(b); n <= 0 {
+			return b, ErrCorrupt
+		} else {
+			if v > maxIndexEntries {
+				return b, ErrUnsupported
+			}
+			uOff = v
+			b = b[n:]
+		}
+		if v, n := binary.Varint(b); n <= 0 {
+			return b, ErrCorrupt
+		} else {
+			if v > maxIndexEntries {
+				return b, ErrUnsupported
+			}
+			cOff = v
+			b = b[n:]
+		}
+
+		if idx > 0 {
+			// Update compressed size prediction, with half the error.
+			cPredictNew := cPredict + cOff/2
+
+			prev := i.info[idx-1]
+			uOff += prev.uncompressedOffset + (i.estBlockUncomp)
+			cOff += prev.compressedOffset + cPredict
+			cPredict = cPredictNew
+		}
+		fmt.Println(uOff, "->", cOff)
+		i.info[idx] = struct {
+			compressedOffset   int64
+			uncompressedOffset int64
+		}{compressedOffset: cOff, uncompressedOffset: uOff}
+	}
+	if len(b) < 4+len(S2IndexTrailer) {
+		return b, io.ErrUnexpectedEOF
+	}
+	// Skip size...
+	b = b[4:]
+
+	// Check trailer...
+	if !bytes.Equal(b[:len(S2IndexTrailer)], []byte(S2IndexTrailer)) {
+		return b, ErrCorrupt
+	}
+	return b[len(S2IndexTrailer):], nil
+}
+
+func (i *index) LoadStream(rs io.ReadSeeker) error {
+	// Go to end.
+	_, err := rs.Seek(-10, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	var tmp [10]byte
+	_, err = io.ReadFull(rs, tmp[:])
+	if err != nil {
+		return err
+	}
+	// Check trailer...
+	if !bytes.Equal(tmp[4:4+len(S2IndexTrailer)], []byte(S2IndexTrailer)) {
+		return ErrUnsupported
+	}
+	sz := binary.LittleEndian.Uint32(tmp[:4])
+	if sz > maxChunkSize+skippableFrameHeader {
+
+	}
+	_, err = rs.Seek(-int64(sz), io.SeekEnd)
+	if err != nil {
+		return err
+	}
+
+	// Read index.
+	buf := make([]byte, sz)
+	_, err = io.ReadFull(rs, buf)
+	if err != nil {
+		return err
+	}
+	_, err = i.Load(buf)
+	return err
+}

--- a/s2/index.go
+++ b/s2/index.go
@@ -209,7 +209,7 @@ func (i *index) Load(b []byte) ([]byte, error) {
 		b = b[n:]
 	}
 
-	// Total Uncompressed
+	// Total Compressed
 	if v, n := binary.Varint(b); n <= 0 {
 		return b, ErrCorrupt
 	} else {
@@ -222,7 +222,7 @@ func (i *index) Load(b []byte) ([]byte, error) {
 		return b, ErrCorrupt
 	} else {
 		if v < 0 {
-			return b, ErrUnsupported
+			return b, ErrCorrupt
 		}
 		i.estBlockUncomp = v
 		b = b[n:]
@@ -251,18 +251,12 @@ func (i *index) Load(b []byte) ([]byte, error) {
 		if v, n := binary.Varint(b); n <= 0 {
 			return b, ErrCorrupt
 		} else {
-			if v > maxIndexEntries {
-				return b, ErrUnsupported
-			}
 			uOff = v
 			b = b[n:]
 		}
 		if v, n := binary.Varint(b); n <= 0 {
 			return b, ErrCorrupt
 		} else {
-			if v > maxIndexEntries {
-				return b, ErrUnsupported
-			}
 			cOff = v
 			b = b[n:]
 		}
@@ -312,7 +306,7 @@ func (i *index) LoadStream(rs io.ReadSeeker) error {
 	}
 	sz := binary.LittleEndian.Uint32(tmp[:4])
 	if sz > maxChunkSize+skippableFrameHeader {
-
+		return ErrCorrupt
 	}
 	_, err = rs.Seek(-int64(sz), io.SeekEnd)
 	if err != nil {

--- a/s2/index_test.go
+++ b/s2/index_test.go
@@ -1,0 +1,103 @@
+package s2_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"sync"
+
+	"github.com/klauspost/compress/s2"
+)
+
+func ExampleIndex_Load() {
+	fatalErr := func(err error) {
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Create a test corpus
+	tmp := make([]byte, 5<<20)
+	rng := rand.New(rand.NewSource(0xbeefcafe))
+	rng.Read(tmp)
+	// Make it compressible...
+	for i, v := range tmp {
+		tmp[i] = '0' + v&3
+	}
+	// Compress it...
+	var buf bytes.Buffer
+	// We use smaller blocks just for the example...
+	enc := s2.NewWriter(&buf, s2.WriterBlockSize(100<<10), s2.WriterAddIndex())
+	err := enc.EncodeBuffer(tmp)
+	fatalErr(err)
+
+	// Close and get index...
+	idxBytes, err := enc.CloseIndex()
+	fatalErr(err)
+
+	// This is our compressed stream...
+	compressed := buf.Bytes()
+
+	var once sync.Once
+	for wantOffset := int64(0); wantOffset < int64(len(tmp)); wantOffset += 555555 {
+		// Let's assume we want to read from uncompressed offset 'i'
+		// and we cannot seek in input, but we have the index.
+		want := tmp[wantOffset:]
+
+		// Load the index.
+		var index s2.Index
+		_, err = index.Load(idxBytes)
+		fatalErr(err)
+
+		// Find offset in file:
+		compressedOffset, uncompressedOffset, err := index.Find(wantOffset)
+		fatalErr(err)
+
+		// Offset the input to the compressed offset.
+		// Notice how we do not provide any bytes before the offset.
+		input := io.Reader(bytes.NewBuffer(compressed[compressedOffset:]))
+		if _, ok := input.(io.Seeker); !ok {
+			// Notice how the input cannot be seeked...
+			once.Do(func() {
+				fmt.Println("Input does not support seeking...")
+			})
+		} else {
+			panic("did you implement seeking on bytes.Buffer?")
+		}
+
+		// When creating the decoder we must specify that it should not
+		// expect a frame header at the beginning og the frame.
+		dec := s2.NewReader(input, s2.ReaderIgnoreFrameHeader())
+
+		rs, err := dec.ReadSeeker(true, nil)
+		rs.Seek(wantOffset, io.SeekStart)
+		// We now have a reader, but it will start outputting at uncompressedOffset,
+		// and not the actual offset we want, so skip forward to that.
+		toSkip := wantOffset - uncompressedOffset
+		err = dec.Skip(toSkip)
+		fatalErr(err)
+
+		// Read the rest of the stream...
+		got, err := ioutil.ReadAll(dec)
+		fatalErr(err)
+		if bytes.Equal(got, want) {
+			fmt.Println("Successfully skipped forward to", wantOffset)
+		} else {
+			fmt.Println("Failed to skip forward to", wantOffset)
+		}
+	}
+	// OUTPUT:
+	//Input does not support seeking...
+	//Successfully skipped forward to 0
+	//Successfully skipped forward to 555555
+	//Successfully skipped forward to 1111110
+	//Successfully skipped forward to 1666665
+	//Successfully skipped forward to 2222220
+	//Successfully skipped forward to 2777775
+	//Successfully skipped forward to 3333330
+	//Successfully skipped forward to 3888885
+	//Successfully skipped forward to 4444440
+	//Successfully skipped forward to 4999995
+}

--- a/s2/index_test.go
+++ b/s2/index_test.go
@@ -68,11 +68,9 @@ func ExampleIndex_Load() {
 		}
 
 		// When creating the decoder we must specify that it should not
-		// expect a frame header at the beginning og the frame.
-		dec := s2.NewReader(input, s2.ReaderIgnoreFrameHeader())
+		// expect a stream identifier at the beginning og the frame.
+		dec := s2.NewReader(input, s2.ReaderIgnoreStreamIdentifier())
 
-		rs, err := dec.ReadSeeker(true, nil)
-		rs.Seek(wantOffset, io.SeekStart)
 		// We now have a reader, but it will start outputting at uncompressedOffset,
 		// and not the actual offset we want, so skip forward to that.
 		toSkip := wantOffset - uncompressedOffset

--- a/s2/index_test.go
+++ b/s2/index_test.go
@@ -29,7 +29,7 @@ func ExampleIndex_Load() {
 	// Compress it...
 	var buf bytes.Buffer
 	// We use smaller blocks just for the example...
-	enc := s2.NewWriter(&buf, s2.WriterBlockSize(100<<10), s2.WriterAddIndex())
+	enc := s2.NewWriter(&buf, s2.WriterBlockSize(100<<10))
 	err := enc.EncodeBuffer(tmp)
 	fatalErr(err)
 

--- a/s2/s2.go
+++ b/s2/s2.go
@@ -102,7 +102,7 @@ const (
 const (
 	chunkTypeCompressedData   = 0x00
 	chunkTypeUncompressedData = 0x01
-	ChunkTypeIndex            = 0x88
+	ChunkTypeIndex            = 0x99
 	chunkTypePadding          = 0xfe
 	chunkTypeStreamIdentifier = 0xff
 )

--- a/s2/s2.go
+++ b/s2/s2.go
@@ -87,6 +87,9 @@ const (
 	// minBlockSize is the minimum size of block setting when creating a writer.
 	minBlockSize = 4 << 10
 
+	skippableFrameHeader = 4
+	maxChunkSize         = 1<<24 - 1 // 16777215
+
 	// Default block size
 	defaultBlockSize = 1 << 20
 
@@ -99,6 +102,7 @@ const (
 const (
 	chunkTypeCompressedData   = 0x00
 	chunkTypeUncompressedData = 0x01
+	ChunkTypeIndex            = 0x88
 	chunkTypePadding          = 0xfe
 	chunkTypeStreamIdentifier = 0xff
 )


### PR DESCRIPTION
# Stream Seek Index

S2 and Snappy streams can have indexes. These indexes will allow random seeking within the compressed data.

The index can either be appended to the stream as a skippable block or returned for separate storage.

When the index is appended to a stream it will be skipped by regular decoders, 
so the output remains compatible with other decoders. 

## Creating an Index

To automatically add an index to a stream, add `WriterAddIndex()` option to your writer.
Then the index will be added to the stream when `Close()` is called.

```
    // Add Index to stream...
	enc := s2.NewWriter(w, s2.WriterAddIndex())
	io.Copy(enc, r)
	enc.Close()
```

If you want to store the index separately, you can use `CloseIndex()` instead of the regular `Close()`.
This will return the index. Note that `CloseIndex()` should only be called once, and you shouldn't call `Close()`.

```
    // Get index for separate storage... 
	enc := s2.NewWriter(w)
	io.Copy(enc, r)
	index, err := enc.CloseIndex()
```

The `index` can then be used needing to read from the stream. 
This means the index can be used without needing to seek to the end of the stream 
or for manually forwarding streams. See below.

## Using Indexes

To use indexes there is a `ReadSeeker(random bool, index []byte) (*ReadSeeker, error)` function available.

Calling ReadSeeker will return an [io.ReadSeeker](https://pkg.go.dev/io#ReadSeeker) compatible version of the reader.

If 'random' is specified the returned io.Seeker can be used for random seeking, otherwise only forward seeking is supported.
Enabling random seeking requires the original input to support the [io.Seeker](https://pkg.go.dev/io#Seeker) interface.

```
	dec := s2.NewReader(r)
	rs, err := dec.ReadSeeker(false, nil)
	rs.Seek(wantOffset, io.SeekStart)	
```

Get a seeker to seek forward. Since no index is provided, the index is read from the stream.
This requires that an index was added and that `r` supports the [io.Seeker](https://pkg.go.dev/io#Seeker) interface.

A custom index can be specified which will be used if supplied.
When using a custom index, it will not be read from the input stream.

```
	dec := s2.NewReader(r)
	rs, err := dec.ReadSeeker(false, index)
	rs.Seek(wantOffset, io.SeekStart)	
```

This will read the index from `index`. Since we specify non-random (forward only) seeking `r` does not have to be an io.Seeker

```
	dec := s2.NewReader(r)
	rs, err := dec.ReadSeeker(true, index)
	rs.Seek(wantOffset, io.SeekStart)	
```

Finally, since we specify that we want to do random seeking `r` must be an io.Seeker. 

The returned [ReadSeeker](https://pkg.go.dev/github.com/klauspost/compress/s2#ReadSeeker) contains a shallow reference to the existing Reader,
meaning changes performed to one is reflected in the other.

## Manually Forwarding Streams

Indexes can also be read outside the decoder using the [Index](https://pkg.go.dev/github.com/klauspost/compress/s2#Index) type.
This can be used for parsing indexes, either separate or in streams.

In some cases it may not be possible to serve a seekable stream.
This can for instance be an HTTP stream, where the Range request 
is sent at the start of the stream. 

With a little bit of extra code it is still possible to forward 

It is possible to load the index manually like this: 
```
	var index s2.Index
	_, err = index.Load(idxBytes)
```

This can be used to figure out how much to offset the compressed stream:

```
	compressedOffset, uncompressedOffset, err := index.Find(wantOffset)
```

The `compressedOffset` is the number of bytes that should be skipped 
from the beginning of the compressed file.

The `uncompressedOffset` will then be offset of the uncompressed bytes returned
when decoding from that position. This will always be <= wantOffset.

When creating a decoder it must be specified that it should *not* expect a frame header
at the beginning of the stream. Assuming the io.Reader `r` has been forwarded to `compressedOffset`
we create the decoder like this:

```
	dec := s2.NewReader(r, s2.ReaderIgnoreFrameHeader())
```

We are not completely done. We still need to forward the stream the uncompressed bytes we didn't want.
This is done using the regular "Skip" function:

```
	err = dec.Skip(wantOffset - uncompressedOffset)
```

This will ensure that we are at exactly the offset we want, and reading from `dec` will start at the requested offset.
