### PR TITLE
huff0: Use bmi1 on GOAMD64=v3

### DIFF
--- a/huff0/decompress_8b_amd64.s
+++ b/huff0/decompress_8b_amd64.s
@@ -137,8 +137,8 @@ skip_fill0:
 	ADDQ    CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
-	// buf[stream][off] = uint8(v0.entry >> 8)
-	// buf[stream][off+1] = uint8(v1.entry >> 8)
+	// buf[stream][off+2] = uint8(v2.entry >> 8)
+	// buf[stream][off+3] = uint8(v3.entry >> 8)
 	MOVW BX, 0+2(buffer)(off*1)
 
 	// update the bitrader reader structure
@@ -241,8 +241,8 @@ skip_fill1:
 	ADDQ    CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
-	// buf[stream][off] = uint8(v0.entry >> 8)
-	// buf[stream][off+1] = uint8(v1.entry >> 8)
+	// buf[stream][off+2] = uint8(v2.entry >> 8)
+	// buf[stream][off+3] = uint8(v3.entry >> 8)
 	MOVW BX, 256+2(buffer)(off*1)
 
 	// update the bitrader reader structure
@@ -345,8 +345,8 @@ skip_fill2:
 	ADDQ    CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
-	// buf[stream][off] = uint8(v0.entry >> 8)
-	// buf[stream][off+1] = uint8(v1.entry >> 8)
+	// buf[stream][off+2] = uint8(v2.entry >> 8)
+	// buf[stream][off+3] = uint8(v3.entry >> 8)
 	MOVW BX, 512+2(buffer)(off*1)
 
 	// update the bitrader reader structure
@@ -449,8 +449,8 @@ skip_fill3:
 	ADDQ    CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
-	// buf[stream][off] = uint8(v0.entry >> 8)
-	// buf[stream][off+1] = uint8(v1.entry >> 8)
+	// buf[stream][off+2] = uint8(v2.entry >> 8)
+	// buf[stream][off+3] = uint8(v3.entry >> 8)
 	MOVW BX, 768+2(buffer)(off*1)
 
 	// update the bitrader reader structure

--- a/huff0/decompress_amd64.s
+++ b/huff0/decompress_amd64.s
@@ -6,6 +6,12 @@
 #include "funcdata.h"
 #include "go_asm.h"
 
+#ifdef GOAMD64_v4
+#ifndef GOAMD64_v3
+#define GOAMD64_v3
+#endif
+#endif
+
 #define bufoff      256 // see decompress.go, we're using [4][256]byte table
 
 // func decompress4x_main_loop_x86(pbr0, pbr1, pbr2, pbr3 *bitReaderShifted,
@@ -48,9 +54,9 @@ main_loop:
 	MOVQ    bitReaderShifted_value(br0), br_value
 	MOVQ    bitReaderShifted_off(br0), br_offset
 
-	// if b.bitsRead >= 32 {
-	CMPQ br_bits_read, $32
-	JB   skip_fill0
+	// We must have at least 2 * max tablelog left
+	CMPQ br_bits_read, $64-22
+	JBE  skip_fill0
 
 	SUBQ $32, br_bits_read // b.bitsRead -= 32
 	SUBQ $4, br_offset     // b.off -= 4
@@ -59,12 +65,19 @@ main_loop:
 	// v = v[:4]
 	// low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
 	MOVQ bitReaderShifted_in(br0), AX
-	MOVL 0(br_offset)(AX*1), AX       // AX = uint32(b.in[b.off:b.off+4])
 
 	// b.value |= uint64(low) << (b.bitsRead & 63)
+#ifdef GOAMD64_v3
+	SHLXQ br_bits_read, 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4]) << (b.bitsRead & 63)
+
+#else
+	MOVL 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4])
 	MOVQ br_bits_read, CX
 	SHLQ CL, AX
