### PR TITLE
huff0: Skip unneeded exhaust check

### DIFF
--- a/huff0/decompress_amd64.s
+++ b/huff0/decompress_amd64.s
@@ -66,13 +66,13 @@ main_loop:
 	SHLQ CL, AX
 	ORQ  AX, br_value
 
-	// }
-skip_fill0:
-
 	// exhausted = exhausted || (br0.off < 4)
 	CMPQ  br_offset, $4
 	SETLT DL
 	ORB   DL, DH
+
+	// }
+skip_fill0:
 
 	// val0 := br0.peekTopBits(peekBits)
 	MOVQ br_value, AX
@@ -136,13 +136,13 @@ skip_fill0:
 	SHLQ CL, AX
 	ORQ  AX, br_value
 
-	// }
-skip_fill1:
-
 	// exhausted = exhausted || (br1.off < 4)
 	CMPQ  br_offset, $4
 	SETLT DL
 	ORB   DL, DH
+
+	// }
+skip_fill1:
 
 	// val0 := br1.peekTopBits(peekBits)
 	MOVQ br_value, AX
@@ -206,13 +206,13 @@ skip_fill1:
 	SHLQ CL, AX
 	ORQ  AX, br_value
 
-	// }
-skip_fill2:
-
 	// exhausted = exhausted || (br2.off < 4)
 	CMPQ  br_offset, $4
 	SETLT DL
 	ORB   DL, DH
+
+	// }
+skip_fill2:
 
 	// val0 := br2.peekTopBits(peekBits)
 	MOVQ br_value, AX
@@ -276,13 +276,13 @@ skip_fill2:
 	SHLQ CL, AX
 	ORQ  AX, br_value
 
-	// }
-skip_fill3:
-
 	// exhausted = exhausted || (br3.off < 4)
 	CMPQ  br_offset, $4
 	SETLT DL
 	ORB   DL, DH
+
+	// }
+skip_fill3:
 
 	// val0 := br3.peekTopBits(peekBits)
 	MOVQ br_value, AX

--- a/huff0/decompress_amd64.s.in
+++ b/huff0/decompress_amd64.s.in
@@ -66,13 +66,13 @@ main_loop:
     MOVQ    br_bits_read, CX
     SHLQ    CL, AX
     ORQ     AX, br_value
-    // }
-skip_fill{{ var "id" }}:
 
     // exhausted = exhausted || (br{{ var "id"}}.off < 4)
     CMPQ    br_offset, $4
     SETLT   DL
     ORB     DL, DH
+    // }
+skip_fill{{ var "id" }}:
 
     // val0 := br{{ var "id"}}.peekTopBits(peekBits)
     MOVQ    br_value, AX


### PR DESCRIPTION
When not filling there is no reason to check if exhausted.

```
BenchmarkDecompress4XNoTable/gettysburg/10000-32            11867         11550         -2.67%
BenchmarkDecompress4XNoTable/gettysburg/262143-32           336139        331035        -1.52%
BenchmarkDecompress4XNoTable/twain/10000-32                 11922         11561         -3.03%
BenchmarkDecompress4XNoTable/twain/262143-32                387406        374386        -3.36%
BenchmarkDecompress4XNoTable/pngdata.001/10000-32           12262         11961         -2.45%
BenchmarkDecompress4XNoTable/pngdata.001/262143-32          319131        308746        -3.25%
```