### PR TITLE
huff0: Improve 4X decompression speed

### DIFF
--- a/huff0/decompress.go
+++ b/huff0/decompress.go
@@ -753,23 +753,21 @@ func (d *Decoder) Decompress4X(dst, src []byte) ([]byte, error) {
 			br[stream2].fillFast()
 
 			val := br[stream].peekBitsFast(d.actualTableLog)
-			v := single[val&tlMask]
-			br[stream].advance(uint8(v.entry))
-			buf[off+bufoff*stream] = uint8(v.entry >> 8)
-
 			val2 := br[stream2].peekBitsFast(d.actualTableLog)
+			v := single[val&tlMask]
 			v2 := single[val2&tlMask]
+			br[stream].advance(uint8(v.entry))
 			br[stream2].advance(uint8(v2.entry))
+			buf[off+bufoff*stream] = uint8(v.entry >> 8)
 			buf[off+bufoff*stream2] = uint8(v2.entry >> 8)
 
 			val = br[stream].peekBitsFast(d.actualTableLog)
-			v = single[val&tlMask]
-			br[stream].advance(uint8(v.entry))
-			buf[off+bufoff*stream+1] = uint8(v.entry >> 8)
-
 			val2 = br[stream2].peekBitsFast(d.actualTableLog)
+			v = single[val&tlMask]
 			v2 = single[val2&tlMask]
+			br[stream].advance(uint8(v.entry))
 			br[stream2].advance(uint8(v2.entry))
+			buf[off+bufoff*stream+1] = uint8(v.entry >> 8)
 			buf[off+bufoff*stream2+1] = uint8(v2.entry >> 8)
 		}
 
@@ -780,23 +778,21 @@ func (d *Decoder) Decompress4X(dst, src []byte) ([]byte, error) {
 			br[stream2].fillFast()
 
 			val := br[stream].peekBitsFast(d.actualTableLog)
-			v := single[val&tlMask]
-			br[stream].advance(uint8(v.entry))
-			buf[off+bufoff*stream] = uint8(v.entry >> 8)
-
 			val2 := br[stream2].peekBitsFast(d.actualTableLog)
+			v := single[val&tlMask]
 			v2 := single[val2&tlMask]
+			br[stream].advance(uint8(v.entry))
 			br[stream2].advance(uint8(v2.entry))
+			buf[off+bufoff*stream] = uint8(v.entry >> 8)
 			buf[off+bufoff*stream2] = uint8(v2.entry >> 8)
 
 			val = br[stream].peekBitsFast(d.actualTableLog)
-			v = single[val&tlMask]
-			br[stream].advance(uint8(v.entry))
-			buf[off+bufoff*stream+1] = uint8(v.entry >> 8)
-
 			val2 = br[stream2].peekBitsFast(d.actualTableLog)
+			v = single[val&tlMask]
 			v2 = single[val2&tlMask]
+			br[stream].advance(uint8(v.entry))
 			br[stream2].advance(uint8(v2.entry))
+			buf[off+bufoff*stream+1] = uint8(v.entry >> 8)
 			buf[off+bufoff*stream2+1] = uint8(v2.entry >> 8)
 		}
 


### PR DESCRIPTION
Improve for tablelog > 8:

```
benchmark                                           old ns/op     new ns/op     delta
BenchmarkDecompress4XNoTable/gettysburg-32          2760          2711          -1.78%
BenchmarkDecompress4XNoTable/twain-32               583900        580407        -0.60%
BenchmarkDecompress4XNoTable/pngdata.001-32         79094         77148         -2.46%
BenchmarkDecompress4XNoTableTableLog8/digits-32     158182        158284        +0.06%
BenchmarkDecompress4XTable/digits-32                160960        158540        -1.50%
BenchmarkDecompress4XTable/gettysburg-32            3985          3907          -1.96%
BenchmarkDecompress4XTable/twain-32                 585743        585507        -0.04%
BenchmarkDecompress4XTable/low-ent.10k-32           55110         55175         +0.12%
BenchmarkDecompress4XTable/superlow-ent-10k-32      15096         14993         -0.68%
BenchmarkDecompress4XTable/case1-32                 2003          2001          -0.10%
BenchmarkDecompress4XTable/case2-32                 1970          1964          -0.30%
BenchmarkDecompress4XTable/case3-32                 1974          1993          +0.96%
BenchmarkDecompress4XTable/pngdata.001-32           82138         80294         -2.25%
BenchmarkDecompress4XTable/normcount2-32            1346          1334          -0.89%
```