-	ORQ  AX, br_value
+
+#endif
+
+	ORQ AX, br_value
 
 	// exhausted = exhausted || (br0.off < 4)
 	CMPQ  br_offset, $4
@@ -75,32 +88,62 @@ main_loop:
 skip_fill0:
 
 	// val0 := br0.peekTopBits(peekBits)
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	MOVQ br_value, AX
 	MOVQ peek_bits, CX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
+
+#endif
 
 	// v0 := table[val0&mask]
 	MOVW 0(table)(AX*2), AX // AX - v0
 
 	// br0.advance(uint8(v0.entry))
-	MOVB    AH, BL           // BL = uint8(v0.entry >> 8)
-	MOVBQZX AL, CX
-	SHLQ    CL, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	MOVB AH, BL // BL = uint8(v0.entry >> 8)
 
+#ifdef GOAMD64_v3
+	MOVBQZX AL, CX
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
+
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	// val1 := br0.peekTopBits(peekBits)
 	MOVQ peek_bits, CX
 	MOVQ br_value, AX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
 
+#endif
+
 	// v1 := table[val1&mask]
 	MOVW 0(table)(AX*2), AX // AX - v1
 
 	// br0.advance(uint8(v1.entry))
-	MOVB    AH, BH           // BH = uint8(v1.entry >> 8)
+	MOVB AH, BH // BH = uint8(v1.entry >> 8)
+
+#ifdef GOAMD64_v3
 	MOVBQZX AL, CX
-	SHLQ    CX, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
 	// buf[stream][off] = uint8(v0.entry >> 8)
@@ -118,9 +161,9 @@ skip_fill0:
 	MOVQ    bitReaderShifted_value(br1), br_value
 	MOVQ    bitReaderShifted_off(br1), br_offset
 
-	// if b.bitsRead >= 32 {
-	CMPQ br_bits_read, $32
-	JB   skip_fill1
+	// We must have at least 2 * max tablelog left
+	CMPQ br_bits_read, $64-22
+	JBE  skip_fill1
 
 	SUBQ $32, br_bits_read // b.bitsRead -= 32
 	SUBQ $4, br_offset     // b.off -= 4
@@ -129,12 +172,19 @@ skip_fill0:
 	// v = v[:4]
 	// low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
 	MOVQ bitReaderShifted_in(br1), AX
-	MOVL 0(br_offset)(AX*1), AX       // AX = uint32(b.in[b.off:b.off+4])
 
 	// b.value |= uint64(low) << (b.bitsRead & 63)
+#ifdef GOAMD64_v3
+	SHLXQ br_bits_read, 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4]) << (b.bitsRead & 63)
+
+#else
+	MOVL 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4])
 	MOVQ br_bits_read, CX
 	SHLQ CL, AX
-	ORQ  AX, br_value
+
+#endif
+
+	ORQ AX, br_value
 
 	// exhausted = exhausted || (br1.off < 4)
 	CMPQ  br_offset, $4
@@ -145,32 +195,62 @@ skip_fill0:
 skip_fill1:
 
 	// val0 := br1.peekTopBits(peekBits)
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	MOVQ br_value, AX
 	MOVQ peek_bits, CX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
+
+#endif
 
 	// v0 := table[val0&mask]
 	MOVW 0(table)(AX*2), AX // AX - v0
 
 	// br1.advance(uint8(v0.entry))
-	MOVB    AH, BL           // BL = uint8(v0.entry >> 8)
-	MOVBQZX AL, CX
-	SHLQ    CL, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	MOVB AH, BL // BL = uint8(v0.entry >> 8)
 
+#ifdef GOAMD64_v3
+	MOVBQZX AL, CX
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
+
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	// val1 := br1.peekTopBits(peekBits)
 	MOVQ peek_bits, CX
 	MOVQ br_value, AX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
 
+#endif
+
 	// v1 := table[val1&mask]
 	MOVW 0(table)(AX*2), AX // AX - v1
 
 	// br1.advance(uint8(v1.entry))
