### PR TITLE
zstd: extend executeSimple with history support

### DIFF
--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -213,12 +213,9 @@ func (s *sequenceDecs) decodeSync(hist []byte) error {
 	const asyncHack = true
 	if asyncHack {
 		seqs := make([]seqVals, s.nSeqs)
-		s.decode(seqs)
-		if false {
-			for i, s := range seqs {
-				fmt.Printf("%d: mo = %d\n", i, s.mo)
-			}
-		panic("XXX")
+		err := s.decode(seqs)
+		if err != nil {
+			return err
 		}
 		return s.execute(seqs, hist)
 	}

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -101,8 +101,8 @@ func (s *sequenceDecs) initialize(br *bitReader, hist *history, out []byte) erro
 // execute will execute the decoded sequence with the provided history.
 // The sequence must be evaluated before being sent.
 func (s *sequenceDecs) execute(seqs []seqVals, hist []byte) error {
-	if len(hist) == 0 && len(s.dict) == 0 {
-		return s.executeSimple(seqs)
+	if len(s.dict) == 0 {
+		return s.executeSimple(seqs, hist)
 	}
 
 	// Ensure we have enough output size...
@@ -208,6 +208,21 @@ func (s *sequenceDecs) decodeSync(hist []byte) error {
 	// Grab full sizes tables, to avoid bounds checks.
 	llTable, mlTable, ofTable := s.litLengths.fse.dt[:maxTablesize], s.matchLengths.fse.dt[:maxTablesize], s.offsets.fse.dt[:maxTablesize]
 	llState, mlState, ofState := s.litLengths.state.state, s.matchLengths.state.state, s.offsets.state.state
+
+	// XXX: remove before merge
+	const asyncHack = true
+	if asyncHack {
+		seqs := make([]seqVals, s.nSeqs)
+		s.decode(seqs)
+		if false {
+			for i, s := range seqs {
+				fmt.Printf("%d: mo = %d\n", i, s.mo)
+			}
+		panic("XXX")
+		}
+		return s.execute(seqs, hist)
+	}
+
 	out := s.out
 	maxBlockSize := maxCompressedBlockSize
 	if s.windowSize < maxBlockSize {

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -208,18 +208,6 @@ func (s *sequenceDecs) decodeSync(hist []byte) error {
 	// Grab full sizes tables, to avoid bounds checks.
 	llTable, mlTable, ofTable := s.litLengths.fse.dt[:maxTablesize], s.matchLengths.fse.dt[:maxTablesize], s.offsets.fse.dt[:maxTablesize]
 	llState, mlState, ofState := s.litLengths.state.state, s.matchLengths.state.state, s.offsets.state.state
-
-	// XXX: remove before merge
-	const asyncHack = true
-	if asyncHack {
-		seqs := make([]seqVals, s.nSeqs)
-		err := s.decode(seqs)
-		if err != nil {
-			return err
-		}
-		return s.execute(seqs, hist)
-	}
-
 	out := s.out
 	maxBlockSize := maxCompressedBlockSize
 	if s.windowSize < maxBlockSize {

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -101,6 +101,7 @@ type executeAsmContext struct {
 	seqs        []seqVals
 	seqIndex    int
 	out         []byte
+	history     []byte
 	literals    []byte
 	outPosition int
 	litPosition int
@@ -117,8 +118,8 @@ func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
 
 const overwriteSize = 16
 
-// executeSimple handles cases when no history nor dictionary are used.
-func (s *sequenceDecs) executeSimple(seqs []seqVals) error {
+// executeSimple handles cases when dictionary is not used.
+func (s *sequenceDecs) executeSimple(seqs []seqVals, hist []byte) error {
 	// Ensure we have enough output size...
 	if len(s.out)+s.seqSize+overwriteSize > cap(s.out) {
 		addBytes := s.seqSize + len(s.out) + overwriteSize
@@ -137,6 +138,7 @@ func (s *sequenceDecs) executeSimple(seqs []seqVals) error {
 		seqs:        seqs,
 		seqIndex:    0,
 		out:         out,
+		history:     hist,
 		outPosition: t,
 		litPosition: 0,
 		literals:    s.literals,
@@ -146,7 +148,7 @@ func (s *sequenceDecs) executeSimple(seqs []seqVals) error {
 	ok := sequenceDecs_executeSimple_amd64(&ctx)
 	if !ok {
 		return fmt.Errorf("match offset (%d) bigger than current history (%d)",
-			seqs[ctx.seqIndex].mo, ctx.outPosition)
+			seqs[ctx.seqIndex].mo, ctx.outPosition + len(hist))
 	}
 	s.literals = s.literals[ctx.litPosition:]
 	t = ctx.outPosition

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -148,7 +148,7 @@ func (s *sequenceDecs) executeSimple(seqs []seqVals, hist []byte) error {
 	ok := sequenceDecs_executeSimple_amd64(&ctx)
 	if !ok {
 		return fmt.Errorf("match offset (%d) bigger than current history (%d)",
-			seqs[ctx.seqIndex].mo, ctx.outPosition + len(hist))
+			seqs[ctx.seqIndex].mo, ctx.outPosition+len(hist))
 	}
 	s.literals = s.literals[ctx.litPosition:]
 	t = ctx.outPosition

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -590,80 +590,119 @@ TEXT ·sequenceDecs_executeSimple_amd64(SB), $0-9
 	MOVQ  24(DI), DX
 	MOVQ  32(DI), BX
 	MOVQ  40(DI), SI
-	MOVQ  56(DI), SI
-	MOVQ  80(DI), R8
-	MOVQ  96(DI), DI
+	MOVQ  80(DI), SI
+	MOVQ  104(DI), R8
+	MOVQ  120(DI), R9
+	MOVQ  56(DI), R10
+	MOVQ  64(DI), DI
+	ADDQ  DI, R10
 
 	// seqsBase += 24 * seqIndex
-	LEAQ (DX)(DX*2), R9
-	SHLQ $0x03, R9
-	ADDQ R9, AX
+	LEAQ (DX)(DX*2), R11
+	SHLQ $0x03, R11
+	ADDQ R11, AX
 
 	// outBase += outPosition
 	ADDQ R8, BX
 
 main_loop:
-	MOVQ 8(AX), R9
-	MOVQ (AX), R10
+	MOVQ (AX), R13
+	MOVQ 8(AX), R11
+	MOVQ 16(AX), R12
 
 	// Copy literals
-	TESTQ R10, R10
-	JZ    copy_match
-	XORQ  R11, R11
+	TESTQ R13, R13
+	JZ    copy_history
+	XORQ  R14, R14
 
 copy_1:
-	MOVUPS (SI)(R11*1), X0
-	MOVUPS X0, (BX)(R11*1)
-	ADDQ   $0x10, R11
-	CMPQ   R11, R10
+	MOVUPS (SI)(R14*1), X0
+	MOVUPS X0, (BX)(R14*1)
+	ADDQ   $0x10, R14
+	CMPQ   R14, R13
 	JB     copy_1
-	ADDQ   R10, SI
-	ADDQ   R10, BX
-	ADDQ   R10, R8
+	ADDQ   R13, SI
+	ADDQ   R13, BX
+	ADDQ   R13, R8
 
-	// Copy match
+	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
+	LEAQ (R8)(DI*1), R13
+	CMPQ R12, R13
+	JG   error_match_off_too_big
+	CMPQ R12, R9
+	JG   error_match_off_too_big
+
+	// Copy match from history
+copy_history:
+	MOVQ R12, R13
+	SUBQ R8, R13
+	CMPQ R13, $0x00
+	JLE  copy_match
+	MOVQ R10, R14
+	SUBQ R13, R14
+	CMPQ R11, R13
+	JGE  copy_all_from_history
+	XORQ R12, R12
+
+copy_4:
+	MOVUPS (R14)(R12*1), X0
+	MOVUPS X0, (BX)(R12*1)
+	ADDQ   $0x10, R12
+	CMPQ   R12, R11
+	JB     copy_4
+	ADDQ   R11, R8
+	ADDQ   R11, BX
+	JMP    handle_loop
+
+copy_all_from_history:
+	XORQ R15, R15
+
+copy_5:
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (BX)(R15*1)
+	ADDQ   $0x10, R15
+	CMPQ   R15, R13
+	JB     copy_5
+	ADDQ   R13, BX
+	ADDQ   R13, R8
+	SUBQ   R13, R11
+
+	// Copy match from the current buffer
 copy_match:
-	TESTQ R9, R9
+	TESTQ R11, R11
 	JZ    handle_loop
-	MOVQ  16(AX), R10
-
-	// Malformed input if seq.mo > t || seq.mo > s.windowSize)
-	CMPQ R10, R8
-	JG   error_match_off_to_big
-	CMPQ R10, DI
-	JG   error_match_off_to_big
-	MOVQ BX, R11
-	SUBQ R10, R11
+	MOVQ  BX, R13
+	SUBQ  R12, R13
 
 	// ml <= mo
-	CMPQ R9, R10
+	CMPQ R11, R12
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R10, R10
+	XORQ R12, R12
 
 copy_2:
-	MOVUPS (R11)(R10*1), X0
-	MOVUPS X0, (BX)(R10*1)
-	ADDQ   $0x10, R10
-	CMPQ   R10, R9
+	MOVUPS (R13)(R12*1), X0
+	MOVUPS X0, (BX)(R12*1)
+	ADDQ   $0x10, R12
+	CMPQ   R12, R11
 	JB     copy_2
-	ADDQ   R9, BX
-	ADDQ   R9, R8
+	ADDQ   R11, BX
+	ADDQ   R11, R8
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ R10, R10
+	XORQ R12, R12
 
 copy_slow_3:
-	MOVB (R11)(R10*1), R12
-	MOVB R12, (BX)(R10*1)
-	INCQ R10
-	CMPQ R10, R9
+	MOVB (R13)(R12*1), R14
+	MOVB R14, (BX)(R12*1)
+	INCQ R12
+	CMPQ R12, R11
 	JB   copy_slow_3
-	ADDQ R9, BX
-	ADDQ R9, R8
+	ADDQ R11, BX
+	ADDQ R11, R8
 
 handle_loop:
 	ADDQ $0x18, AX
@@ -677,23 +716,23 @@ handle_loop:
 	// Update the context
 	MOVQ ctx+0(FP), AX
 	MOVQ DX, 24(AX)
-	MOVQ R8, 80(AX)
-	MOVQ 56(AX), CX
+	MOVQ R8, 104(AX)
+	MOVQ 80(AX), CX
 	SUBQ CX, SI
-	MOVQ SI, 88(AX)
+	MOVQ SI, 112(AX)
 	RET
 
-error_match_off_to_big:
+error_match_off_too_big:
 	// Return value
 	MOVB $0x00, ret+8(FP)
 
 	// Update the context
 	MOVQ ctx+0(FP), AX
 	MOVQ DX, 24(AX)
-	MOVQ R8, 80(AX)
-	MOVQ 56(AX), CX
+	MOVQ R8, 104(AX)
+	MOVQ 80(AX), CX
 	SUBQ CX, SI
-	MOVQ SI, 88(AX)
+	MOVQ SI, 112(AX)
 	RET
 
 empty_seqs:

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -652,7 +652,11 @@ copy_4:
 	JB     copy_4
 	ADDQ   R11, R8
 	ADDQ   R11, BX
-	JMP    handle_loop
+	ADDQ   $0x18, AX
+	INCQ   DX
+	CMPQ   DX, CX
+	JB     main_loop
+	JMP    loop_finished
 
 copy_all_from_history:
 	XORQ R15, R15
@@ -710,6 +714,7 @@ handle_loop:
 	CMPQ DX, CX
 	JB   main_loop
 
+loop_finished:
 	// Return value
 	MOVB $0x01, ret+8(FP)
 


### PR DESCRIPTION
Add history support in the asm implementation. Part of task #515.

~As usual marking as a draft, because of few failing tests.~ [fixed]

Performance comparison between the current master and this branch on an IceLake machine with the hacked `decodeSync` is below. There are some nice speedups, but there are also regressions for almost all cases without history. To overcome that, we can have two specialisations: `executeWithoutDictionary` and `executeWithoutDictionatyAndHistory` - what do you think?

```
benchmark                                                                 old ns/op     new ns/op     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-16                            3819656       3185382       -16.61%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-16                        687254        683309        -0.57%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-16                         15227858      10251054      -32.68%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-16                           10867594      7523672       -30.77%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-16                         2261701       2320133       +2.58%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-16                          3265967       3064706       -6.16%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-16                             1177235       1232534       +4.70%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-16                       206482        207584        +0.53%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-16                       127624        126746        -0.69%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-16                             12893835      9988261       -22.53%
BenchmarkDecoder_DecoderSmall/html.zst-16                                 703112        755146        +7.40%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-16                        69432         70033         +0.87%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-16                               403208        405417        +0.55%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-16                           83419         83828         +0.49%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-16                            1156823       1164450       +0.66%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-16                              860108        872507        +1.44%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-16                            297202        303211        +2.02%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-16                             373296        380265        +1.87%
BenchmarkDecoder_DecodeAll/html_x_4.zst-16                                224877        228995        +1.83%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-16                          21549         21690         +0.65%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-16                          11303         11298         -0.04%
BenchmarkDecoder_DecodeAll/urls.10K.zst-16                                1097797       1105211       +0.68%
BenchmarkDecoder_DecodeAll/html.zst-16                                    90909         93460         +2.81%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-16                           8817          8797          -0.23%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-16      926242        940397        +1.53%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-16      895830        905638        +1.09%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-16       875836        863300        -1.43%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-16         927245        950947        +2.56%
BenchmarkDecoder_DecodeAllFiles/e.txt/fastest-16                          9188          9192          +0.04%
BenchmarkDecoder_DecodeAllFiles/e.txt/default-16                          223014        218049        -2.23%
BenchmarkDecoder_DecodeAllFiles/e.txt/better-16                           185555        185699        +0.08%
BenchmarkDecoder_DecodeAllFiles/e.txt/best-16                             150550        153267        +1.80%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/fastest-16              3701          3366          -9.05%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/default-16              3487          2965          -14.97%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/better-16               4076          3944          -3.24%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/best-16                 11714         10794         -7.85%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/fastest-16                 4748          4653          -2.00%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/default-16                 7346          7346          +0.00%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/better-16                  7374          7364          -0.14%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/best-16                    7802          7340          -5.92%
BenchmarkDecoder_DecodeAllFiles/html.txt/fastest-16                       59084         59315         +0.39%
BenchmarkDecoder_DecodeAllFiles/html.txt/default-16                       59571         60995         +2.39%
BenchmarkDecoder_DecodeAllFiles/html.txt/better-16                        56208         57822         +2.87%
BenchmarkDecoder_DecodeAllFiles/html.txt/best-16                          63838         62055         -2.79%
BenchmarkDecoder_DecodeAllFiles/pi.txt/fastest-16                         9188          9244          +0.61%
BenchmarkDecoder_DecodeAllFiles/pi.txt/default-16                         222181        219850        -1.05%
BenchmarkDecoder_DecodeAllFiles/pi.txt/better-16                          183699        183255        -0.24%
BenchmarkDecoder_DecodeAllFiles/pi.txt/best-16                            150052        152918        +1.91%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/fastest-16                    27367         28237         +3.18%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/default-16                    32047         31990         -0.18%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/better-16                     25215         25213         -0.01%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/best-16                       33244         32875         -1.11%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/fastest-16                     9194          9213          +0.21%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/default-16                     9184          9177          -0.08%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/better-16                      9174          9177          +0.03%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/best-16                        9226          9211          -0.16%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/fastest-16     124135        126397        +1.82%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/default-16     127338        129774        +1.91%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/better-16      116233        117785        +1.34%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/best-16        124661        124190        -0.38%
BenchmarkDecoder_DecodeAllFilesP/e.txt/fastest-16                         1045          1032          -1.24%
BenchmarkDecoder_DecodeAllFilesP/e.txt/default-16                         35303         35490         +0.53%
BenchmarkDecoder_DecodeAllFilesP/e.txt/better-16                          28175         28136         -0.14%
BenchmarkDecoder_DecodeAllFilesP/e.txt/best-16                            18557         19057         +2.69%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/fastest-16             688           619           -10.05%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/default-16             712           753           +5.76%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/better-16              621           626           +0.81%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/best-16                984           991           +0.68%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/fastest-16                940           930           -1.09%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/default-16                1398          1377          -1.50%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/better-16                 1365          1343          -1.61%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/best-16                   1608          1601          -0.44%
BenchmarkDecoder_DecodeAllFilesP/html.txt/fastest-16                      12915         13114         +1.54%
BenchmarkDecoder_DecodeAllFilesP/html.txt/default-16                      13258         13571         +2.36%
BenchmarkDecoder_DecodeAllFilesP/html.txt/better-16                       12649         12879         +1.82%
BenchmarkDecoder_DecodeAllFilesP/html.txt/best-16                         13239         13779         +4.08%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/fastest-16                        1044          1068          +2.30%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/default-16                        35834         35656         -0.50%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/better-16                         27434         27765         +1.21%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/best-16                           18431         18744         +1.70%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/fastest-16                   4915          4912          -0.06%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/default-16                   5031          4972          -1.17%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/better-16                    4317          4340          +0.53%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/best-16                      3984          4006          +0.55%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/fastest-16                    1035          1033          -0.19%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/default-16                    1035          1068          +3.19%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/better-16                     1036          1032          -0.39%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/best-16                       1046          1058          +1.15%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-16                       67482         68458         +1.45%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-16                   19201         19512         +1.62%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-16                    197985        200836        +1.44%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-16                      152815        153857        +0.68%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-16                    47876         48784         +1.90%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-16                     67123         68004         +1.31%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-16                        58916         59247         +0.56%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-16                  7954          8082          +1.61%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-16                  1269          1290          +1.65%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-16                        178699        176447        -1.26%
BenchmarkDecoder_DecodeAllParallel/html.zst-16                            19159         19408         +1.30%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-16                   1988          1998          +0.50%

benchmark                                                                 old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-16                            386.05       462.91       1.20x
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-16                        1380.43      1388.40      1.01x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-16                         253.15       376.05       1.49x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-16                           314.15       453.77       1.44x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-16                         442.78       431.63       0.97x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-16                          372.54       397.01       1.07x
BenchmarkDecoder_DecoderSmall/html_x_4.zst-16                             2783.47      2658.59      0.96x
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-16                       3967.42      3946.36      0.99x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-16                       7715.99      7769.40      1.01x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-16                             435.61       562.33       1.29x
BenchmarkDecoder_DecoderSmall/html.zst-16                                 1165.11      1084.82      0.93x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-16                        469.64       465.61       0.99x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-16                               457.13       454.64       0.99x
BenchmarkDecoder_DecodeAll/geo.protodata.zst-16                           1421.59      1414.67      1.00x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-16                            416.54       413.81       0.99x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-16                              496.16       489.11       0.99x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-16                            421.19       412.85       0.98x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-16                             407.42       399.96       0.98x
BenchmarkDecoder_DecodeAll/html_x_4.zst-16                                1821.44      1788.69      0.98x
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-16                          4751.98      4721.03      0.99x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-16                          10890.36     10895.22     1.00x
BenchmarkDecoder_DecodeAll/urls.10K.zst-16                                639.54       635.25       0.99x
BenchmarkDecoder_DecodeAll/html.zst-16                                    1126.40      1095.66      0.97x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-16                           462.27       463.36       1.00x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-16      418.86       412.55       0.98x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-16      433.08       428.39       0.99x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-16       442.96       449.40       1.01x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-16         418.40       407.98       0.98x
BenchmarkDecoder_DecodeAllFiles/e.txt/fastest-16                          10883.57     10879.92     1.00x
BenchmarkDecoder_DecodeAllFiles/e.txt/default-16                          448.42       458.63       1.02x
BenchmarkDecoder_DecodeAllFiles/e.txt/better-16                           538.94       538.52       1.00x
BenchmarkDecoder_DecodeAllFiles/e.txt/best-16                             664.25       652.48       0.98x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/fastest-16              1111.98      1222.64      1.10x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/default-16              1180.47      1388.41      1.18x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/better-16               1009.87      1043.58      1.03x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/best-16                 351.37       381.32       1.09x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/fastest-16                 326.01       332.71       1.02x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/default-16                 210.73       210.73       1.00x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/better-16                  209.93       210.21       1.00x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/best-16                    198.41       210.90       1.06x
BenchmarkDecoder_DecodeAllFiles/html.txt/fastest-16                       752.78       749.85       1.00x
BenchmarkDecoder_DecodeAllFiles/html.txt/default-16                       746.62       729.19       0.98x
BenchmarkDecoder_DecodeAllFiles/html.txt/better-16                        791.29       769.20       0.97x
BenchmarkDecoder_DecodeAllFiles/html.txt/best-16                          696.71       716.74       1.03x
BenchmarkDecoder_DecodeAllFiles/pi.txt/fastest-16                         10883.72     10818.13     0.99x
BenchmarkDecoder_DecodeAllFiles/pi.txt/default-16                         450.10       454.87       1.01x
BenchmarkDecoder_DecodeAllFiles/pi.txt/better-16                          544.39       545.70       1.00x
BenchmarkDecoder_DecodeAllFiles/pi.txt/best-16                            666.46       653.97       0.98x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/fastest-16                    1870.83      1813.22      0.97x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/default-16                    1597.68      1600.52      1.00x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/better-16                     2030.51      2030.70      1.00x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/best-16                       1540.11      1557.41      1.01x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/fastest-16                     10876.68     10854.61     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/default-16                     10888.55     10897.00     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/better-16                      10900.78     10897.23     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/best-16                        10838.94     10857.06     1.00x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/fastest-16     3125.33      3069.41      0.98x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/default-16     3046.72      2989.53      0.98x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/better-16      3337.82      3293.84      0.99x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/best-16        3112.14      3123.96      1.00x
BenchmarkDecoder_DecodeAllFilesP/e.txt/fastest-16                         95716.88     96892.28     1.01x
BenchmarkDecoder_DecodeAllFilesP/e.txt/default-16                         2832.71      2817.79      0.99x
BenchmarkDecoder_DecodeAllFilesP/e.txt/better-16                          3549.41      3554.26      1.00x
BenchmarkDecoder_DecodeAllFilesP/e.txt/best-16                            5388.87      5247.50      0.97x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/fastest-16             5984.25      6652.65      1.11x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/default-16             5783.78      5469.36      0.95x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/better-16              6627.33      6574.29      0.99x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/best-16                4183.29      4154.88      0.99x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/fastest-16                1646.95      1664.97      1.01x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/default-16                1107.64      1123.95      1.01x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/better-16                 1134.36      1152.28      1.02x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/best-16                   962.67       967.12       1.00x
BenchmarkDecoder_DecodeAllFilesP/html.txt/fastest-16                      3443.93      3391.58      0.98x
BenchmarkDecoder_DecodeAllFilesP/html.txt/default-16                      3354.65      3277.40      0.98x
BenchmarkDecoder_DecodeAllFilesP/html.txt/better-16                       3516.30      3453.57      0.98x
BenchmarkDecoder_DecodeAllFilesP/html.txt/best-16                         3359.52      3227.77      0.96x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/fastest-16                        95765.44     93621.55     0.98x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/default-16                        2790.76      2804.67      1.00x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/better-16                         3645.23      3601.82      0.99x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/best-16                           5425.74      5335.08      0.98x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/fastest-16                   10417.13     10422.70     1.00x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/default-16                   10176.13     10296.83     1.01x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/better-16                    11860.57     11796.01     0.99x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/best-16                      12851.09     12779.36     0.99x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/fastest-16                    96638.52     96769.88     1.00x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/default-16                    96660.04     93623.18     0.97x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/better-16                     96528.12     96886.29     1.00x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/best-16                       95635.43     94530.39     0.99x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-16                       2731.40      2692.47      0.99x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-16                   6176.03      6077.82      0.98x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-16                    2433.82      2399.27      0.99x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-16                      2792.61      2773.71      0.99x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-16                    2614.65      2565.97      0.98x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-16                     2265.83      2236.47      0.99x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-16                        6952.21      6913.46      0.99x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-16                  12874.36     12669.91     0.98x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-16                  96991.66     95392.25     0.98x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-16                        3928.89      3979.03      1.01x
BenchmarkDecoder_DecodeAllParallel/html.zst-16                            5344.75      5276.27      0.99x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-16                   2050.37      2039.73      0.99x
```