### PR TITLE
Update deprecated CreateHeaderRaw to correctly call CreateRaw

### DIFF
--- a/zip/writer.go
+++ b/zip/writer.go
@@ -438,7 +438,7 @@ func min64(x, y uint64) uint64 {
 
 // Deprecated: CreateHeaderRaw is replaced by CreateRaw (stdlib name).
 func (w *Writer) CreateHeaderRaw(fh *FileHeader) (io.Writer, error) {
-	return w.CreateHeader(fh)
+	return w.CreateRaw(fh)
 }
 
 // CreateRaw adds a file to the zip archive using the provided FileHeader and


### PR DESCRIPTION
[fastzip](https://github.com/saracen/fastzip) had reports of malformed compressed data (https://github.com/saracen/fastzip/issues/32). I've narrowed the fix down to this.

I'll update `fastzip` to call the non-deprecated function now, but fixing this here is still a good idea. [gitLab-runner ](https://gitlab.com/gitlab-org/gitlab-runner) uses fastzip and stumbled across this issue when the `klauspost/compress` dependency was indirectly updated via a minor minio upgrade. 😢 