-	MOVB    AH, BH           // BH = uint8(v1.entry >> 8)
+	MOVB AH, BH // BH = uint8(v1.entry >> 8)
+
+#ifdef GOAMD64_v3
 	MOVBQZX AL, CX
-	SHLQ    CX, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
 	// buf[stream][off] = uint8(v0.entry >> 8)
@@ -188,9 +268,9 @@ skip_fill1:
 	MOVQ    bitReaderShifted_value(br2), br_value
 	MOVQ    bitReaderShifted_off(br2), br_offset
 
-	// if b.bitsRead >= 32 {
-	CMPQ br_bits_read, $32
-	JB   skip_fill2
+	// We must have at least 2 * max tablelog left
+	CMPQ br_bits_read, $64-22
+	JBE  skip_fill2
 
 	SUBQ $32, br_bits_read // b.bitsRead -= 32
 	SUBQ $4, br_offset     // b.off -= 4
@@ -199,12 +279,19 @@ skip_fill1:
 	// v = v[:4]
 	// low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
 	MOVQ bitReaderShifted_in(br2), AX
-	MOVL 0(br_offset)(AX*1), AX       // AX = uint32(b.in[b.off:b.off+4])
 
 	// b.value |= uint64(low) << (b.bitsRead & 63)
+#ifdef GOAMD64_v3
+	SHLXQ br_bits_read, 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4]) << (b.bitsRead & 63)
+
+#else
+	MOVL 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4])
 	MOVQ br_bits_read, CX
 	SHLQ CL, AX
-	ORQ  AX, br_value
+
+#endif
+
+	ORQ AX, br_value
 
 	// exhausted = exhausted || (br2.off < 4)
 	CMPQ  br_offset, $4
@@ -215,32 +302,62 @@ skip_fill1:
 skip_fill2:
 
 	// val0 := br2.peekTopBits(peekBits)
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	MOVQ br_value, AX
 	MOVQ peek_bits, CX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
+
+#endif
 
 	// v0 := table[val0&mask]
 	MOVW 0(table)(AX*2), AX // AX - v0
 
 	// br2.advance(uint8(v0.entry))
-	MOVB    AH, BL           // BL = uint8(v0.entry >> 8)
-	MOVBQZX AL, CX
-	SHLQ    CL, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	MOVB AH, BL // BL = uint8(v0.entry >> 8)
 
+#ifdef GOAMD64_v3
+	MOVBQZX AL, CX
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
+
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	// val1 := br2.peekTopBits(peekBits)
 	MOVQ peek_bits, CX
 	MOVQ br_value, AX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
 
+#endif
+
 	// v1 := table[val1&mask]
 	MOVW 0(table)(AX*2), AX // AX - v1
 
 	// br2.advance(uint8(v1.entry))
-	MOVB    AH, BH           // BH = uint8(v1.entry >> 8)
+	MOVB AH, BH // BH = uint8(v1.entry >> 8)
+
+#ifdef GOAMD64_v3
 	MOVBQZX AL, CX
-	SHLQ    CX, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
 	// buf[stream][off] = uint8(v0.entry >> 8)
@@ -258,9 +375,9 @@ skip_fill2:
 	MOVQ    bitReaderShifted_value(br3), br_value
 	MOVQ    bitReaderShifted_off(br3), br_offset
 
-	// if b.bitsRead >= 32 {
-	CMPQ br_bits_read, $32
-	JB   skip_fill3
+	// We must have at least 2 * max tablelog left
+	CMPQ br_bits_read, $64-22
+	JBE  skip_fill3
 
 	SUBQ $32, br_bits_read // b.bitsRead -= 32
 	SUBQ $4, br_offset     // b.off -= 4
@@ -269,12 +386,19 @@ skip_fill2:
 	// v = v[:4]
 	// low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
 	MOVQ bitReaderShifted_in(br3), AX
