### PR TITLE
zstd: x86 assembler implementation of sequenceDecs.executeSimple

### DIFF
--- a/zstd/_generate/gen.go
+++ b/zstd/_generate/gen.go
@@ -577,7 +577,6 @@ func (e executeSimple) generateProcedure(name string) {
 	outLen := GP64()
 	literals := GP64()
 	outPosition := GP64()
-	litPosition := GP64()
 	windowSize := GP64()
 
 	{
@@ -591,7 +590,6 @@ func (e executeSimple) generateProcedure(name string) {
 		Load(ctx.Field("out").Len(), outLen)
 		Load(ctx.Field("literals").Base(), literals)
 		Load(ctx.Field("outPosition"), outPosition)
-		Load(ctx.Field("litPosition"), litPosition)
 		Load(ctx.Field("windowSize"), windowSize)
 
 		tmp := GP64()
@@ -625,7 +623,6 @@ func (e executeSimple) generateProcedure(name string) {
 		e.copyMemory("1", literals, outBase, ll)
 
 		ADDQ(ll, literals)
-		ADDQ(ll, litPosition)
 		ADDQ(ll, outBase)
 		ADDQ(ll, outPosition)
 	}
@@ -700,7 +697,12 @@ func (e executeSimple) generateProcedure(name string) {
 		ctx := Dereference(Param("ctx"))
 		Store(seqIndex, ctx.Field("seqIndex"))
 		Store(outPosition, ctx.Field("outPosition"))
-		Store(litPosition, ctx.Field("litPosition"))
+
+		// compute litPosition
+		tmp := GP64()
+		Load(ctx.Field("literals").Base(), tmp)
+		SUBQ(tmp, literals) // litPosition := current - initial literals pointer
+		Store(literals, ctx.Field("litPosition"))
 	}
 	returnValue(1)
 	RET()

--- a/zstd/_generate/gen.go
+++ b/zstd/_generate/gen.go
@@ -50,6 +50,10 @@ func main() {
 	o.genDecodeSeqAsm("sequenceDecs_decode_amd64")
 	o.bmi2 = true
 	o.genDecodeSeqAsm("sequenceDecs_decode_bmi2")
+
+	exec := executeSimple{}
+	exec.generateProcedure("sequenceDecs_executeSimple_amd64")
+
 	Generate()
 	b, err := ioutil.ReadFile(out.Value.String())
 	if err != nil {
@@ -549,4 +553,195 @@ func (o options) adjustOffset(name string, moP, llP Mem, offsetB reg.GPVirtual) 
 	}
 	Label(name + "_end")
 	return offset
+}
+
+type executeSimple struct{}
+
+// copySize returns register size used to fast copy.
+//
+// See copyMemory()
+func (e executeSimple) copySize() int {
+	return 16
+}
+
+func (e executeSimple) generateProcedure(name string) {
+	Package("github.com/klauspost/compress/zstd")
+	TEXT(name, 0, "func (ctx *executeAsmContext) bool")
+	Doc(name+" implements the main loop of sequenceDecs.decode in x86 asm", "")
+	Pragma("noescape")
+
+	seqsBase := GP64()
+	seqsLen := GP64()
+	seqIndex := GP64()
+	outBase := GP64()
+	outLen := GP64()
+	literals := GP64()
+	outPosition := GP64()
+	litPosition := GP64()
+
+	{
+		ctx := Dereference(Param("ctx"))
+		Load(ctx.Field("seqs").Base(), seqsBase)
+		Load(ctx.Field("seqs").Len(), seqsLen)
+		Load(ctx.Field("seqIndex"), seqIndex)
+		Load(ctx.Field("out").Base(), outBase)
+		Load(ctx.Field("out").Len(), outLen)
+		Load(ctx.Field("literals").Base(), literals)
+		Load(ctx.Field("outPosition"), outPosition)
+		Load(ctx.Field("litPosition"), litPosition)
+
+		tmp := GP64()
+		Comment("seqsBase += 24 * seqIndex")
+		LEAQ(Mem{Base: seqIndex, Index: seqIndex, Scale: 2}, tmp) // * 3
+		SHLQ(U8(3), tmp)                                          // * 8
+		ADDQ(tmp, seqsBase)
+
+		Comment("outBase += outPosition")
+		ADDQ(outPosition, outBase)
+	}
+
+	Label("main_loop")
+
+	ml := GP64()
+	mo := GP64()
+	ll := GP64()
+
+	moPtr := Mem{Base: seqsBase, Disp: 2 * 8}
+	mlPtr := Mem{Base: seqsBase, Disp: 1 * 8}
+	llPtr := Mem{Base: seqsBase, Disp: 0 * 8}
+
+	MOVQ(mlPtr, ml)
+	MOVQ(llPtr, ll)
+
+	Comment("Check if we won't overflow ctx.out while fast copying")
+	total := GP64()
+	{
+		max := GP64()
+		LEAQ(Mem{Base: ml, Index: ll, Scale: 1}, total) // ml + ll
+		LEAQ(Mem{Base: outPosition, Index: total, Scale: 1, Disp: e.copySize()}, max)
+		CMPQ(max, outLen)
+		JA(LabelRef("slow_path"))
+	}
+
+	Comment("Update the counters upfront")
+	{
+		ADDQ(total, outPosition)
+		ADDQ(ll, litPosition)
+	}
+
+	Comment("Copy literals")
+	Label("copy_literals")
+	{
+		TESTQ(ll, ll)
+		JZ(LabelRef("copy_match"))
+		e.copyMemory("1", literals, outBase, ll)
+
+		ADDQ(ll, literals)
+		ADDQ(ll, outBase)
+	}
+
+	Comment("Copy match")
+	Label("copy_match")
+	{
+		TESTQ(ml, ml)
+		JZ(LabelRef("handle_loop"))
+
+		MOVQ(moPtr, mo)
+		src := GP64()
+		MOVQ(outBase, src)
+		SUBQ(mo, src) // src = &s.out[t - mo]
+
+		// start := t - mo
+		// if ml <= t-start {
+		//     // no overlap
+		// } else {
+		//     // overlapping copy
+		// }
+		//
+		// Note: ml <= t - start
+		//       ml <= t - (t - mo)
+		//       ml <= mo
+		Comment("ml <= mo")
+		CMPQ(ml, mo)
+		JA(LabelRef("copy_overalapping_match"))
+
+		Comment("Copy non-overlapping match")
+		Label("copy_non_overalapping_match")
+		{
+			e.copyMemory("2", src, outBase, ml)
+			ADDQ(ml, outBase)
+			JMP(LabelRef("handle_loop"))
+		}
+
+		Comment("Copy overlapping match")
+		Label("copy_overalapping_match")
+		{
+			e.copyOverlappedMemory("3", src, outBase, ml)
+			ADDQ(ml, outBase)
+		}
+	}
+
+	Label("handle_loop")
+	ADDQ(U8(24), seqsBase) // seqs += sizeof(seqVals)
+	INCQ(seqIndex)
+	CMPQ(seqIndex, seqsLen)
+	JB(LabelRef("main_loop"))
+
+	returnValue := func(val int) {
+		ret, err := ReturnIndex(0).Resolve()
+		if err != nil {
+			panic(err)
+		}
+
+		Comment("Return value")
+		MOVB(U8(val), ret.Addr)
+
+		Comment("Update the context")
+		ctx := Dereference(Param("ctx"))
+		Store(seqIndex, ctx.Field("seqIndex"))
+		Store(outPosition, ctx.Field("outPosition"))
+		Store(litPosition, ctx.Field("litPosition"))
+	}
+
+	returnValue(1)
+	RET()
+
+	Label("slow_path")
+	returnValue(0)
+	RET()
+}
+
+// copyMemory will copy memory in blocks of 16 or 32 bytes,
+// overwriting up to 15 or 31 extra bytes.
+func (e executeSimple) copyMemory(suffix string, src, dst, length reg.GPVirtual) {
+	label := "copy_" + suffix
+	ofs := GP64()
+	s := Mem{Base: src, Index: ofs, Scale: 1}
+	d := Mem{Base: dst, Index: ofs, Scale: 1}
+
+	XORQ(ofs, ofs)
+	Label(label)
+	t := XMM()
+	MOVUPS(s, t)
+	MOVUPS(t, d)
+	ADDQ(U8(e.copySize()), ofs)
+	CMPQ(ofs, length)
+	JB(LabelRef(label))
+}
+
+// copyOverlappedMemory will copy one byte at the time from src to dst.
+func (e executeSimple) copyOverlappedMemory(suffix string, src, dst, length reg.GPVirtual) {
+	label := "copy_slow_" + suffix
+	ofs := GP64()
+	s := Mem{Base: src, Index: ofs, Scale: 1}
+	d := Mem{Base: dst, Index: ofs, Scale: 1}
+	t := GP64()
+
+	XORQ(ofs, ofs)
+	Label(label)
+	MOVB(s, t.As8())
+	MOVB(t.As8(), d)
+	INCQ(ofs)
+	CMPQ(ofs, length)
+	JB(LabelRef(label))
 }

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -1151,7 +1151,7 @@ func testDecoderFileBad(t *testing.T, fn string, newDec func() (*Decoder, error)
 				if want == "" {
 					want = "<error>"
 				}
-				t.Error("Did not get expected error", want, "- got ", len(got), "bytes")
+				t.Error("Did not get expected error", want, "- got", len(got), "bytes")
 				return
 			}
 			if errMap[tt.Name] == "" {

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -101,6 +101,10 @@ func (s *sequenceDecs) initialize(br *bitReader, hist *history, out []byte) erro
 // execute will execute the decoded sequence with the provided history.
 // The sequence must be evaluated before being sent.
 func (s *sequenceDecs) execute(seqs []seqVals, hist []byte) error {
+	if len(hist) == 0 && len(s.dict) == 0 {
+		return s.executeSimple(seqs)
+	}
+
 	// Ensure we have enough output size...
 	if len(s.out)+s.seqSize > cap(s.out) {
 		addBytes := s.seqSize + len(s.out)

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -591,3 +591,115 @@ sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch:
 sequenceDecs_decode_bmi2_error_match_len_too_big:
 	MOVQ $0x00000002, ret+24(FP)
 	RET
+
+// func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
+// Requires: SSE
+TEXT ·sequenceDecs_executeSimple_amd64(SB), $0-9
+	MOVQ ctx+0(FP), R9
+	MOVQ (R9), AX
+	MOVQ 8(R9), CX
+	MOVQ 24(R9), DX
+	MOVQ 32(R9), BX
+	MOVQ 40(R9), SI
+	MOVQ 56(R9), DI
+	MOVQ 80(R9), R8
+	MOVQ 88(R9), R9
+
+	// seqsBase += 24 * seqIndex
+	LEAQ (DX)(DX*2), R10
+	SHLQ $0x03, R10
+	ADDQ R10, AX
+
+	// outBase += outPosition
+	ADDQ R8, BX
+
+main_loop:
+	MOVQ 8(AX), R10
+	MOVQ (AX), R11
+
+	// Check if we won't overflow ctx.out while fast copying
+	LEAQ (R10)(R11*1), R12
+	LEAQ 16(R8)(R12*1), R13
+	CMPQ R13, SI
+	JA   slow_path
+
+	// Update the counters upfront
+	ADDQ R12, R8
+	ADDQ R11, R9
+
+	// Copy literals
+	TESTQ R11, R11
+	JZ    copy_match
+	XORQ  R12, R12
+
+copy_1:
+	MOVUPS (DI)(R12*1), X0
+	MOVUPS X0, (BX)(R12*1)
+	ADDQ   $0x10, R12
+	CMPQ   R12, R11
+	JB     copy_1
+	ADDQ   R11, DI
+	ADDQ   R11, BX
+
+	// Copy match
+copy_match:
+	TESTQ R10, R10
+	JZ    handle_loop
+	MOVQ  16(AX), R11
+	MOVQ  BX, R12
+	SUBQ  R11, R12
+
+	// ml <= mo
+	CMPQ R10, R11
+	JA   copy_overalapping_match
+
+	// Copy non-overlapping match
+	XORQ R11, R11
+
+copy_2:
+	MOVUPS (R12)(R11*1), X0
+	MOVUPS X0, (BX)(R11*1)
+	ADDQ   $0x10, R11
+	CMPQ   R11, R10
+	JB     copy_2
+	ADDQ   R10, BX
+	JMP    handle_loop
+
+	// Copy overlapping match
+copy_overalapping_match:
+	XORQ R11, R11
+
+copy_slow_3:
+	MOVB (R12)(R11*1), R13
+	MOVB R13, (BX)(R11*1)
+	INCQ R11
+	CMPQ R11, R10
+	JB   copy_slow_3
+	ADDQ R10, BX
+
+handle_loop:
+	ADDQ $0x18, AX
+	INCQ DX
+	CMPQ DX, CX
+	JB   main_loop
+
+	// Return value
+	MOVB $0x01, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R8, 80(AX)
+	MOVQ R9, 88(AX)
+	RET
+
+slow_path:
+	// Return value
+	MOVB $0x00, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R8, 80(AX)
+	MOVQ R9, 88(AX)
+	RET

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -605,80 +605,78 @@ TEXT ·sequenceDecs_executeSimple_amd64(SB), $0-9
 	MOVQ  40(DI), SI
 	MOVQ  56(DI), SI
 	MOVQ  80(DI), R8
-	MOVQ  88(DI), R9
 	MOVQ  96(DI), DI
 
 	// seqsBase += 24 * seqIndex
-	LEAQ (DX)(DX*2), R10
-	SHLQ $0x03, R10
-	ADDQ R10, AX
+	LEAQ (DX)(DX*2), R9
+	SHLQ $0x03, R9
+	ADDQ R9, AX
 
 	// outBase += outPosition
 	ADDQ R8, BX
 
 main_loop:
-	MOVQ 8(AX), R10
-	MOVQ (AX), R11
+	MOVQ 8(AX), R9
+	MOVQ (AX), R10
 
 	// Copy literals
-	TESTQ R11, R11
+	TESTQ R10, R10
 	JZ    copy_match
-	XORQ  R12, R12
+	XORQ  R11, R11
 
 copy_1:
-	MOVUPS (SI)(R12*1), X0
-	MOVUPS X0, (BX)(R12*1)
-	ADDQ   $0x10, R12
-	CMPQ   R12, R11
-	JB     copy_1
-	ADDQ   R11, SI
-	ADDQ   R11, R9
-	ADDQ   R11, BX
-	ADDQ   R11, R8
-
-	// Copy match
-copy_match:
-	TESTQ R10, R10
-	JZ    handle_loop
-	MOVQ  16(AX), R11
-
-	// Malformed input if seq.mo > t || seq.mo > s.windowSize)
-	CMPQ R11, R8
-	JG   error_match_off_to_big
-	CMPQ R11, DI
-	JG   error_match_off_to_big
-	MOVQ BX, R12
-	SUBQ R11, R12
-
-	// ml <= mo
-	CMPQ R10, R11
-	JA   copy_overalapping_match
-
-	// Copy non-overlapping match
-	XORQ R11, R11
-
-copy_2:
-	MOVUPS (R12)(R11*1), X0
+	MOVUPS (SI)(R11*1), X0
 	MOVUPS X0, (BX)(R11*1)
 	ADDQ   $0x10, R11
 	CMPQ   R11, R10
-	JB     copy_2
+	JB     copy_1
+	ADDQ   R10, SI
 	ADDQ   R10, BX
 	ADDQ   R10, R8
+
+	// Copy match
+copy_match:
+	TESTQ R9, R9
+	JZ    handle_loop
+	MOVQ  16(AX), R10
+
+	// Malformed input if seq.mo > t || seq.mo > s.windowSize)
+	CMPQ R10, R8
+	JG   error_match_off_to_big
+	CMPQ R10, DI
+	JG   error_match_off_to_big
+	MOVQ BX, R11
+	SUBQ R10, R11
+
+	// ml <= mo
+	CMPQ R9, R10
+	JA   copy_overalapping_match
+
+	// Copy non-overlapping match
+	XORQ R10, R10
+
+copy_2:
+	MOVUPS (R11)(R10*1), X0
+	MOVUPS X0, (BX)(R10*1)
+	ADDQ   $0x10, R10
+	CMPQ   R10, R9
+	JB     copy_2
+	ADDQ   R9, BX
+	ADDQ   R9, R8
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overalapping_match:
-	XORQ R11, R11
+	XORQ R10, R10
 
 copy_slow_3:
-	MOVB (R12)(R11*1), R13
-	MOVB R13, (BX)(R11*1)
-	INCQ R11
-	CMPQ R11, R10
+	MOVB (R11)(R10*1), R12
+	MOVB R12, (BX)(R10*1)
+	INCQ R10
+	CMPQ R10, R9
 	JB   copy_slow_3
-	ADDQ R10, BX
-	ADDQ R10, R8
+	ADDQ R9, BX
+	ADDQ R9, R8
 
 handle_loop:
 	ADDQ $0x18, AX
@@ -693,7 +691,9 @@ handle_loop:
 	MOVQ ctx+0(FP), AX
 	MOVQ DX, 24(AX)
 	MOVQ R8, 80(AX)
-	MOVQ R9, 88(AX)
+	MOVQ 56(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 88(AX)
 	RET
 
 error_match_off_to_big:
@@ -704,7 +704,9 @@ error_match_off_to_big:
 	MOVQ ctx+0(FP), AX
 	MOVQ DX, 24(AX)
 	MOVQ R8, 80(AX)
-	MOVQ R9, 88(AX)
+	MOVQ 56(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 88(AX)
 	RET
 
 empty_seqs:

--- a/zstd/seqdec_generic.go
+++ b/zstd/seqdec_generic.go
@@ -152,3 +152,64 @@ func (s *sequenceDecs) decode(seqs []seqVals) error {
 	}
 	return err
 }
+
+// executeSimple handles cases when no history nor dictionary are used.
+func (s *sequenceDecs) executeSimple(seqs []seqVals) error {
+	// Ensure we have enough output size...
+	if len(s.out)+s.seqSize > cap(s.out) {
+		addBytes := s.seqSize + len(s.out)
+		s.out = append(s.out, make([]byte, addBytes)...)
+		s.out = s.out[:len(s.out)-addBytes]
+	}
+
+	if debugDecoder {
+		printf("Execute %d seqs with literals: %d into %d bytes\n", len(seqs), len(s.literals), s.seqSize)
+	}
+
+	var t = len(s.out)
+	out := s.out[:t+s.seqSize]
+
+	for _, seq := range seqs {
+		// Add literals
+		copy(out[t:], s.literals[:seq.ll])
+		t += seq.ll
+		s.literals = s.literals[seq.ll:]
+
+		// Malformed input
+		if seq.mo > t || seq.mo > s.windowSize {
+			return fmt.Errorf("match offset (%d) bigger than current history (%d)", seq.mo, t)
+		}
+
+		// We must be in current buffer now
+		if seq.ml > 0 {
+			start := t - seq.mo
+			if seq.ml <= t-start {
+				// No overlap
+				copy(out[t:], out[start:start+seq.ml])
+				t += seq.ml
+			} else {
+				// Overlapping copy
+				// Extend destination slice and copy one byte at the time.
+				src := out[start : start+seq.ml]
+				dst := out[t:]
+				dst = dst[:len(src)]
+				t += len(src)
+				// Destination is the space we just added.
+				for i := range src {
+					dst[i] = src[i]
+				}
+			}
+		}
+	}
+	// Add final literals
+	copy(out[t:], s.literals)
+	if debugDecoder {
+		t += len(s.literals)
+		if t != len(out) {
+			panic(fmt.Errorf("length mismatch, want %d, got %d, ss: %d", len(out), t, s.seqSize))
+		}
+	}
+	s.out = out
+
+	return nil
+}


### PR DESCRIPTION
This is plain x86 and x86 with BMI2 implementation of `sequenceDecs.executeSimple`. Part of #515.

I extracted function `executeSimple` to handle cases when no history nor dictionary is used. My quick check showed that for `go test` such cases is 83% of all calls, while for `go test -bench .` it's 99%. Thus, it's the vast majority of cases. Of course, we may consider handling all cases in another PR (but after completing #529).

~As always, I'm marking it as a draft, as some tests fail. I will figure out what's wrong, likely as usual I missed something silly.~ [fixed (I was right, it was silly)]

Below are preliminary benchmark results from IceLake machine: it's noasm vs GOARM64=v3. Currently, the branch is built on top of #528, thus we see the combined performance boost from x86 BMI use in both `decode` and `execute`.

```
benchmark                                                                 old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-16                            260.20       348.57       1.34x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-16                         211.67       251.78       1.19x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-16                           250.34       298.27       1.19x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-16                         233.78       373.57       1.60x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-16                          209.63       322.12       1.54x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-16                       6952.38      7619.23      1.10x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-16                             363.22       431.34       1.19x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-16                        366.19       458.76       1.25x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-16                               261.76       386.54       1.48x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-16                            221.62       350.06       1.58x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-16                              262.00       389.86       1.49x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-16                            231.21       361.89       1.57x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-16                             209.42       335.43       1.60x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-16                          9356.96      10893.21     1.16x
BenchmarkDecoder_DecodeAll/urls.10K.zst-16                                388.64       539.45       1.39x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-16                           357.89       444.40       1.24x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-16      226.70       360.78       1.59x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-16      224.89       354.12       1.57x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-16       239.08       369.24       1.54x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-16         219.11       329.76       1.50x
BenchmarkDecoder_DecodeAllFiles/e.txt/fastest-16                          9348.18      10886.74     1.16x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/fastest-16              1052.83      1292.48      1.23x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/best-16                 432.47       419.43       0.97x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/fastest-16                 264.89       324.29       1.22x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/default-16                 184.00       207.14       1.13x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/better-16                  182.83       205.27       1.12x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/best-16                    165.99       192.78       1.16x
BenchmarkDecoder_DecodeAllFiles/html.txt/fastest-16                       401.53       562.99       1.40x
BenchmarkDecoder_DecodeAllFiles/html.txt/default-16                       382.26       558.41       1.46x
BenchmarkDecoder_DecodeAllFiles/html.txt/better-16                        413.76       587.31       1.42x
BenchmarkDecoder_DecodeAllFiles/html.txt/best-16                          389.76       540.86       1.39x
BenchmarkDecoder_DecodeAllFiles/pi.txt/fastest-16                         9334.02      10878.93     1.17x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/fastest-16                     9349.18      10882.05     1.16x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/default-16                     9357.66      10897.99     1.16x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/better-16                      9356.77      10893.79     1.16x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/best-16                        9332.25      10890.70     1.17x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/fastest-16     1502.94      2665.02      1.77x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/default-16     1431.25      2625.59      1.83x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/better-16      1443.33      2770.91      1.92x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/best-16        1518.36      2649.41      1.74x
BenchmarkDecoder_DecodeAllFilesP/e.txt/fastest-16                         67904.31     97302.23     1.43x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/fastest-16             5855.79      5776.46      0.99x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/best-16                4075.41      4028.22      0.99x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/fastest-16                1468.79      1620.82      1.10x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/default-16                996.97       1099.55      1.10x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/better-16                 1014.07      1097.88      1.08x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/best-16                   823.45       943.41       1.15x
BenchmarkDecoder_DecodeAllFilesP/html.txt/fastest-16                      1845.55      2886.39      1.56x
BenchmarkDecoder_DecodeAllFilesP/html.txt/default-16                      1687.15      2817.55      1.67x
BenchmarkDecoder_DecodeAllFilesP/html.txt/better-16                       1911.29      3005.57      1.57x
BenchmarkDecoder_DecodeAllFilesP/html.txt/best-16                         1730.33      2881.95      1.67x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/fastest-16                        67953.72     94562.80     1.39x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/fastest-16                    67918.38     97067.32     1.43x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/default-16                    67942.13     95589.74     1.41x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/better-16                     67922.47     96824.04     1.43x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/best-16                       67918.38     95890.17     1.41x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-16                       1517.85      2819.81      1.86x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-16                    1277.90      2531.84      1.98x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-16                      1523.41      2878.54      1.89x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-16                    1306.50      2575.44      1.97x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-16                     1145.33      2332.57      2.04x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-16                  68109.62     95841.69     1.41x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-16                        2821.39      4603.53      1.63x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-16                   2019.39      2534.19      1.25x
```