### PR TITLE
enh: revert back to array for llTable/mlTable/ofTable

### DIFF
--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -97,7 +97,7 @@ func (s *sequenceDecs) initialize(br *bitReader, hist *history, literals, out []
 func (s *sequenceDecs) decode(seqs int, br *bitReader, hist []byte) error {
 	startSize := len(s.out)
 	// Go 1.17+ no longer bounds checks access to array; avoid slice indirection overhead.
-	llTable, mlTable, ofTable := s.litLengths.fse.dt, s.matchLengths.fse.dt, s.offsets.fse.dt
+	llTable, mlTable, ofTable := &s.litLengths.fse.dt, &s.matchLengths.fse.dt, &s.offsets.fse.dt
 	llState, mlState, ofState := s.litLengths.state.state, s.matchLengths.state.state, s.offsets.state.state
 
 	for i := seqs - 1; i >= 0; i-- {

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -96,8 +96,8 @@ func (s *sequenceDecs) initialize(br *bitReader, hist *history, literals, out []
 // decode sequences from the stream with the provided history.
 func (s *sequenceDecs) decode(seqs int, br *bitReader, hist []byte) error {
 	startSize := len(s.out)
-	// Grab full sizes tables, to avoid bounds checks.
-	llTable, mlTable, ofTable := s.litLengths.fse.dt[:maxTablesize], s.matchLengths.fse.dt[:maxTablesize], s.offsets.fse.dt[:maxTablesize]
+	// Go 1.17+ no longer bounds checks access to array; avoid slice indirection overhead.
+	llTable, mlTable, ofTable := s.litLengths.fse.dt, s.matchLengths.fse.dt, s.offsets.fse.dt
 	llState, mlState, ofState := s.litLengths.state.state, s.matchLengths.state.state, s.offsets.state.state
 
 	for i := seqs - 1; i >= 0; i-- {


### PR DESCRIPTION
The extra indirection of creating a slice with size maxTableSize is no longer needed; this results in a 25% performance increase on x86_64 for some workloads (esp html_x_4), and flat performance on aarch64.

go1.17/amd64:
```
benchmark                                                    old ns/op     new ns/op     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               3494468       3379259       -3.30%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           687076        681387        -0.83%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            11085443      10924817      -1.45%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              8407670       8158085       -2.97%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            2825509       2749297       -2.70%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             3736775       3604104       -3.55%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                1903319       1417892       -25.50%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          159818        154350        -3.42%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          75035         75623         +0.78%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                9421182       9058897       -3.85%
BenchmarkDecoder_DecoderSmall/html.zst-12                    795930        771416        -3.08%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           66842         65826         -1.52%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  435892        424669        -2.57%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              84058         90552         +7.73%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               1383197       1352505       -2.22%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 1042932       1005006       -3.64%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               355043        349566        -1.54%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                462460        448584        -3.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   236942        178127        -24.82%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             19407         18649         -3.91%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             8641          8690          +0.57%
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   1152539       1132885       -1.71%
BenchmarkDecoder_DecodeAll/html.zst-12                       99663         95678         -4.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              8361          8438          +0.92%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          71902         68621         -4.56%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      14927         14423         -3.38%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       241417        229017        -5.14%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         178932        169150        -5.47%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       59359         56624         -4.61%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        77809         74909         -3.73%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           43376         32490         -25.10%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     3572          3451          -3.39%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     1535          1539          +0.26%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           190123        185012        -2.69%
BenchmarkDecoder_DecodeAllParallel/html.zst-12               17203         16557         -3.76%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      1509          1515          +0.40%

benchmark                                                    old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               421.97       436.36       1.03x
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           1380.79      1392.31      1.01x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            347.74       352.86       1.01x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              406.06       418.48       1.03x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            354.43       364.25       1.03x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             325.60       337.59       1.04x
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                1721.62      2311.04      1.34x
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          5125.84      5307.43      1.04x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          13123.74     13021.82     0.99x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                596.18       620.02       1.04x
BenchmarkDecoder_DecoderSmall/html.zst-12                    1029.24      1061.94      1.03x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           487.83       495.36       1.02x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  422.86       434.03       1.03x
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              1410.79      1309.62      0.93x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               348.37       356.27       1.02x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 409.19       424.63       1.04x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               352.57       358.10       1.02x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                328.87       339.04       1.03x
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   1728.70      2299.49      1.33x
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             5276.43      5490.77      1.04x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             14245.78     14165.08     0.99x
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   609.17       619.73       1.02x
BenchmarkDecoder_DecodeAll/html.zst-12                       1027.46      1070.26      1.04x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              487.51       483.08       0.99x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          2563.50      2686.05      1.05x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      7944.49      8221.96      1.03x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       1995.97      2104.04      1.05x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         2385.01      2522.94      1.06x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       2108.86      2210.70      1.05x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        1954.64      2030.32      1.04x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           9443.01      12606.94     1.34x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     28670.75     29674.17     1.03x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     80178.39     79977.77     1.00x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           3692.80      3794.81      1.03x
BenchmarkDecoder_DecodeAllParallel/html.zst-12               5952.37      6184.74      1.04x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      2701.93      2691.29      1.00x

benchmark                                                    old allocs     new allocs     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               1              1              +0.00%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           1              1              +0.00%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            1              1              +0.00%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              1              1              +0.00%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            1              1              +0.00%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             1              1              +0.00%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                1              1              +0.00%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                1              1              +0.00%
BenchmarkDecoder_DecoderSmall/html.zst-12                    1              1              +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           1              1              +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  0              0              +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              0              0              +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               0              0              +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 0              0              +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               0              0              +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                0              0              +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             0              0              +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             0              0              +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/html.zst-12                       0              0              +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html.zst-12               0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      0              0              +0.00%

benchmark                                                    old bytes     new bytes     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               19459         19347         -0.58%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           2704          2594          -4.07%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            165860        158323        -4.54%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              108902        105083        -3.51%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            8997          8892          -1.17%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             17441         16595         -4.85%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                24948         18030         -27.73%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          48            527           +997.92%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          332           326           -1.81%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                199639        195355        -2.15%
BenchmarkDecoder_DecoderSmall/html.zst-12                    48            48            +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           48            48            +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  0             0             +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              0             0             +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               0             0             +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 0             0             +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               0             0             +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                0             0             +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             0             0             +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             0             0             +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/html.zst-12                       0             0             +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              0             0             +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          141           131           -7.09%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      18            18            +0.00%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       1302          1289          -1.00%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         986           741           -24.85%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       78            75            -3.85%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        122           130           +6.56%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           179           133           -25.70%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     3             3             +0.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     2             2             +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           1539          1515          -1.56%
BenchmarkDecoder_DecodeAllParallel/html.zst-12               18            17            -5.56%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      0             0             +0.00%
```

go1.17/arm64:
```
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               7285584       7358412       +1.00%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           1948236       1954437       +0.32%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            23894495      23566187      -1.37%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              17781669      17587395      -1.09%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            6056783       5986820       -1.16%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             7595705       7503978       -1.21%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                4190851       4190728       -0.00%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          553375        561100        +1.40%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          348653        348737        +0.02%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                21020394      20865234      -0.74%
BenchmarkDecoder_DecoderSmall/html.zst-4                    2038084       2009719       -1.39%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           146524        156045        +6.50%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  900881        908068        +0.80%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              240917        242009        +0.45%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               2962741       2932156       -1.03%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 2203425       2174672       -1.30%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               752544        743828        -1.16%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                943281        931194        -1.28%
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   515398        517646        +0.44%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             67341         68499         +1.72%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             41159         41151         -0.02%
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   2594535       2577253       -0.67%
BenchmarkDecoder_DecodeAll/html.zst-4                       252830        249818        -1.19%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              18349         19569         +6.65%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          226216        228030        +0.80%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      60384         60714         +0.55%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       748918        738658        -1.37%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         555155        547405        -1.40%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       188566        186724        -0.98%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        236716        233740        -1.26%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           129772        129420        -0.27%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     16902         17164         +1.55%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     10399         11602         +11.57%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           652628        688743        +5.53%
BenchmarkDecoder_DecodeAllParallel/html.zst-4               63494         62539         -1.50%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      4707          5002          +6.27%

benchmark                                                   old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               202.39       200.39       0.99x
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           486.96       485.41       1.00x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            161.33       163.58       1.01x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              192.00       194.12       1.01x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            165.34       167.27       1.01x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             160.18       162.14       1.01x
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                781.89       781.92       1.00x
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          1480.37      1459.99      0.99x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          2824.42      2823.74      1.00x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                267.20       269.19       1.01x
BenchmarkDecoder_DecoderSmall/html.zst-4                    401.95       407.62       1.01x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           222.54       208.97       0.94x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  204.60       202.98       0.99x
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              492.24       490.01       1.00x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               162.64       164.34       1.01x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 193.68       196.24       1.01x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               166.34       168.29       1.01x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                161.23       163.33       1.01x
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   794.72       791.28       1.00x
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             1520.61      1494.92      0.98x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             2990.65      2991.24      1.00x
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   270.60       272.42       1.01x
BenchmarkDecoder_DecodeAll/html.zst-4                       405.02       409.90       1.01x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              222.14       208.29       0.94x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          814.80       808.32       0.99x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      1963.88      1953.22      0.99x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       643.41       652.35       1.01x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         768.71       779.59       1.01x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       663.85       670.39       1.01x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        642.49       650.68       1.01x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           3156.31      3164.88      1.00x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     6058.38      5966.06      0.98x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     11837.16     10609.44     0.90x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           1075.78      1019.37      0.95x
BenchmarkDecoder_DecodeAllParallel/html.zst-4               1612.75      1637.37      1.02x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      865.88       814.92       0.94x

benchmark                                                   old allocs     new allocs     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               1              1              +0.00%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           1              1              +0.00%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            1              1              +0.00%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              1              1              +0.00%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            1              1              +0.00%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             1              1              +0.00%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                1              1              +0.00%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                2              2              +0.00%
BenchmarkDecoder_DecoderSmall/html.zst-4                    1              1              +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           1              1              +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  0              0              +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              0              0              +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               0              0              +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 0              0              +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               0              0              +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                0              0              +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             0              0              +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             0              0              +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/html.zst-4                       0              0              +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html.zst-4               0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      0              0              +0.00%

benchmark                                                   old bytes     new bytes     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               40877         41129         +0.62%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           7053          7064          +0.16%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            392190        400904        +2.22%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              252577        266541        +5.53%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            19158         18939         -1.14%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             35133         34691         -1.26%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                52036         52056         +0.04%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          48            48            +0.00%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          1385          1397          +0.87%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                498947        499662        +0.14%
BenchmarkDecoder_DecoderSmall/html.zst-4                    48            48            +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           48            48            +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  0             0             +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              0             0             +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               0             0             +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 0             0             +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               0             0             +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                0             0             +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             0             0             +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             0             0             +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/html.zst-4                       0             0             +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              0             0             +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          161           175           +8.70%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      24            24            +0.00%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       1277          1290          +1.02%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         811           795           -1.97%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       84            83            -1.19%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        124           122           -1.61%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           179           180           +0.56%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     6             6             +0.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     4             4             +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           1621          1866          +15.11%
BenchmarkDecoder_DecodeAllParallel/html.zst-4               22            23            +4.55%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      0             0             +0.00%

```

go1.18beta1/amd64:
```
benchmark                                                    old ns/op     new ns/op     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               3429133       3412857       -0.47%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           693702        689294        -0.64%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            11083126      10933642      -1.35%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              8218440       8152884       -0.80%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            2785808       2798601       +0.46%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             3688584       3571942       -3.16%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                1911532       1427758       -25.31%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          158056        156551        -0.95%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          75471         77183         +2.27%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                9104808       9158698       +0.59%
BenchmarkDecoder_DecoderSmall/html.zst-12                    782330        781526        -0.10%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           65191         65823         +0.97%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  435635        426514        -2.09%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              82841         83354         +0.62%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               1393424       1348864       -3.20%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 1039729       1014956       -2.38%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               348633        346539        -0.60%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                467920        450939        -3.63%
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   235601        177940        -24.47%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             19147         18806         -1.78%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             8691          8654          -0.43%
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   1153057       1133712       -1.68%
BenchmarkDecoder_DecodeAll/html.zst-12                       96474         96299         -0.18%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              8127          8280          +1.88%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          71412         69662         -2.45%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      14648         14681         +0.23%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       237199        230351        -2.89%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         175811        171509        -2.45%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       58541         57730         -1.39%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        77509         75253         -2.91%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           43140         32879         -23.79%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     3507          3518          +0.31%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     1549          1628          +5.10%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           188335        186864        -0.78%
BenchmarkDecoder_DecodeAllParallel/html.zst-12               16975         16777         -1.17%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      1483          1520          +2.49%

benchmark                                                    old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               430.01       432.06       1.00x
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           1367.60      1376.34      1.01x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            347.82       352.57       1.01x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              415.41       418.75       1.01x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            359.48       357.83       1.00x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             329.86       340.63       1.03x
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                1714.23      2295.07      1.34x
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          5182.97      5232.79      1.01x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          13048.05     12758.55     0.98x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                616.89       613.26       0.99x
BenchmarkDecoder_DecoderSmall/html.zst-12                    1047.13      1048.21      1.00x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           500.19       495.39       0.99x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  423.11       432.15       1.02x
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              1431.52      1422.70      0.99x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               345.81       357.23       1.03x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 410.45       420.47       1.02x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               359.06       361.23       1.01x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                325.03       337.27       1.04x
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   1738.53      2301.90      1.32x
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             5347.99      5444.99      1.02x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             14162.80     14223.98     1.00x
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   608.89       619.28       1.02x
BenchmarkDecoder_DecodeAll/html.zst-12                       1061.42      1063.35      1.00x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              501.52       492.26       0.98x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          2581.10      2645.93      1.03x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      8095.89      8077.87      1.00x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       2031.47      2091.86      1.03x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         2427.35      2488.22      1.03x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       2138.31      2168.34      1.01x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        1962.22      2021.03      1.03x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           9494.70      12457.71     1.31x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     29195.75     29104.21     1.00x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     79453.05     75621.54     0.95x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           3727.86      3757.20      1.01x
BenchmarkDecoder_DecodeAllParallel/html.zst-12               6032.46      6103.48      1.01x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      2748.11      2681.07      0.98x

benchmark                                                    old allocs     new allocs     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               1              1              +0.00%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           1              1              +0.00%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            1              1              +0.00%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              1              1              +0.00%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            1              1              +0.00%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             1              1              +0.00%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                1              1              +0.00%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                1              1              +0.00%
BenchmarkDecoder_DecoderSmall/html.zst-12                    1              1              +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           1              1              +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  0              0              +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              0              0              +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               0              0              +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 0              0              +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               0              0              +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                0              0              +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             0              0              +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             0              0              +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/html.zst-12                       0              0              +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html.zst-12               0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      0              0              +0.00%

benchmark                                                    old bytes     new bytes     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-12               19821         19297         -2.64%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-12           2650          2568          -3.09%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-12            165995        161008        -3.00%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-12              108565        109515        +0.88%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-12            9148          8733          -4.54%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-12             17213         16911         -1.75%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-12                23886         18246         -23.61%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-12          48            48            +0.00%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-12          331           336           +1.51%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-12                195130        195411        +0.14%
BenchmarkDecoder_DecoderSmall/html.zst-12                    48            48            +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-12           48            48            +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-12                  0             0             +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-12              0             0             +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-12               0             0             +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-12                 0             0             +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-12               0             0             +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-12                0             0             +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-12                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-12             0             0             +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-12             0             0             +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-12                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/html.zst-12                       0             0             +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-12              0             0             +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-12          135           140           +3.70%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-12      18            18            +0.00%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-12       1359          1252          -7.87%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-12         766           895           +16.84%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-12       77            76            -1.30%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-12        123           130           +5.69%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-12           178           134           -24.72%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-12     3             3             +0.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-12     2             2             +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-12           1502          1604          +6.79%
BenchmarkDecoder_DecodeAllParallel/html.zst-12               18            18            +0.00%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-12      0             0             +0.00%
```

go1.18beta1/arm64:
```
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               7033872       7065133       +0.44%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           1842957       1899113       +3.05%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            23085034      22961622      -0.53%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              17288191      17104125      -1.06%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            5873367       5861024       -0.21%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             7362972       7335302       -0.38%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                4473970       4254649       -4.90%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          537208        550142        +2.41%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          349598        349861        +0.08%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                20083735      20279622      +0.98%
BenchmarkDecoder_DecoderSmall/html.zst-4                    1946366       1982454       +1.85%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           142151        151195        +6.36%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  870742        874869        +0.47%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              228264        234817        +2.87%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               2870046       2846427       -0.82%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 2132110       2120306       -0.55%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               728814        728754        -0.01%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                915257        910217        -0.55%
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   553045        523042        -5.43%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             65675         66909         +1.88%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             41037         41045         +0.02%
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   2493022       2512490       +0.78%
BenchmarkDecoder_DecodeAll/html.zst-4                       241560        246458        +2.03%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              17804         18944         +6.40%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          218806        219646        +0.38%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      57340         58808         +2.56%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       721637        717992        -0.51%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         536653        537130        +0.09%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       182853        182832        -0.01%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        231020        228202        -1.22%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           138214        131220        -5.06%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     16427         16844         +2.54%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     10339         10398         +0.57%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           627512        631049        +0.56%
BenchmarkDecoder_DecodeAllParallel/html.zst-4               60454         61648         +1.98%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      4524          4808          +6.28%

benchmark                                                   old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               209.64       208.71       1.00x
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           514.77       499.55       0.97x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            166.99       167.88       1.01x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              197.48       199.60       1.01x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            170.50       170.86       1.00x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             165.25       165.87       1.00x
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                732.41       770.17       1.05x
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          1524.92      1489.07      0.98x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          2816.79      2814.68      1.00x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                279.66       276.96       0.99x
BenchmarkDecoder_DecoderSmall/html.zst-4                    420.89       413.23       0.98x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           229.39       215.67       0.94x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  211.68       210.68       1.00x
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              519.52       505.02       0.97x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               167.89       169.29       1.01x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 200.16       201.27       1.01x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               171.76       171.77       1.00x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                166.17       167.09       1.01x
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   740.63       783.11       1.06x
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             1559.20      1530.44      0.98x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             2999.56      2998.99      1.00x
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   281.62       279.44       0.99x
BenchmarkDecoder_DecodeAll/html.zst-4                       423.91       415.49       0.98x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              228.94       215.16       0.94x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          842.39       839.17       1.00x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      2068.14      2016.52      0.98x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       667.73       671.12       1.01x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         795.21       794.51       1.00x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       684.59       684.67       1.00x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        658.34       666.47       1.01x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           2963.51      3121.47      1.05x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     6233.72      6079.40      0.98x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     11905.70     11838.39     0.99x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           1118.84      1112.57      0.99x
BenchmarkDecoder_DecodeAllParallel/html.zst-4               1693.84      1661.04      0.98x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      901.07       847.82       0.94x

benchmark                                                   old allocs     new allocs     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               1              1              +0.00%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           1              1              +0.00%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            1              2              +100.00%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              1              1              +0.00%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            1              1              +0.00%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             1              1              +0.00%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                1              1              +0.00%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          1              1              +0.00%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                1              1              +0.00%
BenchmarkDecoder_DecoderSmall/html.zst-4                    1              1              +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           1              1              +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  0              0              +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              0              0              +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               0              0              +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 0              0              +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               0              0              +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                0              0              +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             0              0              +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             0              0              +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   0              0              +0.00%
BenchmarkDecoder_DecodeAll/html.zst-4                       0              0              +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/html.zst-4               0              0              +0.00%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      0              0              +0.00%

benchmark                                                   old bytes     new bytes     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-4               39448         39582         +0.34%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-4           6716          6944          +3.39%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-4            400904        401496        +0.15%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-4              223823        223823        +0.00%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-4            18568         18595         +0.15%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-4             34178         33968         -0.61%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-4                55559         52877         -4.83%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-4          48            48            +0.00%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-4          1397          1403          +0.43%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-4                437238        437240        +0.00%
BenchmarkDecoder_DecoderSmall/html.zst-4                    48            48            +0.00%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-4           48            48            +0.00%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-4                  0             0             +0.00%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-4              0             0             +0.00%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-4               0             0             +0.00%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-4                 0             0             +0.00%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-4               0             0             +0.00%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-4                0             0             +0.00%
BenchmarkDecoder_DecodeAll/html_x_4.zst-4                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-4             0             0             +0.00%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-4             0             0             +0.00%
BenchmarkDecoder_DecodeAll/urls.10K.zst-4                   0             0             +0.00%
BenchmarkDecoder_DecodeAll/html.zst-4                       0             0             +0.00%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-4              0             0             +0.00%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-4          143           161           +12.59%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-4      23            24            +4.35%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-4       1220          1233          +1.07%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-4         778           797           +2.44%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-4       81            82            +1.23%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-4        121           121           +0.00%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-4           192           181           -5.73%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-4     5             6             +20.00%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-4     4             4             +0.00%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-4           1578          1612          +2.15%
BenchmarkDecoder_DecodeAllParallel/html.zst-4               21            21            +0.00%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-4      0             0             +0.00%
```

amd64 processor details (6 core / 12 hyperthread):
```
processor	: 0
vendor_id	: AuthenticAMD
cpu family	: 25
model		: 33
model name	: AMD Ryzen 5 5600X 6-Core Processor
stepping	: 0
microcode	: 0xa201009
cpu MHz		: 2200.000
cache size	: 512 KB
physical id	: 0
siblings	: 12
core id		: 0
cpu cores	: 6
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 16
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 invpcid cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr rdpru wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor smca
bugs		: sysret_ss_attrs spectre_v1 spectre_v2 spec_store_bypass
bogomips	: 7385.90
TLB size	: 2560 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 48 bits physical, 48 bits virtual
power management: ts ttp tm hwpstate cpb eff_freq_ro [13] [14]
```
arm64 processor details: graviton2, c6g.xlarge (4 core)
```
processor	: 0
BogoMIPS	: 243.75
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x3
CPU part	: 0xd0c
CPU revision	: 1
```