-	MOVL 0(br_offset)(AX*1), AX       // AX = uint32(b.in[b.off:b.off+4])
 
 	// b.value |= uint64(low) << (b.bitsRead & 63)
+#ifdef GOAMD64_v3
+	SHLXQ br_bits_read, 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4]) << (b.bitsRead & 63)
+
+#else
+	MOVL 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4])
 	MOVQ br_bits_read, CX
 	SHLQ CL, AX
-	ORQ  AX, br_value
+
+#endif
+
+	ORQ AX, br_value
 
 	// exhausted = exhausted || (br3.off < 4)
 	CMPQ  br_offset, $4
@@ -285,32 +409,62 @@ skip_fill2:
 skip_fill3:
 
 	// val0 := br3.peekTopBits(peekBits)
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	MOVQ br_value, AX
 	MOVQ peek_bits, CX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
+
+#endif
 
 	// v0 := table[val0&mask]
 	MOVW 0(table)(AX*2), AX // AX - v0
 
 	// br3.advance(uint8(v0.entry))
-	MOVB    AH, BL           // BL = uint8(v0.entry >> 8)
-	MOVBQZX AL, CX
-	SHLQ    CL, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	MOVB AH, BL // BL = uint8(v0.entry >> 8)
 
+#ifdef GOAMD64_v3
+	MOVBQZX AL, CX
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
+
+#ifdef GOAMD64_v3
+	SHRXQ peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+
+#else
 	// val1 := br3.peekTopBits(peekBits)
 	MOVQ peek_bits, CX
 	MOVQ br_value, AX
 	SHRQ CL, AX        // AX = (value >> peek_bits) & mask
 
+#endif
+
 	// v1 := table[val1&mask]
 	MOVW 0(table)(AX*2), AX // AX - v1
 
 	// br3.advance(uint8(v1.entry))
-	MOVB    AH, BH           // BH = uint8(v1.entry >> 8)
+	MOVB AH, BH // BH = uint8(v1.entry >> 8)
+
+#ifdef GOAMD64_v3
 	MOVBQZX AL, CX
-	SHLQ    CX, br_value     // value <<= n
-	ADDQ    CX, br_bits_read // bits_read += n
+	SHLXQ   AX, br_value, br_value // value <<= n
+
+#else
+	MOVBQZX AL, CX
+	SHLQ    CL, br_value // value <<= n
+
+#endif
+
+	ADDQ CX, br_bits_read // bits_read += n
 
 	// these two writes get coalesced
 	// buf[stream][off] = uint8(v0.entry >> 8)

--- a/huff0/decompress_amd64.s.in
+++ b/huff0/decompress_amd64.s.in
@@ -6,6 +6,11 @@
 #include "funcdata.h"
 #include "go_asm.h"
 
+#ifdef GOAMD64_v4
+#ifndef GOAMD64_v3
+#define GOAMD64_v3
+#endif
+#endif
 
 #define bufoff      256     // see decompress.go, we're using [4][256]byte table
 
@@ -49,9 +54,9 @@ main_loop:
     MOVQ    bitReaderShifted_value(br{{ var "id" }}), br_value
     MOVQ    bitReaderShifted_off(br{{ var "id" }}), br_offset
 
-	// if b.bitsRead >= 32 {
-    CMPQ    br_bits_read, $32
-    JB      skip_fill{{ var "id" }}
+    // We must have at least 2 * max tablelog left
+    CMPQ    br_bits_read, $64-22
+    JBE     skip_fill{{ var "id" }}
 
     SUBQ    $32, br_bits_read       // b.bitsRead -= 32
     SUBQ    $4, br_offset           // b.off -= 4
@@ -60,11 +65,16 @@ main_loop:
 	// v = v[:4]
 	// low := (uint32(v[0])) | (uint32(v[1]) << 8) | (uint32(v[2]) << 16) | (uint32(v[3]) << 24)
     MOVQ    bitReaderShifted_in(br{{ var "id" }}), AX
