### PR TITLE
zstd: Asm decoder tweaks

### DIFF
--- a/internal/cpuinfo/cpuinfo.go
+++ b/internal/cpuinfo/cpuinfo.go
@@ -15,6 +15,16 @@ func HasBMI2() bool {
 	return hasBMI2
 }
 
+// DisableBMI2 will disable BMI2, for testing purposes.
+// Call returned function to restore previous state.
+func DisableBMI2() func() {
+	old := hasBMI2
+	hasBMI2 = false
+	return func() {
+		hasBMI2 = old
+	}
+}
+
 // HasBMI checks whether an x86 CPU supports both BMI1 and BMI2 extensions.
 func HasBMI() bool {
 	return HasBMI1() && HasBMI2()

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -30,22 +30,12 @@ const errorMatchLenTooBig = 2
 // sequenceDecs_decode implements the main loop of sequenceDecs in x86 asm.
 //
 // Please refer to seqdec_generic.go for the reference implementation.
+//go:noescape
 func sequenceDecs_decode_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
 
 // sequenceDecs_decode implements the main loop of sequenceDecs in x86 asm with BMI2 extensions.
+//go:noescape
 func sequenceDecs_decode_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-
-type sequenceDecs_decode_function = func(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-
-var sequenceDecs_decode sequenceDecs_decode_function
-
-func init() {
-	if cpuinfo.HasBMI2() {
-		sequenceDecs_decode = sequenceDecs_decode_bmi2
-	} else {
-		sequenceDecs_decode = sequenceDecs_decode_amd64
-	}
-}
 
 // decode sequences from the stream without the provided history.
 func (s *sequenceDecs) decode(seqs []seqVals) error {
@@ -70,7 +60,12 @@ func (s *sequenceDecs) decode(seqs []seqVals) error {
 
 	s.seqSize = 0
 
-	errCode := sequenceDecs_decode(s, br, &ctx)
+	var errCode int
+	if cpuinfo.HasBMI2() {
+		errCode = sequenceDecs_decode_bmi2(s, br, &ctx)
+	} else {
+		errCode = sequenceDecs_decode_amd64(s, br, &ctx)
+	}
 	if errCode != 0 {
 		i := len(seqs) - ctx.iteration
 		switch errCode {

--- a/zstd/seqdec_amd64_test.go
+++ b/zstd/seqdec_amd64_test.go
@@ -1,0 +1,148 @@
+//go:build amd64 && !appengine && !noasm && gc
+// +build amd64,!appengine,!noasm,gc
+
+package zstd
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/klauspost/compress/internal/cpuinfo"
+	"github.com/klauspost/compress/zip"
+)
+
+func Test_sequenceDecs_decodeNoBMI(t *testing.T) {
+	if !cpuinfo.HasBMI2() {
+		t.Skip("Already tested, platform does not have bmi")
+		return
+	}
+	sequenceDecs_decode = sequenceDecs_decode_amd64
+	defer func() {
+		sequenceDecs_decode = sequenceDecs_decode_bmi2
+	}()
+
+	const writeWant = false
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	want := map[string][]seqVals{}
+	var wantOffsets = map[string][3]int{}
+	if !writeWant {
+		fn := "testdata/seqs-want.zip"
+		data, err := ioutil.ReadFile(fn)
+		tb := t
+		if err != nil {
+			tb.Fatal(err)
+		}
+		zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			tb.Fatal(err)
+		}
+		for _, tt := range zr.File {
+			var ref testSequence
+			if !ref.parse(tt.Name) {
+				tb.Skip("unable to parse:", tt.Name)
+			}
+			o, err := tt.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := csv.NewReader(o)
+			recs, err := r.ReadAll()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i, rec := range recs {
+				if i == 0 {
+					var o [3]int
+					o[0], _ = strconv.Atoi(rec[0])
+					o[1], _ = strconv.Atoi(rec[1])
+					o[2], _ = strconv.Atoi(rec[2])
+					wantOffsets[tt.Name] = o
+					continue
+				}
+				s := seqVals{}
+				s.mo, _ = strconv.Atoi(rec[0])
+				s.ml, _ = strconv.Atoi(rec[1])
+				s.ll, _ = strconv.Atoi(rec[2])
+				want[tt.Name] = append(want[tt.Name], s)
+			}
+			o.Close()
+		}
+	}
+	fn := "testdata/seqs.zip"
+	data, err := ioutil.ReadFile(fn)
+	tb := t
+	if err != nil {
+		tb.Fatal(err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	for _, tt := range zr.File {
+		var ref testSequence
+		if !ref.parse(tt.Name) {
+			tb.Skip("unable to parse:", tt.Name)
+		}
+		r, err := tt.Open()
+		if err != nil {
+			tb.Error(err)
+			return
+		}
+
+		seqData, err := ioutil.ReadAll(r)
+		if err != nil {
+			tb.Error(err)
+			return
+		}
+		var buf = bytes.NewBuffer(seqData)
+		s := readDecoders(tb, buf, ref)
+		seqs := make([]seqVals, ref.n)
+
+		t.Run(tt.Name, func(t *testing.T) {
+			fatalIf := func(err error) {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			fatalIf(s.br.init(buf.Bytes()))
+			fatalIf(s.litLengths.init(s.br))
+			fatalIf(s.offsets.init(s.br))
+			fatalIf(s.matchLengths.init(s.br))
+
+			err := s.decode(seqs)
+			if err != nil {
+				t.Error(err)
+			}
+			if writeWant {
+				w, err := zw.Create(tt.Name)
+				fatalIf(err)
+				c := csv.NewWriter(w)
+				w.Write([]byte(fmt.Sprintf("%d,%d,%d\n", s.prevOffset[0], s.prevOffset[1], s.prevOffset[2])))
+				for _, seq := range seqs {
+					c.Write([]string{strconv.Itoa(seq.mo), strconv.Itoa(seq.ml), strconv.Itoa(seq.ll)})
+				}
+				c.Flush()
+			} else {
+				if s.prevOffset != wantOffsets[tt.Name] {
+					t.Errorf("want offsets %v, got %v", wantOffsets[tt.Name], s.prevOffset)
+				}
+
+				if !reflect.DeepEqual(want[tt.Name], seqs) {
+					t.Errorf("got %v\nwant %v", seqs, want[tt.Name])
+				}
+			}
+		})
+	}
+	if writeWant {
+		zw.Close()
+		ioutil.WriteFile("testdata/seqs-want.zip", buf.Bytes(), os.ModePerm)
+	}
+}

--- a/zstd/seqdec_amd64_test.go
+++ b/zstd/seqdec_amd64_test.go
@@ -17,6 +17,18 @@ import (
 	"github.com/klauspost/compress/zip"
 )
 
+func Benchmark_seqdec_decodeNoBMI(b *testing.B) {
+	if !cpuinfo.HasBMI2() {
+		b.Skip("Already tested, platform does not have bmi")
+		return
+	}
+	sequenceDecs_decode = sequenceDecs_decode_amd64
+	defer func() {
+		sequenceDecs_decode = sequenceDecs_decode_bmi2
+	}()
+	benchmark_seqdec_decode(b)
+}
+
 func Test_sequenceDecs_decodeNoBMI(t *testing.T) {
 	if !cpuinfo.HasBMI2() {
 		t.Skip("Already tested, platform does not have bmi")

--- a/zstd/seqdec_amd64_test.go
+++ b/zstd/seqdec_amd64_test.go
@@ -19,25 +19,20 @@ import (
 
 func Benchmark_seqdec_decodeNoBMI(b *testing.B) {
 	if !cpuinfo.HasBMI2() {
-		b.Skip("Already tested, platform does not have bmi")
+		b.Skip("Already tested, platform does not have bmi2")
 		return
 	}
-	sequenceDecs_decode = sequenceDecs_decode_amd64
-	defer func() {
-		sequenceDecs_decode = sequenceDecs_decode_bmi2
-	}()
+	defer cpuinfo.DisableBMI2()()
+
 	benchmark_seqdec_decode(b)
 }
 
 func Test_sequenceDecs_decodeNoBMI(t *testing.T) {
 	if !cpuinfo.HasBMI2() {
-		t.Skip("Already tested, platform does not have bmi")
+		t.Skip("Already tested, platform does not have bmi2")
 		return
 	}
-	sequenceDecs_decode = sequenceDecs_decode_amd64
-	defer func() {
-		sequenceDecs_decode = sequenceDecs_decode_bmi2
-	}()
+	defer cpuinfo.DisableBMI2()()
 
 	const writeWant = false
 	var buf bytes.Buffer

--- a/zstd/seqdec_test.go
+++ b/zstd/seqdec_test.go
@@ -404,6 +404,10 @@ func Test_seqdec_decodeSync(t *testing.T) {
 }
 
 func Benchmark_seqdec_decode(b *testing.B) {
+	benchmark_seqdec_decode(b)
+}
+
+func benchmark_seqdec_decode(b *testing.B) {
 	fn := "testdata/seqs.zip"
 	data, err := ioutil.ReadFile(fn)
 	tb := b


### PR DESCRIPTION
* Add non-bmi amd64 tests
* Use BEXTRQ for extracting shifted values.
* Move 0 check into getBits.
* Remove ctx alloc.

Sequences only, BMI:
```
benchmark                                                                                          old ns/op     new ns/op     delta
Benchmark_seqdec_decode/n-12286-lits-13914-prev-9869-1990358-3296656-win-4194304.blk-32            91657         91114         -0.59%
Benchmark_seqdec_decode/n-12485-lits-6960-prev-976039-2250252-2463561-win-4194304.blk-32           92392         90416         -2.14%
Benchmark_seqdec_decode/n-14746-lits-14461-prev-209-8-1379909-win-4194304.blk-32                   83022         79745         -3.95%
Benchmark_seqdec_decode/n-1525-lits-1498-prev-2009476-797934-2994405-win-4194304.blk-32            9149          8856          -3.20%
Benchmark_seqdec_decode/n-3478-lits-3628-prev-895243-2104056-2119329-win-4194304.blk-32            22402         22102         -1.34%
Benchmark_seqdec_decode/n-8422-lits-5840-prev-168095-2298675-433830-win-4194304.blk-32             60844         60114         -1.20%
Benchmark_seqdec_decode/n-1000-lits-1057-prev-21887-92-217-win-8388608.blk-32                      5785          5879          +1.62%
Benchmark_seqdec_decode/n-15134-lits-20798-prev-4882976-4884216-4474622-win-8388608.blk-32         118030        115597        -2.06%
Benchmark_seqdec_decode/n-2-lits-0-prev-620601-689171-848-win-8388608.blk-32                       135           64.3          -52.35%
Benchmark_seqdec_decode/n-90-lits-67-prev-19498-23-19710-win-8388608.blk-32                        648           589           -9.03%
Benchmark_seqdec_decode/n-931-lits-1179-prev-36502-1526-1518-win-8388608.blk-32                    5555          5467          -1.58%
Benchmark_seqdec_decode/n-2898-lits-4062-prev-335-386-751-win-8388608.blk-32                       17896         17605         -1.63%
Benchmark_seqdec_decode/n-4056-lits-12419-prev-10792-66-309849-win-8388608.blk-32                  27457         27232         -0.82%
Benchmark_seqdec_decode/n-8028-lits-4568-prev-917-65-920-win-8388608.blk-32                        59341         58158         -1.99%
```
No BMI:

```
benchmark                                                                                           old ns/op     new ns/op     delta
Benchmark_seqdec_decodeNoBMI/n-12286-lits-13914-prev-9869-1990358-3296656-win-4194304.blk-32        114889        113333        -1.35%
Benchmark_seqdec_decodeNoBMI/n-12485-lits-6960-prev-976039-2250252-2463561-win-4194304.blk-32       121269        119500        -1.46%
Benchmark_seqdec_decodeNoBMI/n-14746-lits-14461-prev-209-8-1379909-win-4194304.blk-32               106986        102585        -4.11%
Benchmark_seqdec_decodeNoBMI/n-1525-lits-1498-prev-2009476-797934-2994405-win-4194304.blk-32        10910         10304         -5.55%
Benchmark_seqdec_decodeNoBMI/n-3478-lits-3628-prev-895243-2104056-2119329-win-4194304.blk-32        25965         24642         -5.10%
Benchmark_seqdec_decodeNoBMI/n-8422-lits-5840-prev-168095-2298675-433830-win-4194304.blk-32         80183         77980         -2.75%
Benchmark_seqdec_decodeNoBMI/n-1000-lits-1057-prev-21887-92-217-win-8388608.blk-32                  6702          6369          -4.97%
Benchmark_seqdec_decodeNoBMI/n-15134-lits-20798-prev-4882976-4884216-4474622-win-8388608.blk-32     151867        148752        -2.05%
Benchmark_seqdec_decodeNoBMI/n-2-lits-0-prev-620601-689171-848-win-8388608.blk-32                   139           46.8          -66.31%
Benchmark_seqdec_decodeNoBMI/n-90-lits-67-prev-19498-23-19710-win-8388608.blk-32                    744           609           -18.13%
Benchmark_seqdec_decodeNoBMI/n-931-lits-1179-prev-36502-1526-1518-win-8388608.blk-32                6570          6083          -7.41%
Benchmark_seqdec_decodeNoBMI/n-2898-lits-4062-prev-335-386-751-win-8388608.blk-32                   20448         19955         -2.41%
Benchmark_seqdec_decodeNoBMI/n-4056-lits-12419-prev-10792-66-309849-win-8388608.blk-32              34177         32790         -4.06%
Benchmark_seqdec_decodeNoBMI/n-8028-lits-4568-prev-917-65-920-win-8388608.blk-32                    77864         75628         -2.87%
```