-    MOVL    0(br_offset)(AX*1), AX  // AX = uint32(b.in[b.off:b.off+4])
 
 	// b.value |= uint64(low) << (b.bitsRead & 63)
+#ifdef GOAMD64_v3
+    SHLXQ   br_bits_read, 0(br_offset)(AX*1), AX // AX = uint32(b.in[b.off:b.off+4]) << (b.bitsRead & 63)
+#else
+    MOVL    0(br_offset)(AX*1), AX  // AX = uint32(b.in[b.off:b.off+4])
     MOVQ    br_bits_read, CX
     SHLQ    CL, AX
+#endif
+
     ORQ     AX, br_value
 
     // exhausted = exhausted || (br{{ var "id"}}.off < 4)
@@ -75,31 +85,54 @@ main_loop:
 skip_fill{{ var "id" }}:
 
     // val0 := br{{ var "id"}}.peekTopBits(peekBits)
+#ifdef GOAMD64_v3
+    SHRXQ   peek_bits, br_value, AX // AX = (value >> peek_bits) & mask
+#else
     MOVQ    br_value, AX
     MOVQ    peek_bits, CX
     SHRQ    CL, AX                  // AX = (value >> peek_bits) & mask
+#endif
 
     // v0 := table[val0&mask]
     MOVW    0(table)(AX*2), AX      // AX - v0
 
     // br{{ var "id"}}.advance(uint8(v0.entry))
     MOVB    AH, BL                  // BL = uint8(v0.entry >> 8)
+
+#ifdef GOAMD64_v3
+    MOVBQZX AL, CX
+    SHLXQ   AX, br_value, br_value // value <<= n
+#else
     MOVBQZX AL, CX
     SHLQ    CL, br_value            // value <<= n
+#endif
+
     ADDQ    CX, br_bits_read        // bits_read += n
 
+
+#ifdef GOAMD64_v3
+    SHRXQ    peek_bits, br_value, AX  // AX = (value >> peek_bits) & mask
+#else
     // val1 := br{{ var "id"}}.peekTopBits(peekBits)
     MOVQ    peek_bits, CX
     MOVQ    br_value, AX
     SHRQ    CL, AX                  // AX = (value >> peek_bits) & mask
+#endif
 
     // v1 := table[val1&mask]
     MOVW    0(table)(AX*2), AX      // AX - v1
 
     // br{{ var "id"}}.advance(uint8(v1.entry))
     MOVB    AH, BH                  // BH = uint8(v1.entry >> 8)
+
+#ifdef GOAMD64_v3
     MOVBQZX AL, CX
-    SHLQ    CX, br_value            // value <<= n
+    SHLXQ   AX, br_value, br_value // value <<= n
+#else
+    MOVBQZX AL, CX
+    SHLQ    CL, br_value            // value <<= n
+#endif
+
     ADDQ    CX, br_bits_read        // bits_read += n
 
 


### PR DESCRIPTION
Go v1.18 feature. Set `GOAMD64=v3` to enable. Nothing worth having separate codepaths for.

Allows breaking dependency chain a bit.

```
benchmark                                              old ns/op     new ns/op     delta
BenchmarkDecompress4XNoTable/gettysburg/10000-32       11464         11195         -2.35%
BenchmarkDecompress4XNoTable/gettysburg/262143-32      322679        319985        -0.83%
BenchmarkDecompress4XNoTable/twain/10000-32            11505         11238         -2.32%
BenchmarkDecompress4XNoTable/twain/262143-32           373751        370410        -0.89%
BenchmarkDecompress4XNoTable/pngdata.001/10000-32      11957         11461         -4.15%
BenchmarkDecompress4XNoTable/pngdata.001/262143-32     306403        300566        -1.91%
```