### PR TITLE
zstd: asm version of decodeSync

### DIFF
--- a/zstd/_generate/gen.go
+++ b/zstd/_generate/gen.go
@@ -1195,7 +1195,7 @@ func (e executeSimple) executeSingleTriple(c *executeSingleTripleContext, handle
 
 		Comment("Copy non-overlapping match")
 		{
-			e.copyMemory("2", src, c.outBase, ml)
+			e.copyMemoryPrecise("2", src, c.outBase, ml)
 			ADDQ(ml, c.outBase)
 			ADDQ(ml, c.outPosition)
 			JMP(LabelRef("handle_loop"))

--- a/zstd/_generate/gen.go
+++ b/zstd/_generate/gen.go
@@ -448,9 +448,9 @@ func (o options) generateBody(name string, executeSingleTriple func(ctx *execute
 	{
 		Label(name + "_error_match_len_too_big")
 		if !o.useSeqs {
+			ctx := Dereference(Param("ctx"))
 			tmp := GP64()
 			MOVQ(mlP, tmp)
-			ctx := Dereference(Param("ctx"))
 			Store(tmp, ctx.Field("ml"))
 		}
 		o.returnWithCode(errorMatchLenTooBig)

--- a/zstd/_generate/gen.go
+++ b/zstd/_generate/gen.go
@@ -27,6 +27,9 @@ const errorMatchLenOfsMismatch = 1
 // error reported when ml > maxMatchLen
 const errorMatchLenTooBig = 2
 
+// error reported when mo > t or mo > s.windowSize
+const errorMatchOffTooBig = 3
+
 const maxMatchLen = 131074
 
 // size of struct seqVals
@@ -47,9 +50,11 @@ func main() {
 	Constraint(buildtags.Term("gc").ToConstraint())
 	Constraint(buildtags.Not("noasm").ToConstraint())
 
+    /*
 	o := options{
 		bmi2:     false,
 		fiftysix: false,
+        useSeqs: true,
 	}
 	o.genDecodeSeqAsm("sequenceDecs_decode_amd64")
 	o.fiftysix = true
@@ -60,8 +65,19 @@ func main() {
 	o.fiftysix = true
 	o.genDecodeSeqAsm("sequenceDecs_decode_56_bmi2")
 
-	exec := executeSimple{}
+	exec := executeSimple{
+        useSeqs: true
+    }
 	exec.generateProcedure("sequenceDecs_executeSimple_amd64")
+    */
+
+	decodeSync := decodeSync{}
+	decodeSync.setBMI2(false)
+	decodeSync.generateProcedure("sequenceDecs_decodeSync_amd64")
+    /*
+	decodeSync.setBMI2(true)
+	decodeSync.generateProcedure("sequenceDecs_decodeSync_bmi2")
+    */
 
 	Generate()
 	b, err := ioutil.ReadFile(out.Value.String())
@@ -111,6 +127,7 @@ func assert(fn func(ok LabelRef)) {
 type options struct {
 	bmi2     bool
 	fiftysix bool // Less than max 56 bits/loop
+	useSeqs bool // When true generate code for `decode`, otherwise for `decodeSync`
 }
 
 func (o options) genDecodeSeqAsm(name string) {
@@ -119,6 +136,13 @@ func (o options) genDecodeSeqAsm(name string) {
 	Doc(name+" decodes a sequence", "")
 	Pragma("noescape")
 
+	nop := func(literals, outBase, outPosition, windowSize, histBase, histLen reg.GPVirtual, llPtr, moPtr, mlPtr, histBasePtr, histLenPtr Mem, handleLoop func()) {}
+
+	o.generateBody(name, nop)
+}
+
+func (o options) generateBody(name string, executeSingleTriple func(literals, outBase, outPosition, windowSize, histBase, histLen reg.GPVirtual, llPtr, moPtr, mlPtr, histBasePtr, histLenPtr Mem, handleLoop func())) {
+	// for decode
 	brValue := GP64()
 	brBitsRead := GP64()
 	brOffset := GP64()
@@ -126,6 +150,17 @@ func (o options) genDecodeSeqAsm(name string) {
 	mlState := GP64()
 	ofState := GP64()
 	seqBase := GP64()
+
+	// for execute
+	outBase := GP64()
+	outLen := GP64()
+	literals := GP64()
+	outPosition := GP64()
+    histLen := GP64()
+    histBase := GP64()
+	windowSize := GP64()
+    var histBasePtr Mem
+    var histLenPtr Mem
 
 	// 1. load bitReader (done once)
 	brPointerStash := AllocLocal(8)
@@ -146,12 +181,45 @@ func (o options) genDecodeSeqAsm(name string) {
 		Load(ctx.Field("llState"), llState)
 		Load(ctx.Field("mlState"), mlState)
 		Load(ctx.Field("ofState"), ofState)
-		Load(ctx.Field("seqs").Base(), seqBase)
+		if o.useSeqs {
+			Load(ctx.Field("seqs").Base(), seqBase)
+		} else {
+			Load(ctx.Field("out").Base(), outBase)
+			Load(ctx.Field("out").Len(), outLen)
+			Load(ctx.Field("literals").Base(), literals)
+			Load(ctx.Field("outPosition"), outPosition)
+			Load(ctx.Field("windowSize"), windowSize)
+            base := GP64()
+            length := GP64()
+            Load(ctx.Field("history").Base(), base)
+            Load(ctx.Field("history").Len(), length)
+
+            ADDQ(length, base) // Note: we always copy from &hist[len(hist) - v]
+
+            histBasePtr = AllocLocal(8)
+            histLenPtr = AllocLocal(8)
+
+            MOVQ(base, histBasePtr)
+            MOVQ(length, histLenPtr)
+
+			Comment("outBase += outPosition")
+			ADDQ(outPosition, outBase)
+		}
 	}
 
-	moP := Mem{Base: seqBase, Disp: 2 * 8} // Pointer to current mo
-	mlP := Mem{Base: seqBase, Disp: 1 * 8} // Pointer to current ml
-	llP := Mem{Base: seqBase, Disp: 0 * 8} // Pointer to current ll
+	var moP Mem
+	var mlP Mem
+	var llP Mem
+
+	if o.useSeqs {
+		moP = Mem{Base: seqBase, Disp: 2 * 8} // Pointer to current mo
+		mlP = Mem{Base: seqBase, Disp: 1 * 8} // Pointer to current ml
+		llP = Mem{Base: seqBase, Disp: 0 * 8} // Pointer to current ll
+	} else {
+		moP = AllocLocal(8)
+		mlP = AllocLocal(8)
+		llP = AllocLocal(8)
+	}
 
 	// Store previous offsets in registers.
 	var offsets [3]reg.GPVirtual
@@ -276,6 +344,14 @@ func (o options) genDecodeSeqAsm(name string) {
 	}
 
 	Label(name + "_match_len_ofs_ok")
+
+    handleLoop := func() {
+        JMP(LabelRef("handle_loop"))
+    }
+
+	executeSingleTriple(literals, outBase, outPosition, windowSize, histBase, histLen, llP, moP, mlP, histBasePtr, histLenPtr, handleLoop)
+
+	Label("handle_loop")
 	ADDQ(U8(seqValsSize), seqBase)
 	ctx = Dereference(Param("ctx"))
 	iterationP, err := ctx.Field("iteration").Resolve()
@@ -306,9 +382,13 @@ func (o options) genDecodeSeqAsm(name string) {
 	Label(name + "_error_match_len_ofs_mismatch")
 	o.returnWithCode(errorMatchLenOfsMismatch)
 
-	Comment("Return with match too long error")
+	Comment("Return with match length too long error")
 	Label(name + "_error_match_len_too_big")
 	o.returnWithCode(errorMatchLenTooBig)
+
+	Comment("Return with match offset too long error")
+	Label("error_match_off_too_big")
+	o.returnWithCode(errorMatchOffTooBig)
 }
 
 func (o options) returnWithCode(returnCode uint32) {
@@ -594,7 +674,9 @@ func (o options) adjustOffset(name string, moP, llP Mem, offsetB reg.GPVirtual, 
 	return offset
 }
 
-type executeSimple struct{}
+type executeSimple struct{
+    useSeqs bool
+}
 
 // copySize returns register size used to fast copy.
 //
@@ -609,6 +691,10 @@ func (e executeSimple) generateProcedure(name string) {
 	Doc(name+" implements the main loop of sequenceDecs.decode in x86 asm", "")
 	Pragma("noescape")
 
+	e.generateBody(name)
+}
+
+func (e executeSimple) generateBody(name string) {
 	seqsBase := GP64()
 	seqsLen := GP64()
 	seqIndex := GP64()
@@ -649,17 +735,12 @@ func (e executeSimple) generateProcedure(name string) {
 
 	Label("main_loop")
 
-	ml := GP64()
-	mo := GP64()
-	ll := GP64()
-
 	moPtr := Mem{Base: seqsBase, Disp: 2 * 8}
 	mlPtr := Mem{Base: seqsBase, Disp: 1 * 8}
 	llPtr := Mem{Base: seqsBase, Disp: 0 * 8}
 
-	MOVQ(llPtr, ll)
-	MOVQ(mlPtr, ml)
-	MOVQ(moPtr, mo)
+    var unusedHistBasePtr Mem
+    var unusedHistLenPtr Mem
 
 	// generates the loop tail
 	handleLoop := func() {
@@ -669,9 +750,52 @@ func (e executeSimple) generateProcedure(name string) {
 		JB(LabelRef("main_loop"))
 	}
 
+	e.executeSingleTriple(literals, outBase, outPosition, windowSize, histBase, histLen, llPtr, moPtr, mlPtr, unusedHistBasePtr, unusedHistLenPtr, handleLoop)
+
+	Label("handle_loop")
+    handleLoop()
+
+	ret, err := ReturnIndex(0).Resolve()
+	if err != nil {
+		panic(err)
+	}
+
+	returnValue := func(val int) {
+
+		Comment("Return value")
+		MOVB(U8(val), ret.Addr)
+
+		Comment("Update the context")
+		ctx := Dereference(Param("ctx"))
+		Store(seqIndex, ctx.Field("seqIndex"))
+		Store(outPosition, ctx.Field("outPosition"))
+
+		// compute litPosition
+		tmp := GP64()
+		Load(ctx.Field("literals").Base(), tmp)
+		SUBQ(tmp, literals) // litPosition := current - initial literals pointer
+		Store(literals, ctx.Field("litPosition"))
+	}
+	returnValue(1)
+	RET()
+
+	Label("error_match_off_too_big")
+	returnValue(0)
+	RET()
+
+	Label("empty_seqs")
+	Comment("Return value")
+	MOVB(U8(1), ret.Addr)
+	RET()
+}
+
+func (e executeSimple) executeSingleTriple(literals, outBase, outPosition, windowSize, histBase, histLen reg.GPVirtual, llPtr, moPtr, mlPtr, histBasePtr, histLenPtr Mem, handleLoop func()) {
+
 	Comment("Copy literals")
 	Label("copy_literals")
 	{
+		ll := GP64()
+		MOVQ(llPtr, ll)
 		TESTQ(ll, ll)
 		JZ(LabelRef("check_offset"))
 		// TODO: Investigate if it is possible to consistently overallocate literals.
@@ -682,19 +806,32 @@ func (e executeSimple) generateProcedure(name string) {
 		ADDQ(ll, outPosition)
 	}
 
+    mo := GP64()
+
 	Comment("Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)")
 	{
 		Label("check_offset")
-		tmp := GP64()
-		LEAQ(Mem{Base: outPosition, Index: histLen, Scale: 1}, tmp)
-		CMPQ(mo, tmp)
-		JG(LabelRef("error_match_off_too_big"))
-		CMPQ(mo, windowSize)
-		JG(LabelRef("error_match_off_too_big"))
+        MOVQ(moPtr, mo)
+        tmp := GP64()
+        if e.useSeqs {
+            LEAQ(Mem{Base: outPosition, Index: histLen, Scale: 1}, tmp)
+        } else {
+            fmt.Printf("%v\n", histLenPtr)
+            MOVQ(histLenPtr, tmp)
+            ADDQ(outPosition, tmp)
+        }
+
+        CMPQ(mo, tmp)
+        JG(LabelRef("error_match_off_too_big"))
+        CMPQ(mo, windowSize)
+        JG(LabelRef("error_match_off_too_big"))
 	}
+
+	ml := GP64()
 
 	Comment("Copy match from history")
 	{
+		MOVQ(mlPtr, ml)
 		v := GP64()
 		MOVQ(mo, v)
 		SUBQ(outPosition, v)        // v := seq.mo - outPosition
@@ -726,7 +863,7 @@ func (e executeSimple) generateProcedure(name string) {
 		// Note: for the current go tests this branch is taken in 99.53% cases,
 		//       this is why we repeat a little code here.
 		handleLoop()
-		JMP(LabelRef("loop_finished"))
+		//JMP(LabelRef("loop_finished")) XXX -- sort it out...
 
 		Label("copy_all_from_history")
 		/*  if seq.ml > v {
@@ -744,11 +881,24 @@ func (e executeSimple) generateProcedure(name string) {
 		// fallback to the next block
 	}
 
+
 	Comment("Copy match from the current buffer")
 	Label("copy_match")
 	{
 		TESTQ(ml, ml)
 		JZ(LabelRef("handle_loop"))
+
+		mo := GP64()
+		MOVQ(moPtr, mo)
+
+		Comment("Malformed input if seq.mo > t || seq.mo > s.windowSize")
+		CMPQ(mo, outPosition)
+		JG(LabelRef("error_match_off_too_big"))
+		if false {
+			// XXX -- when enabled: allocation failure
+			CMPQ(mo, windowSize)
+			JG(LabelRef("error_match_off_too_big"))
+		}
 
 		src := GP64()
 		MOVQ(outBase, src)
@@ -784,43 +934,6 @@ func (e executeSimple) generateProcedure(name string) {
 			ADDQ(ml, outPosition)
 		}
 	}
-
-	Label("handle_loop")
-	handleLoop()
-
-	ret, err := ReturnIndex(0).Resolve()
-	if err != nil {
-		panic(err)
-	}
-
-	returnValue := func(val int) {
-
-		Comment("Return value")
-		MOVB(U8(val), ret.Addr)
-
-		Comment("Update the context")
-		ctx := Dereference(Param("ctx"))
-		Store(seqIndex, ctx.Field("seqIndex"))
-		Store(outPosition, ctx.Field("outPosition"))
-
-		// compute litPosition
-		tmp := GP64()
-		Load(ctx.Field("literals").Base(), tmp)
-		SUBQ(tmp, literals) // litPosition := current - initial literals pointer
-		Store(literals, ctx.Field("litPosition"))
-	}
-	Label("loop_finished")
-	returnValue(1)
-	RET()
-
-	Label("error_match_off_too_big")
-	returnValue(0)
-	RET()
-
-	Label("empty_seqs")
-	Comment("Return value")
-	MOVB(U8(1), ret.Addr)
-	RET()
 }
 
 // copyMemory will copy memory in blocks of 16 bytes,
@@ -915,4 +1028,24 @@ func (e executeSimple) copyOverlappedMemory(suffix string, src, dst, length reg.
 	INCQ(ofs)
 	CMPQ(ofs, length)
 	JB(LabelRef(label))
+}
+
+type decodeSync struct {
+	decode  options
+	execute executeSimple
+}
+
+func (d *decodeSync) setBMI2(flag bool) {
+	d.decode.bmi2 = flag
+}
+
+func (d *decodeSync) generateProcedure(name string) {
+	Package("github.com/klauspost/compress/zstd")
+	TEXT(name, 0, "func (s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int")
+	Doc(name+" implements the main loop of sequenceDecs.decodeSync in x86 asm", "")
+	Pragma("noescape")
+
+	d.decode.generateBody(name, d.execute.executeSingleTriple)
+
+	RET()
 }

--- a/zstd/_generate/gen.go
+++ b/zstd/_generate/gen.go
@@ -195,7 +195,7 @@ func (o options) generateBody(name string, executeSingleTriple func(ctx *execute
 			ec.outCapPtr = AllocLocal(8)
 
 			ec.outBase = GP64()
-			ec.literalsPtr = AllocLocal(8)
+			ec.literals = GP64()
 			ec.outPosition = GP64()
 			ec.histLenPtr = AllocLocal(8)
 			ec.histBasePtr = AllocLocal(8)
@@ -226,7 +226,7 @@ func (o options) generateBody(name string, executeSingleTriple func(ctx *execute
 			}
 
 			Load(ctx.Field("out").Base(), ec.outBase)
-			loadFieldBase("literals", ec.literalsPtr)
+			Load(ctx.Field("literals").Base(), ec.literals)
 			Load(ctx.Field("outPosition"), ec.outPosition)
 			loadField("windowSize", ec.windowSizePtr)
 			loadFieldBase("history", ec.histBasePtr)
@@ -1021,7 +1021,6 @@ type executeSingleTripleContext struct {
 
 	// values used when useSeqs is false
 	outCapPtr     Mem
-	literalsPtr   Mem
 	histBasePtr   Mem
 	histLenPtr    Mem
 	windowSizePtr Mem
@@ -1049,20 +1048,10 @@ func (e executeSimple) executeSingleTriple(c *executeSingleTripleContext, handle
 		TESTQ(ll, ll)
 		JZ(LabelRef("check_offset"))
 		// TODO: Investigate if it is possible to consistently overallocate literals.
-		if e.useSeqs {
-			e.copyMemoryPrecise("1", c.literals, c.outBase, ll)
-			ADDQ(ll, c.literals)
-			ADDQ(ll, c.outBase)
-			ADDQ(ll, c.outPosition)
-		} else {
-			literals := GP64()
-			MOVQ(c.literalsPtr, literals)
-			e.copyMemoryPrecise("1", literals, c.outBase, ll)
-
-			ADDQ(ll, c.literalsPtr)
-			ADDQ(ll, c.outBase)
-			ADDQ(ll, c.outPosition)
-		}
+		e.copyMemoryPrecise("1", c.literals, c.outBase, ll)
+		ADDQ(ll, c.literals)
+		ADDQ(ll, c.outBase)
+		ADDQ(ll, c.outPosition)
 	}
 
 	mo := GP64()

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -1060,7 +1060,12 @@ func testDecoderFile(t *testing.T, fn string, newDec func() (*Decoder, error)) {
 			}
 
 			wantB := want[tt.Name]
-			if !bytes.Equal(wantB, got) {
+
+			compareWith := func(got []byte, displayName, name string) bool {
+				if bytes.Equal(wantB, got) {
+					return false
+				}
+
 				if len(wantB)+len(got) < 1000 {
 					t.Logf(" got: %v\nwant: %v", got, wantB)
 				} else {
@@ -1069,32 +1074,24 @@ func testDecoderFile(t *testing.T, fn string, newDec func() (*Decoder, error)) {
 					err := ioutil.WriteFile(fileName, wantB, os.ModePerm)
 					t.Log("Wrote file", fileName, err)
 
-					fileName, _ = filepath.Abs(filepath.Join("testdata", t.Name()+"-got.bin"))
+					fileName, _ = filepath.Abs(filepath.Join("testdata", t.Name()+"-"+name+".bin"))
 					_ = os.MkdirAll(filepath.Dir(fileName), os.ModePerm)
 					err = ioutil.WriteFile(fileName, got, os.ModePerm)
 					t.Log("Wrote file", fileName, err)
 				}
 				t.Logf("Length, want: %d, got: %d", len(wantB), len(got))
-				t.Error("Output mismatch")
+				t.Errorf("%s mismatch", displayName)
+				return true
+			}
+
+			if compareWith(got, "Output", "got") {
 				return
 			}
-			if !bytes.Equal(wantB, gotDecAll) {
-				if len(wantB)+len(got) < 1000 {
-					t.Logf(" got: %v\nwant: %v", got, wantB)
-				} else {
-					fileName, _ := filepath.Abs(filepath.Join("testdata", t.Name()+"-want.bin"))
-					_ = os.MkdirAll(filepath.Dir(fileName), os.ModePerm)
-					err := ioutil.WriteFile(fileName, wantB, os.ModePerm)
-					t.Log("Wrote file", fileName, err)
 
-					fileName, _ = filepath.Abs(filepath.Join("testdata", t.Name()+"-got.bin"))
-					_ = os.MkdirAll(filepath.Dir(fileName), os.ModePerm)
-					err = ioutil.WriteFile(fileName, got, os.ModePerm)
-					t.Log("Wrote file", fileName, err)
-				}
-				t.Logf("Length, want: %d, got: %d", len(wantB), len(got))
-				t.Error("DecodeAll Output mismatch")
+			if compareWith(gotDecAll, "DecodeAll Output", "decoded") {
+				return
 			}
+
 			t.Log(len(got), "bytes returned, matches input, ok!")
 		})
 	}

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -806,6 +806,7 @@ func TestDecoder_Reset(t *testing.T) {
 		t.Error(err, len(decoded))
 	}
 	if !bytes.Equal(decoded, in) {
+		t.Logf("size = %d, got = %d", len(decoded), len(in))
 		t.Fatal("Decoded does not match")
 	}
 	t.Log("Encoded content matched")

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -202,6 +202,12 @@ func (s *sequenceDecs) execute(seqs []seqVals, hist []byte) error {
 
 // decode sequences from the stream with the provided history.
 func (s *sequenceDecs) decodeSync(hist []byte) error {
+	{
+		supported, err := s.decodeSyncSimple(hist)
+		if supported {
+			return err
+		}
+	}
 	br := s.br
 	seqs := s.nSeqs
 	startSize := len(s.out)

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -202,7 +202,7 @@ func (s *sequenceDecs) execute(seqs []seqVals, hist []byte) error {
 
 // decode sequences from the stream with the provided history.
 func (s *sequenceDecs) decodeSync(hist []byte) error {
-	{
+	if true {
 		supported, err := s.decodeSyncSimple(hist)
 		if supported {
 			return err

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -223,7 +223,7 @@ func (s *sequenceDecs) decode(seqs []seqVals) error {
 
 		case errorNotEnoughLiterals:
 			ll := ctx.seqs[i].ll
-			fmt.Errorf("unexpected literal count, want %d bytes, but only %d is available", ll, ctx.litRemain+ll)
+			return fmt.Errorf("unexpected literal count, want %d bytes, but only %d is available", ll, ctx.litRemain+ll)
 		}
 
 		return fmt.Errorf("sequenceDecs_decode_amd64 returned erronous code %d", errCode)

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -43,7 +43,8 @@ func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyn
 
 // decode sequences from the stream with the provided history but without a dictionary.
 func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
-	if len(s.dict) > 0 {
+	// XXX: history is not supported yet (waiting for another PR)
+	if len(s.dict) > 0 || len(hist) > 0 {
 		return false, nil
 	}
 

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -42,7 +42,7 @@ func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyn
 
 // decode sequences from the stream with the provided history but without a dictionary.
 func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
-	if len(s.dict) > 0 {
+	if len(s.dict) > 0 || cap(s.out)-len(s.out) < maxCompressedBlockSizeAlloc {
 		return false, nil
 	}
 

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -70,6 +70,7 @@ func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
 	}
 
 	s.seqSize = 0
+	startSize := len(s.out)
 
 	for {
 		var errCode int
@@ -107,18 +108,13 @@ func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
 			return true, fmt.Errorf("match len (%d) bigger than max allowed length", ctx.ml)
 
 		case errorMatchOffTooBig:
-			return true, fmt.Errorf("match offset (%d) bigger than max allowed length (%d)", ctx.mo, ctx.outPosition)
+			return true, fmt.Errorf("match offset (%d) bigger than current history (%d)", ctx.mo, ctx.outPosition+len(hist)-startSize)
 		case errorNotEnoughLiterals:
 			return true, fmt.Errorf("unexpected literal count, want %d bytes, but only %d is available", ctx.ll, ctx.litRemain+ctx.ll)
 		default:
 			return true, fmt.Errorf("sequenceDecs_decode_amd64 returned erronous code %d", errCode)
 		}
 
-	}
-
-	if ctx.litRemain < 0 {
-		return true, fmt.Errorf("literal count is too big: total available %d, total requested %d",
-			len(s.literals), len(s.literals)-ctx.litRemain)
 	}
 
 	s.seqSize += ctx.litRemain

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -42,8 +42,7 @@ func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyn
 
 // decode sequences from the stream with the provided history but without a dictionary.
 func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
-	// XXX: history is not supported yet (waiting for another PR)
-	if len(s.dict) > 0 || len(hist) > 0 {
+	if len(s.dict) > 0 {
 		return false, nil
 	}
 
@@ -72,7 +71,7 @@ func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
 
 	s.seqSize = 0
 
-	for true {
+	for {
 		var errCode int
 		if cpuinfo.HasBMI2() {
 			errCode = sequenceDecs_decodeSync_bmi2(s, br, &ctx)

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -19,11 +19,10 @@ type decodeSyncAsmContext struct {
 	iteration   int
 	litRemain   int
 	out         []byte
-	literals    []byte
-	history     []byte
 	outPosition int
 	literals    []byte
 	litPosition int
+	history     []byte
 	windowSize  int
 	retry       bool // set be the caller when `out` got resized after reporting errorOutOfCapacity
 	ll          int  // set on error

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -45,24 +45,21 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $88-32
 	MOVQ CX, 24(SP)
 	MOVQ 232(AX), CX
 	MOVQ CX, 8(SP)
-	MOVQ 224(AX), CX
-	MOVQ CX, 16(SP)
+	MOVQ 224(AX), AX
+	MOVQ AX, 16(SP)
 	JMP  execute_single_triple
 	MOVQ s+0(FP), AX
-	MOVQ 144(AX), R10
-	MOVQ 152(AX), R11
-	MOVQ 160(AX), R12
 
 sequenceDecs_decodeSync_amd64_main_loop:
-	MOVQ (SP), R13
+	MOVQ (SP), R10
 
 	// Fill bitreader to have enough for the offset and match length.
 	CMPQ SI, $0x08
 	JL   sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R13
-	MOVQ (R13), DX
+	SUBQ AX, R10
+	MOVQ (R10), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_end
@@ -73,10 +70,10 @@ sequenceDecs_decodeSync_amd64_fill_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R13
+	SUBQ    $0x01, R10
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R13), AX
+	MOVBQZX (R10), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 
@@ -84,31 +81,31 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	// Update offset
 	MOVQ    R9, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R14
-	SHLQ    CL, R14
+	MOVQ    DX, R11
+	SHLQ    CL, R11
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R14
+	SHRQ    CL, R11
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R14
-	ADDQ    R14, AX
+	CMOVQEQ CX, R11
+	ADDQ    R11, AX
 	MOVQ    AX, 8(SP)
 
 	// Update match length
 	MOVQ    R8, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R14
-	SHLQ    CL, R14
+	MOVQ    DX, R11
+	SHLQ    CL, R11
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R14
+	SHRQ    CL, R11
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R14
-	ADDQ    R14, AX
+	CMOVQEQ CX, R11
+	ADDQ    R11, AX
 	MOVQ    AX, 16(SP)
 
 	// Fill bitreader to have enough for the remaining
@@ -116,8 +113,8 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	JL   sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R13
-	MOVQ (R13), DX
+	SUBQ AX, R10
+	MOVQ (R10), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_2_end
@@ -128,10 +125,10 @@ sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R13
+	SUBQ    $0x01, R10
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R13), AX
+	MOVBQZX (R10), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 
@@ -139,20 +136,20 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	// Update literal length
 	MOVQ    DI, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R14
-	SHLQ    CL, R14
+	MOVQ    DX, R11
+	SHLQ    CL, R11
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R14
+	SHRQ    CL, R11
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R14
-	ADDQ    R14, AX
+	CMOVQEQ CX, R11
+	ADDQ    R11, AX
 	MOVQ    AX, 24(SP)
 
 	// Fill bitreader for state updates
-	MOVQ    R13, (SP)
+	MOVQ    R10, (SP)
 	MOVQ    R9, AX
 	SHRQ    $0x08, AX
 	MOVBQZX AL, AX
@@ -161,19 +158,19 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	JZ      sequenceDecs_decodeSync_amd64_skip_update
 
 	// Update Literal Length State
-	MOVBQZX DI, R13
+	MOVBQZX DI, R10
 	SHRQ    $0x10, DI
 	MOVWQZX DI, DI
-	CMPQ    R13, $0x00
+	CMPQ    R10, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R13, BX
-	MOVQ    DX, R14
-	SHLQ    CL, R14
-	MOVQ    R13, CX
+	ADDQ    R10, BX
+	MOVQ    DX, R11
+	SHLQ    CL, R11
+	MOVQ    R10, CX
 	NEGQ    CX
-	SHRQ    CL, R14
-	ADDQ    R14, DI
+	SHRQ    CL, R11
+	ADDQ    R11, DI
 
 sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	// Load ctx.llTable
@@ -182,19 +179,19 @@ sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	MOVQ (CX)(DI*8), DI
 
 	// Update Match Length State
-	MOVBQZX R8, R13
+	MOVBQZX R8, R10
 	SHRQ    $0x10, R8
 	MOVWQZX R8, R8
-	CMPQ    R13, $0x00
+	CMPQ    R10, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R13, BX
-	MOVQ    DX, R14
-	SHLQ    CL, R14
-	MOVQ    R13, CX
+	ADDQ    R10, BX
+	MOVQ    DX, R11
+	SHLQ    CL, R11
+	MOVQ    R10, CX
 	NEGQ    CX
-	SHRQ    CL, R14
-	ADDQ    R14, R8
+	SHRQ    CL, R11
+	ADDQ    R11, R8
 
 sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	// Load ctx.mlTable
@@ -203,19 +200,19 @@ sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	MOVQ (CX)(R8*8), R8
 
 	// Update Offset State
-	MOVBQZX R9, R13
+	MOVBQZX R9, R10
 	SHRQ    $0x10, R9
 	MOVWQZX R9, R9
-	CMPQ    R13, $0x00
+	CMPQ    R10, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R13, BX
-	MOVQ    DX, R14
-	SHLQ    CL, R14
-	MOVQ    R13, CX
+	ADDQ    R10, BX
+	MOVQ    DX, R11
+	SHLQ    CL, R11
+	MOVQ    R10, CX
 	NEGQ    CX
-	SHRQ    CL, R14
-	ADDQ    R14, R9
+	SHRQ    CL, R11
+	ADDQ    R11, R9
 
 sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 	// Load ctx.ofTable
@@ -225,75 +222,65 @@ sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 
 sequenceDecs_decodeSync_amd64_skip_update:
 	// Adjust offset
-	MOVQ 8(SP), CX
-	CMPQ AX, $0x01
-	JBE  sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
-	MOVQ R11, R12
-	MOVQ R10, R11
-	MOVQ CX, R10
-	JMP  sequenceDecs_decodeSync_amd64_adjust_end
+	MOVQ   s+0(FP), CX
+	MOVQ   8(SP), R10
+	CMPQ   AX, $0x01
+	JBE    sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
+	MOVUPS 144(CX), X0
+	MOVQ   R10, 144(CX)
+	MOVUPS X0, 152(CX)
+	JMP    sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
 	CMPQ 24(SP), $0x00000000
 	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
-	INCQ CX
+	INCQ R10
 	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
 
 sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
+	TESTQ R10, R10
 	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
-	MOVQ  R10, CX
+	MOVQ  144(CX), R10
 	JMP   sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decodeSync_amd64_adjust_zero
-	JEQ  sequenceDecs_decodeSync_amd64_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decodeSync_amd64_adjust_three
-	JMP  sequenceDecs_decodeSync_amd64_adjust_two
-
-sequenceDecs_decodeSync_amd64_adjust_zero:
-	MOVQ R10, AX
-	JMP  sequenceDecs_decodeSync_amd64_adjust_test_temp_valid
-
-sequenceDecs_decodeSync_amd64_adjust_one:
-	MOVQ R11, AX
-	JMP  sequenceDecs_decodeSync_amd64_adjust_test_temp_valid
-
-sequenceDecs_decodeSync_amd64_adjust_two:
-	MOVQ R12, AX
-	JMP  sequenceDecs_decodeSync_amd64_adjust_test_temp_valid
-
-sequenceDecs_decodeSync_amd64_adjust_three:
-	LEAQ -1(R10), AX
-
-sequenceDecs_decodeSync_amd64_adjust_test_temp_valid:
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decodeSync_amd64_adjust_temp_valid
-	MOVQ  $0x00000001, AX
+	MOVQ    R10, AX
+	XORQ    R11, R11
+	MOVQ    $-1, R13
+	CMPQ    R10, $0x03
+	CMOVQEQ R11, AX
+	CMOVQEQ R13, R11
+	LEAQ    144(CX), R13
+	ADDQ    (R13)(AX*8), R11
+	JNZ     sequenceDecs_decodeSync_amd64_adjust_temp_valid
+	MOVQ    $0x00000001, R11
 
 sequenceDecs_decodeSync_amd64_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R11, R12
-	MOVQ    R10, R11
-	MOVQ    AX, R10
-	MOVQ    AX, CX
+	CMPQ R10, $0x01
+	JZ   sequenceDecs_decodeSync_amd64_adjust_skip
+	MOVQ 152(CX), AX
+	MOVQ AX, 160(CX)
+
+sequenceDecs_decodeSync_amd64_adjust_skip:
+	MOVQ 144(CX), AX
+	MOVQ AX, 152(CX)
+	MOVQ R11, 144(CX)
+	MOVQ R11, R10
 
 sequenceDecs_decodeSync_amd64_adjust_end:
-	MOVQ CX, 8(SP)
+	MOVQ R10, 8(SP)
 
 	// Check values
 	MOVQ  16(SP), AX
-	MOVQ  24(SP), R13
-	LEAQ  (AX)(R13*1), R14
-	MOVQ  s+0(FP), BP
-	ADDQ  R14, 256(BP)
-	MOVQ  ctx+16(FP), R14
-	SUBQ  R13, 104(R14)
+	MOVQ  24(SP), CX
+	LEAQ  (AX)(CX*1), R11
+	MOVQ  s+0(FP), R13
+	ADDQ  R11, 256(R13)
+	MOVQ  ctx+16(FP), R11
+	SUBQ  CX, 104(R11)
 	CMPQ  AX, $0x00020002
 	JA    sequenceDecs_decodeSync_amd64_error_match_len_too_big
-	TESTQ CX, CX
+	TESTQ R10, R10
 	JNZ   sequenceDecs_decodeSync_amd64_match_len_ofs_ok
 	TESTQ AX, AX
 	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
@@ -312,104 +299,104 @@ execute_single_triple:
 	TESTQ AX, AX
 	JZ    check_offset
 	MOVQ  48(SP), CX
-	MOVQ  40(SP), R13
-	XORQ  R14, R14
+	MOVQ  40(SP), R10
+	XORQ  R11, R11
 	TESTQ $0x00000001, AX
 	JZ    copy_1_word
-	MOVB  (CX)(R14*1), R15
-	MOVB  R15, (R13)(R14*1)
-	ADDQ  $0x01, R14
+	MOVB  (CX)(R11*1), R12
+	MOVB  R12, (R10)(R11*1)
+	ADDQ  $0x01, R11
 
 copy_1_word:
 	TESTQ $0x00000002, AX
 	JZ    copy_1_dword
-	MOVW  (CX)(R14*1), R15
-	MOVW  R15, (R13)(R14*1)
-	ADDQ  $0x02, R14
+	MOVW  (CX)(R11*1), R12
+	MOVW  R12, (R10)(R11*1)
+	ADDQ  $0x02, R11
 
 copy_1_dword:
 	TESTQ $0x00000004, AX
 	JZ    copy_1_qword
-	MOVL  (CX)(R14*1), R15
-	MOVL  R15, (R13)(R14*1)
-	ADDQ  $0x04, R14
+	MOVL  (CX)(R11*1), R12
+	MOVL  R12, (R10)(R11*1)
+	ADDQ  $0x04, R11
 
 copy_1_qword:
 	TESTQ $0x00000008, AX
 	JZ    copy_1_test
-	MOVQ  (CX)(R14*1), R15
-	MOVQ  R15, (R13)(R14*1)
-	ADDQ  $0x08, R14
+	MOVQ  (CX)(R11*1), R12
+	MOVQ  R12, (R10)(R11*1)
+	ADDQ  $0x08, R11
 	JMP   copy_1_test
 
 copy_1:
-	MOVUPS (CX)(R14*1), X0
-	MOVUPS X0, (R13)(R14*1)
-	ADDQ   $0x10, R14
+	MOVUPS (CX)(R11*1), X0
+	MOVUPS X0, (R10)(R11*1)
+	ADDQ   $0x10, R11
 
 copy_1_test:
-	CMPQ R14, AX
+	CMPQ R11, AX
 	JB   copy_1
 	ADDQ AX, 48(SP)
 	ADDQ AX, 40(SP)
 	ADDQ AX, 56(SP)
-	MOVQ 8(SP), R15
+	MOVQ 8(SP), R12
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
 check_offset:
 	MOVQ 56(SP), AX
 	ADDQ 64(SP), AX
-	CMPQ R15, AX
+	CMPQ R12, AX
 	JG   error_match_off_too_big
-	CMPQ R15, 80(SP)
+	CMPQ R12, 80(SP)
 	JG   error_match_off_too_big
 	MOVQ 16(SP), AX
 
 	// Copy match from history
-	MOVQ  R15, CX
+	MOVQ  R12, CX
 	SUBQ  56(SP), CX
 	JLS   copy_match
-	MOVQ  72(SP), R13
-	SUBQ  CX, R13
+	MOVQ  72(SP), R10
+	SUBQ  CX, R10
 	CMPQ  AX, CX
 	JGE   copy_all_from_history
 	MOVQ  40(SP), CX
-	XORQ  R14, R14
+	XORQ  R11, R11
 	TESTQ $0x00000001, AX
 	JZ    copy_4_word
-	MOVB  (R13)(R14*1), BP
-	MOVB  BP, (CX)(R14*1)
-	ADDQ  $0x01, R14
+	MOVB  (R10)(R11*1), R13
+	MOVB  R13, (CX)(R11*1)
+	ADDQ  $0x01, R11
 
 copy_4_word:
 	TESTQ $0x00000002, AX
 	JZ    copy_4_dword
-	MOVW  (R13)(R14*1), BP
-	MOVW  BP, (CX)(R14*1)
-	ADDQ  $0x02, R14
+	MOVW  (R10)(R11*1), R13
+	MOVW  R13, (CX)(R11*1)
+	ADDQ  $0x02, R11
 
 copy_4_dword:
 	TESTQ $0x00000004, AX
 	JZ    copy_4_qword
-	MOVL  (R13)(R14*1), BP
-	MOVL  BP, (CX)(R14*1)
-	ADDQ  $0x04, R14
+	MOVL  (R10)(R11*1), R13
+	MOVL  R13, (CX)(R11*1)
+	ADDQ  $0x04, R11
 
 copy_4_qword:
 	TESTQ $0x00000008, AX
 	JZ    copy_4_test
-	MOVQ  (R13)(R14*1), BP
-	MOVQ  BP, (CX)(R14*1)
-	ADDQ  $0x08, R14
+	MOVQ  (R10)(R11*1), R13
+	MOVQ  R13, (CX)(R11*1)
+	ADDQ  $0x08, R11
 	JMP   copy_4_test
 
 copy_4:
-	MOVUPS (R13)(R14*1), X0
-	MOVUPS X0, (CX)(R14*1)
-	ADDQ   $0x10, R14
+	MOVUPS (R10)(R11*1), X0
+	MOVUPS X0, (CX)(R11*1)
+	ADDQ   $0x10, R11
 
 copy_4_test:
-	CMPQ R14, AX
+	CMPQ R11, AX
 	JB   copy_4
 	ADDQ AX, 56(SP)
 	ADDQ AX, 40(SP)
@@ -417,7 +404,44 @@ copy_4_test:
 	JMP loop_finished
 
 copy_all_from_history:
-	MOVQ 40(SP), R13
+	MOVQ  40(SP), R11
+	XORQ  R13, R13
+	TESTQ $0x00000001, CX
+	JZ    copy_5_word
+	MOVB  (R10)(R13*1), R14
+	MOVB  R14, (R11)(R13*1)
+	ADDQ  $0x01, R13
+
+copy_5_word:
+	TESTQ $0x00000002, CX
+	JZ    copy_5_dword
+	MOVW  (R10)(R13*1), R14
+	MOVW  R14, (R11)(R13*1)
+	ADDQ  $0x02, R13
+
+copy_5_dword:
+	TESTQ $0x00000004, CX
+	JZ    copy_5_qword
+	MOVL  (R10)(R13*1), R14
+	MOVL  R14, (R11)(R13*1)
+	ADDQ  $0x04, R13
+
+copy_5_qword:
+	TESTQ $0x00000008, CX
+	JZ    copy_5_test
+	MOVQ  (R10)(R13*1), R14
+	MOVQ  R14, (R11)(R13*1)
+	ADDQ  $0x08, R13
+	JMP   copy_5_test
+
+copy_5:
+	MOVUPS (R10)(R13*1), X0
+	MOVUPS X0, (R11)(R13*1)
+	ADDQ   $0x10, R13
+
+copy_5_test:
+	CMPQ R13, CX
+	JB   copy_5
 	ADDQ CX, 40(SP)
 	ADDQ CX, 56(SP)
 	SUBQ CX, AX
@@ -427,21 +451,21 @@ copy_match:
 	TESTQ AX, AX
 	JZ    handle_loop
 	MOVQ  40(SP), CX
-	SUBQ  R15, CX
+	SUBQ  R12, CX
 
 	// ml <= mo
-	CMPQ AX, R15
+	CMPQ AX, R12
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	MOVQ 40(SP), R13
-	XORQ R14, R14
+	MOVQ 40(SP), R10
+	XORQ R11, R11
 
 copy_2:
-	MOVUPS (CX)(R14*1), X0
-	MOVUPS X0, (R13)(R14*1)
-	ADDQ   $0x10, R14
-	CMPQ   R14, AX
+	MOVUPS (CX)(R11*1), X0
+	MOVUPS X0, (R10)(R11*1)
+	ADDQ   $0x10, R11
+	CMPQ   R11, AX
 	JB     copy_2
 	ADDQ   AX, 40(SP)
 	ADDQ   AX, 56(SP)
@@ -449,14 +473,14 @@ copy_2:
 
 	// Copy overlapping match
 copy_overlapping_match:
-	MOVQ 40(SP), R13
-	XORQ R14, R14
+	MOVQ 40(SP), R10
+	XORQ R11, R11
 
 copy_slow_3:
-	MOVB (CX)(R14*1), BP
-	MOVB BP, (R13)(R14*1)
-	INCQ R14
-	CMPQ R14, AX
+	MOVB (CX)(R11*1), R13
+	MOVB R13, (R10)(R11*1)
+	INCQ R11
+	CMPQ R11, AX
 	JB   copy_slow_3
 	ADDQ AX, 40(SP)
 	ADDQ AX, 56(SP)
@@ -468,9 +492,6 @@ handle_loop:
 
 loop_finished:
 	MOVQ s+0(FP), AX
-	MOVQ R10, 144(AX)
-	MOVQ R11, 152(AX)
-	MOVQ R12, 160(AX)
 	MOVQ br+8(FP), AX
 	MOVQ DX, 32(AX)
 	MOVB BL, 40(AX)

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -4,7 +4,7 @@
 // +build !appengine,!noasm,gc,!noasm
 
 // func sequenceDecs_decode_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: CMOV, SSE
+// Requires: CMOV
 TEXT ·sequenceDecs_decode_amd64(SB), $8-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
@@ -18,31 +18,35 @@ TEXT ·sequenceDecs_decode_amd64(SB), $8-32
 	MOVQ    80(AX), R8
 	MOVQ    88(AX), R9
 	MOVQ    104(AX), R10
+	MOVQ    s+0(FP), AX
+	MOVQ    144(AX), R11
+	MOVQ    152(AX), R12
+	MOVQ    160(AX), R13
 
 sequenceDecs_decode_amd64_main_loop:
-	MOVQ (SP), R11
+	MOVQ (SP), R14
 
-	// Fill bitreader to have enough for the offset.
-	CMPQ    BX, $0x20
-	JL      sequenceDecs_decode_amd64_fill_end
-	CMPQ    SI, $0x04
-	JL      sequenceDecs_decode_amd64_fill_byte_by_byte
-	SHLQ    $0x20, DX
-	SUBQ    $0x04, R11
-	SUBQ    $0x04, SI
-	SUBQ    $0x20, BX
-	MOVLQZX (R11), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_amd64_fill_end
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decode_amd64_fill_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R14
+	MOVQ (R14), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decode_amd64_fill_end
 
 sequenceDecs_decode_amd64_fill_byte_by_byte:
 	CMPQ    SI, $0x00
 	JLE     sequenceDecs_decode_amd64_fill_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decode_amd64_fill_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R11
+	SUBQ    $0x01, R14
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R11), AX
+	MOVBQZX (R14), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decode_amd64_fill_byte_by_byte
 
@@ -50,99 +54,75 @@ sequenceDecs_decode_amd64_fill_end:
 	// Update offset
 	MOVQ    R9, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
+	MOVQ    DX, R15
+	SHLQ    CL, R15
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R12
+	SHRQ    CL, R15
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R12
-	ADDQ    R12, AX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
 	MOVQ    AX, 16(R10)
 
-	// Fill bitreader for match and literal
-	CMPQ    BX, $0x20
-	JL      sequenceDecs_decode_amd64_fill_2_end
-	CMPQ    SI, $0x04
-	JL      sequenceDecs_decode_amd64_fill_2_byte_by_byte
-	SHLQ    $0x20, DX
-	SUBQ    $0x04, R11
-	SUBQ    $0x04, SI
-	SUBQ    $0x20, BX
-	MOVLQZX (R11), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_amd64_fill_2_end
+	// Update match length
+	MOVQ    R8, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 8(R10)
+
+	// Fill bitreader to have enough for the remaining
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decode_amd64_fill_2_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R14
+	MOVQ (R14), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decode_amd64_fill_2_end
 
 sequenceDecs_decode_amd64_fill_2_byte_by_byte:
 	CMPQ    SI, $0x00
 	JLE     sequenceDecs_decode_amd64_fill_2_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decode_amd64_fill_2_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R11
+	SUBQ    $0x01, R14
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R11), AX
+	MOVBQZX (R14), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decode_amd64_fill_2_byte_by_byte
 
 sequenceDecs_decode_amd64_fill_2_end:
-	// Update match length
-	MOVQ    R8, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R12
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R12
-	ADDQ    R12, AX
-	MOVQ    AX, 8(R10)
-
 	// Update literal length
 	MOVQ    DI, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
+	MOVQ    DX, R15
+	SHLQ    CL, R15
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R12
+	SHRQ    CL, R15
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R12
-	ADDQ    R12, AX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
 	MOVQ    AX, (R10)
 
 	// Fill bitreader for state updates
-	CMPQ    BX, $0x20
-	JL      sequenceDecs_decode_amd64_fill_3_end
-	CMPQ    SI, $0x04
-	JL      sequenceDecs_decode_amd64_fill_3_byte_by_byte
-	SHLQ    $0x20, DX
-	SUBQ    $0x04, R11
-	SUBQ    $0x04, SI
-	SUBQ    $0x20, BX
-	MOVLQZX (R11), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_amd64_fill_3_end
-
-sequenceDecs_decode_amd64_fill_3_byte_by_byte:
-	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decode_amd64_fill_3_end
-	SHLQ    $0x08, DX
-	SUBQ    $0x01, R11
-	SUBQ    $0x01, SI
-	SUBQ    $0x08, BX
-	MOVBQZX (R11), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_amd64_fill_3_byte_by_byte
-
-sequenceDecs_decode_amd64_fill_3_end:
-	MOVQ    R11, (SP)
+	MOVQ    R14, (SP)
 	MOVQ    R9, AX
 	SHRQ    $0x08, AX
 	MOVBQZX AL, AX
@@ -151,19 +131,19 @@ sequenceDecs_decode_amd64_fill_3_end:
 	JZ      sequenceDecs_decode_amd64_skip_update
 
 	// Update Literal Length State
-	MOVBQZX DI, R11
+	MOVBQZX DI, R14
 	SHRQ    $0x10, DI
 	MOVWQZX DI, DI
-	CMPQ    R11, $0x00
+	CMPQ    R14, $0x00
 	JZ      sequenceDecs_decode_amd64_llState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R11, BX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
-	MOVQ    R11, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
 	NEGQ    CX
-	SHRQ    CL, R12
-	ADDQ    R12, DI
+	SHRQ    CL, R15
+	ADDQ    R15, DI
 
 sequenceDecs_decode_amd64_llState_updateState_skip_zero:
 	// Load ctx.llTable
@@ -172,19 +152,19 @@ sequenceDecs_decode_amd64_llState_updateState_skip_zero:
 	MOVQ (CX)(DI*8), DI
 
 	// Update Match Length State
-	MOVBQZX R8, R11
+	MOVBQZX R8, R14
 	SHRQ    $0x10, R8
 	MOVWQZX R8, R8
-	CMPQ    R11, $0x00
+	CMPQ    R14, $0x00
 	JZ      sequenceDecs_decode_amd64_mlState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R11, BX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
-	MOVQ    R11, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
 	NEGQ    CX
-	SHRQ    CL, R12
-	ADDQ    R12, R8
+	SHRQ    CL, R15
+	ADDQ    R15, R8
 
 sequenceDecs_decode_amd64_mlState_updateState_skip_zero:
 	// Load ctx.mlTable
@@ -193,19 +173,19 @@ sequenceDecs_decode_amd64_mlState_updateState_skip_zero:
 	MOVQ (CX)(R8*8), R8
 
 	// Update Offset State
-	MOVBQZX R9, R11
+	MOVBQZX R9, R14
 	SHRQ    $0x10, R9
 	MOVWQZX R9, R9
-	CMPQ    R11, $0x00
+	CMPQ    R14, $0x00
 	JZ      sequenceDecs_decode_amd64_ofState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R11, BX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
-	MOVQ    R11, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
 	NEGQ    CX
-	SHRQ    CL, R12
-	ADDQ    R12, R9
+	SHRQ    CL, R15
+	ADDQ    R15, R9
 
 sequenceDecs_decode_amd64_ofState_updateState_skip_zero:
 	// Load ctx.ofTable
@@ -215,65 +195,75 @@ sequenceDecs_decode_amd64_ofState_updateState_skip_zero:
 
 sequenceDecs_decode_amd64_skip_update:
 	// Adjust offset
-	MOVQ   s+0(FP), CX
-	MOVQ   16(R10), R11
-	CMPQ   AX, $0x01
-	JBE    sequenceDecs_decode_amd64_adjust_offsetB_1_or_0
-	MOVUPS 144(CX), X0
-	MOVQ   R11, 144(CX)
-	MOVUPS X0, 152(CX)
-	JMP    sequenceDecs_decode_amd64_adjust_end
+	MOVQ 16(R10), CX
+	CMPQ AX, $0x01
+	JBE  sequenceDecs_decode_amd64_adjust_offsetB_1_or_0
+	MOVQ R12, R13
+	MOVQ R11, R12
+	MOVQ CX, R11
+	JMP  sequenceDecs_decode_amd64_adjust_end
 
 sequenceDecs_decode_amd64_adjust_offsetB_1_or_0:
 	CMPQ (R10), $0x00000000
 	JNE  sequenceDecs_decode_amd64_adjust_offset_maybezero
-	INCQ R11
+	INCQ CX
 	JMP  sequenceDecs_decode_amd64_adjust_offset_nonzero
 
 sequenceDecs_decode_amd64_adjust_offset_maybezero:
-	TESTQ R11, R11
+	TESTQ CX, CX
 	JNZ   sequenceDecs_decode_amd64_adjust_offset_nonzero
-	MOVQ  144(CX), R11
+	MOVQ  R11, CX
 	JMP   sequenceDecs_decode_amd64_adjust_end
 
 sequenceDecs_decode_amd64_adjust_offset_nonzero:
-	MOVQ    R11, AX
-	XORQ    R12, R12
-	MOVQ    $-1, R13
-	CMPQ    R11, $0x03
-	CMOVQEQ R12, AX
-	CMOVQEQ R13, R12
-	LEAQ    144(CX), R13
-	ADDQ    (R13)(AX*8), R12
-	JNZ     sequenceDecs_decode_amd64_adjust_temp_valid
-	MOVQ    $0x00000001, R12
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_amd64_adjust_zero
+	JEQ  sequenceDecs_decode_amd64_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_amd64_adjust_three
+	JMP  sequenceDecs_decode_amd64_adjust_two
+
+sequenceDecs_decode_amd64_adjust_zero:
+	MOVQ R11, AX
+	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_amd64_adjust_one:
+	MOVQ R12, AX
+	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_amd64_adjust_two:
+	MOVQ R13, AX
+	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_amd64_adjust_three:
+	LEAQ -1(R11), AX
+
+sequenceDecs_decode_amd64_adjust_test_temp_valid:
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decode_amd64_adjust_temp_valid
+	MOVQ  $0x00000001, AX
 
 sequenceDecs_decode_amd64_adjust_temp_valid:
-	CMPQ R11, $0x01
-	JZ   sequenceDecs_decode_amd64_adjust_skip
-	MOVQ 152(CX), AX
-	MOVQ AX, 160(CX)
-
-sequenceDecs_decode_amd64_adjust_skip:
-	MOVQ 144(CX), AX
-	MOVQ AX, 152(CX)
-	MOVQ R12, 144(CX)
-	MOVQ R12, R11
+	CMPQ    CX, $0x01
+	CMOVQNE R12, R13
+	MOVQ    R11, R12
+	MOVQ    AX, R11
+	MOVQ    AX, CX
 
 sequenceDecs_decode_amd64_adjust_end:
-	MOVQ R11, 16(R10)
+	MOVQ CX, 16(R10)
 
 	// Check values
 	MOVQ  8(R10), AX
-	MOVQ  (R10), CX
-	LEAQ  (AX)(CX*1), R12
-	MOVQ  s+0(FP), R13
-	ADDQ  R12, 256(R13)
-	MOVQ  ctx+16(FP), R12
-	SUBQ  CX, 128(R12)
+	MOVQ  (R10), R14
+	LEAQ  (AX)(R14*1), R15
+	MOVQ  s+0(FP), BP
+	ADDQ  R15, 256(BP)
+	MOVQ  ctx+16(FP), R15
+	SUBQ  R14, 128(R15)
 	CMPQ  AX, $0x00020002
 	JA    sequenceDecs_decode_amd64_error_match_len_too_big
-	TESTQ R11, R11
+	TESTQ CX, CX
 	JNZ   sequenceDecs_decode_amd64_match_len_ofs_ok
 	TESTQ AX, AX
 	JNZ   sequenceDecs_decode_amd64_error_match_len_ofs_mismatch
@@ -283,6 +273,10 @@ sequenceDecs_decode_amd64_match_len_ofs_ok:
 	MOVQ ctx+16(FP), AX
 	DECQ 96(AX)
 	JNS  sequenceDecs_decode_amd64_main_loop
+	MOVQ s+0(FP), AX
+	MOVQ R11, 144(AX)
+	MOVQ R12, 152(AX)
+	MOVQ R13, 160(AX)
 	MOVQ br+8(FP), AX
 	MOVQ DX, 32(AX)
 	MOVB BL, 40(AX)
@@ -297,418 +291,14 @@ sequenceDecs_decode_amd64_error_match_len_ofs_mismatch:
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
-	// Return with match length too long error
+	// Return with match too long error
 sequenceDecs_decode_amd64_error_match_len_too_big:
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
-	// Return with match offset too long error
-	MOVQ $0x00000003, ret+24(FP)
-	RET
-
-// func sequenceDecs_decode_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: BMI, BMI2, CMOV, SSE
-TEXT ·sequenceDecs_decode_bmi2(SB), $8-32
-	MOVQ    br+8(FP), CX
-	MOVQ    32(CX), AX
-	MOVBQZX 40(CX), DX
-	MOVQ    24(CX), BX
-	MOVQ    (CX), CX
-	ADDQ    BX, CX
-	MOVQ    CX, (SP)
-	MOVQ    ctx+16(FP), CX
-	MOVQ    72(CX), SI
-	MOVQ    80(CX), DI
-	MOVQ    88(CX), R8
-	MOVQ    104(CX), R9
-
-sequenceDecs_decode_bmi2_main_loop:
-	MOVQ (SP), R10
-
-	// Fill bitreader to have enough for the offset.
-	CMPQ    DX, $0x20
-	JL      sequenceDecs_decode_bmi2_fill_end
-	CMPQ    BX, $0x04
-	JL      sequenceDecs_decode_bmi2_fill_byte_by_byte
-	SHLQ    $0x20, AX
-	SUBQ    $0x04, R10
-	SUBQ    $0x04, BX
-	SUBQ    $0x20, DX
-	MOVLQZX (R10), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_end
-
-sequenceDecs_decode_bmi2_fill_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decode_bmi2_fill_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R10
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R10), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_byte_by_byte
-
-sequenceDecs_decode_bmi2_fill_end:
-	// Update offset
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R11
-	MOVQ   AX, R12
-	LEAQ   (DX)(R11*1), CX
-	ROLQ   CL, R12
-	BZHIQ  R11, R12, R12
-	MOVQ   CX, DX
-	MOVQ   R8, CX
-	SHRQ   $0x20, CX
-	ADDQ   R12, CX
-	MOVQ   CX, 16(R9)
-
-	// Fill bitreader for match and literal
-	CMPQ    DX, $0x20
-	JL      sequenceDecs_decode_bmi2_fill_2_end
-	CMPQ    BX, $0x04
-	JL      sequenceDecs_decode_bmi2_fill_2_byte_by_byte
-	SHLQ    $0x20, AX
-	SUBQ    $0x04, R10
-	SUBQ    $0x04, BX
-	SUBQ    $0x20, DX
-	MOVLQZX (R10), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_2_end
-
-sequenceDecs_decode_bmi2_fill_2_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decode_bmi2_fill_2_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R10
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R10), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_2_byte_by_byte
-
-sequenceDecs_decode_bmi2_fill_2_end:
-	// Update match length
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, DI, R11
-	MOVQ   AX, R12
-	LEAQ   (DX)(R11*1), CX
-	ROLQ   CL, R12
-	BZHIQ  R11, R12, R12
-	MOVQ   CX, DX
-	MOVQ   DI, CX
-	SHRQ   $0x20, CX
-	ADDQ   R12, CX
-	MOVQ   CX, 8(R9)
-
-	// Update literal length
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, SI, R11
-	MOVQ   AX, R12
-	LEAQ   (DX)(R11*1), CX
-	ROLQ   CL, R12
-	BZHIQ  R11, R12, R12
-	MOVQ   CX, DX
-	MOVQ   SI, CX
-	SHRQ   $0x20, CX
-	ADDQ   R12, CX
-	MOVQ   CX, (R9)
-
-	// Fill bitreader for state updates
-	CMPQ    DX, $0x20
-	JL      sequenceDecs_decode_bmi2_fill_3_end
-	CMPQ    BX, $0x04
-	JL      sequenceDecs_decode_bmi2_fill_3_byte_by_byte
-	SHLQ    $0x20, AX
-	SUBQ    $0x04, R10
-	SUBQ    $0x04, BX
-	SUBQ    $0x20, DX
-	MOVLQZX (R10), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_3_end
-
-sequenceDecs_decode_bmi2_fill_3_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decode_bmi2_fill_3_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R10
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R10), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_3_byte_by_byte
-
-sequenceDecs_decode_bmi2_fill_3_end:
-	MOVQ   R10, (SP)
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R10
-	MOVQ   ctx+16(FP), CX
-	CMPQ   96(CX), $0x00
-	JZ     sequenceDecs_decode_bmi2_skip_update
-
-	// Update Literal Length State
-	MOVBQZX SI, R11
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, SI, SI
-	LEAQ    (DX)(R11*1), CX
-	MOVQ    AX, R12
-	MOVQ    CX, DX
-	ROLQ    CL, R12
-	BZHIQ   R11, R12, R12
-	ADDQ    R12, SI
-
-	// Load ctx.llTable
-	MOVQ ctx+16(FP), CX
-	MOVQ (CX), CX
-	MOVQ (CX)(SI*8), SI
-
-	// Update Match Length State
-	MOVBQZX DI, R11
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, DI, DI
-	LEAQ    (DX)(R11*1), CX
-	MOVQ    AX, R12
-	MOVQ    CX, DX
-	ROLQ    CL, R12
-	BZHIQ   R11, R12, R12
-	ADDQ    R12, DI
-
-	// Load ctx.mlTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 24(CX), CX
-	MOVQ (CX)(DI*8), DI
-
-	// Update Offset State
-	MOVBQZX R8, R11
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, R8, R8
-	LEAQ    (DX)(R11*1), CX
-	MOVQ    AX, R12
-	MOVQ    CX, DX
-	ROLQ    CL, R12
-	BZHIQ   R11, R12, R12
-	ADDQ    R12, R8
-
-	// Load ctx.ofTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 48(CX), CX
-	MOVQ (CX)(R8*8), R8
-
-sequenceDecs_decode_bmi2_skip_update:
-	// Adjust offset
-	MOVQ   s+0(FP), CX
-	MOVQ   16(R9), R11
-	CMPQ   R10, $0x01
-	JBE    sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0
-	MOVUPS 144(CX), X0
-	MOVQ   R11, 144(CX)
-	MOVUPS X0, 152(CX)
-	JMP    sequenceDecs_decode_bmi2_adjust_end
-
-sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_bmi2_adjust_offset_maybezero
-	INCQ R11
-	JMP  sequenceDecs_decode_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decode_bmi2_adjust_offset_maybezero:
-	TESTQ R11, R11
-	JNZ   sequenceDecs_decode_bmi2_adjust_offset_nonzero
-	MOVQ  144(CX), R11
-	JMP   sequenceDecs_decode_bmi2_adjust_end
-
-sequenceDecs_decode_bmi2_adjust_offset_nonzero:
-	MOVQ    R11, R10
-	XORQ    R12, R12
-	MOVQ    $-1, R13
-	CMPQ    R11, $0x03
-	CMOVQEQ R12, R10
-	CMOVQEQ R13, R12
-	LEAQ    144(CX), R13
-	ADDQ    (R13)(R10*8), R12
-	JNZ     sequenceDecs_decode_bmi2_adjust_temp_valid
-	MOVQ    $0x00000001, R12
-
-sequenceDecs_decode_bmi2_adjust_temp_valid:
-	CMPQ R11, $0x01
-	JZ   sequenceDecs_decode_bmi2_adjust_skip
-	MOVQ 152(CX), R10
-	MOVQ R10, 160(CX)
-
-sequenceDecs_decode_bmi2_adjust_skip:
-	MOVQ 144(CX), R10
-	MOVQ R10, 152(CX)
-	MOVQ R12, 144(CX)
-	MOVQ R12, R11
-
-sequenceDecs_decode_bmi2_adjust_end:
-	MOVQ R11, 16(R9)
-
-	// Check values
-	MOVQ  8(R9), CX
-	MOVQ  (R9), R10
-	LEAQ  (CX)(R10*1), R12
-	MOVQ  s+0(FP), R13
-	ADDQ  R12, 256(R13)
-	MOVQ  ctx+16(FP), R12
-	SUBQ  R10, 128(R12)
-	CMPQ  CX, $0x00020002
-	JA    sequenceDecs_decode_bmi2_error_match_len_too_big
-	TESTQ R11, R11
-	JNZ   sequenceDecs_decode_bmi2_match_len_ofs_ok
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch
-
-sequenceDecs_decode_bmi2_match_len_ofs_ok:
-	ADDQ $0x18, R9
-	MOVQ ctx+16(FP), CX
-	DECQ 96(CX)
-	JNS  sequenceDecs_decode_bmi2_main_loop
-	MOVQ br+8(FP), CX
-	MOVQ AX, 32(CX)
-	MOVB DL, 40(CX)
-	MOVQ BX, 24(CX)
-
-	// Return success
-	MOVQ $0x00000000, ret+24(FP)
-	RET
-
-	// Return with match length error
-sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch:
-	MOVQ $0x00000001, ret+24(FP)
-	RET
-
-	// Return with match length too long error
-sequenceDecs_decode_bmi2_error_match_len_too_big:
-	MOVQ $0x00000002, ret+24(FP)
-	RET
-
-	// Return with match offset too long error
-	MOVQ $0x00000003, ret+24(FP)
-	RET
-
-// func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
-// Requires: SSE
-TEXT ·sequenceDecs_executeSimple_amd64(SB), $0-9
-	MOVQ  ctx+0(FP), DI
-	MOVQ  8(DI), CX
-	TESTQ CX, CX
-	JZ    empty_seqs
-	MOVQ  (DI), AX
-	MOVQ  24(DI), DX
-	MOVQ  32(DI), BX
-	MOVQ  40(DI), SI
-	MOVQ  56(DI), SI
-	MOVQ  80(DI), R8
-	MOVQ  96(DI), DI
-
-	// seqsBase += 24 * seqIndex
-	LEAQ (DX)(DX*2), DI
-	SHLQ $0x03, DI
-	ADDQ DI, AX
-
-	// outBase += outPosition
-	ADDQ R8, BX
-
-main_loop:
-	// Copy literals
-	MOVQ  (AX), DI
-	TESTQ DI, DI
-	JZ    copy_match
-	XORQ  R9, R9
-
-copy_1:
-	MOVUPS (SI)(R9*1), X0
-	MOVUPS X0, (BX)(R9*1)
-	ADDQ   $0x10, R9
-	CMPQ   R9, DI
-	JB     copy_1
-	ADDQ   DI, SI
-	ADDQ   DI, BX
-	ADDQ   DI, R8
-
-	// Copy match
-copy_match:
-	MOVQ  8(AX), DI
-	TESTQ DI, DI
-	JZ    handle_loop
-	MOVQ  16(AX), R9
-
-	// Malformed input if seq.mo > t || seq.mo > s.windowSize
-	CMPQ R9, R8
-	JG   error_match_off_too_big
-	MOVQ BX, R10
-	SUBQ R9, R10
-
-	// ml <= mo
-	CMPQ DI, R9
-	JA   copy_overlapping_match
-
-	// Copy non-overlapping match
-	XORQ R9, R9
-
-copy_2:
-	MOVUPS (R10)(R9*1), X0
-	MOVUPS X0, (BX)(R9*1)
-	ADDQ   $0x10, R9
-	CMPQ   R9, DI
-	JB     copy_2
-	ADDQ   DI, BX
-	ADDQ   DI, R8
-	JMP    handle_loop
-
-	// Copy overlapping match
-copy_overlapping_match:
-	XORQ R9, R9
-
-copy_slow_3:
-	MOVB (R10)(R9*1), R11
-	MOVB R11, (BX)(R9*1)
-	INCQ R9
-	CMPQ R9, DI
-	JB   copy_slow_3
-	ADDQ DI, BX
-	ADDQ DI, R8
-
-handle_loop:
-	ADDQ $0x18, AX
-	INCQ DX
-	CMPQ DX, CX
-	JB   main_loop
-
-	// Return value
-	MOVB $0x01, ret+8(FP)
-
-	// Update the context
-	MOVQ ctx+0(FP), AX
-	MOVQ DX, 24(AX)
-	MOVQ R8, 80(AX)
-	MOVQ 56(AX), CX
-	SUBQ CX, SI
-	MOVQ SI, 88(AX)
-	RET
-
-error_match_off_too_big:
-	// Return value
-	MOVB $0x00, ret+8(FP)
-
-	// Update the context
-	MOVQ ctx+0(FP), AX
-	MOVQ DX, 24(AX)
-	MOVQ R8, 80(AX)
-	MOVQ 56(AX), CX
-	SUBQ CX, SI
-	MOVQ SI, 88(AX)
-	RET
-
-empty_seqs:
-	// Return value
-	MOVB $0x01, ret+8(FP)
-	RET
-
-// func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
-// Requires: CMOV, SSE
-TEXT ·sequenceDecs_decodeSync_amd64(SB), $40-32
+// func sequenceDecs_decode_56_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
+// Requires: CMOV
+TEXT ·sequenceDecs_decode_56_amd64(SB), $8-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
 	MOVBQZX 40(AX), BX
@@ -716,59 +306,44 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $40-32
 	MOVQ    (AX), AX
 	ADDQ    SI, AX
 	MOVQ    AX, (SP)
-	MOVQ    ctx+16(FP), CX
-	MOVQ    72(CX), DI
-	MOVQ    80(CX), R8
-	MOVQ    88(CX), R9
-	MOVQ    112(CX), R11
-	MOVQ    144(CX), R12
-	MOVQ    136(CX), R13
-	MOVQ    176(CX), AX
-	MOVQ    128(CX), AX
-	MOVQ    AX, 32(SP)
+	MOVQ    ctx+16(FP), AX
+	MOVQ    72(AX), DI
+	MOVQ    80(AX), R8
+	MOVQ    88(AX), R9
+	MOVQ    104(AX), R10
+	MOVQ    s+0(FP), AX
+	MOVQ    144(AX), R11
+	MOVQ    152(AX), R12
+	MOVQ    160(AX), R13
 
-	// outBase += outPosition
-	ADDQ R13, R11
-
-	// Check if we're retrying after `out` resize
-	CMPQ 184(CX), $0x01
-	JNE  sequenceDecs_decodeSync_amd64_main_loop
-	MOVQ 192(CX), AX
-	MOVQ AX, 24(SP)
-	MOVQ 208(CX), AX
-	MOVQ AX, 8(SP)
-	MOVQ 200(CX), AX
-	MOVQ AX, 16(SP)
-	JMP  execute_single_triple
-
-sequenceDecs_decodeSync_amd64_main_loop:
+sequenceDecs_decode_56_amd64_main_loop:
 	MOVQ (SP), R14
 
-	// Fill bitreader to have enough for the offset.
-	CMPQ    BX, $0x20
-	JL      sequenceDecs_decodeSync_amd64_fill_end
-	CMPQ    SI, $0x04
-	JL      sequenceDecs_decodeSync_amd64_fill_byte_by_byte
-	SHLQ    $0x20, DX
-	SUBQ    $0x04, R14
-	SUBQ    $0x04, SI
-	SUBQ    $0x20, BX
-	MOVLQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decodeSync_amd64_fill_end
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decode_56_amd64_fill_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R14
+	MOVQ (R14), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decode_56_amd64_fill_end
 
-sequenceDecs_decodeSync_amd64_fill_byte_by_byte:
+sequenceDecs_decode_56_amd64_fill_byte_by_byte:
 	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decodeSync_amd64_fill_end
+	JLE     sequenceDecs_decode_56_amd64_fill_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decode_56_amd64_fill_end
 	SHLQ    $0x08, DX
 	SUBQ    $0x01, R14
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
 	MOVBQZX (R14), AX
 	ORQ     AX, DX
-	JMP     sequenceDecs_decodeSync_amd64_fill_byte_by_byte
+	JMP     sequenceDecs_decode_56_amd64_fill_byte_by_byte
 
-sequenceDecs_decodeSync_amd64_fill_end:
+sequenceDecs_decode_56_amd64_fill_end:
 	// Update offset
 	MOVQ    R9, AX
 	MOVQ    BX, CX
@@ -782,33 +357,8 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	TESTQ   CX, CX
 	CMOVQEQ CX, R15
 	ADDQ    R15, AX
-	MOVQ    AX, 8(SP)
+	MOVQ    AX, 16(R10)
 
-	// Fill bitreader for match and literal
-	CMPQ    BX, $0x20
-	JL      sequenceDecs_decodeSync_amd64_fill_2_end
-	CMPQ    SI, $0x04
-	JL      sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
-	SHLQ    $0x20, DX
-	SUBQ    $0x04, R14
-	SUBQ    $0x04, SI
-	SUBQ    $0x20, BX
-	MOVLQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decodeSync_amd64_fill_2_end
-
-sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte:
-	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
-	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
-	SUBQ    $0x01, SI
-	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
-
-sequenceDecs_decodeSync_amd64_fill_2_end:
 	// Update match length
 	MOVQ    R8, AX
 	MOVQ    BX, CX
@@ -822,7 +372,7 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	TESTQ   CX, CX
 	CMOVQEQ CX, R15
 	ADDQ    R15, AX
-	MOVQ    AX, 16(SP)
+	MOVQ    AX, 8(R10)
 
 	// Update literal length
 	MOVQ    DI, AX
@@ -837,47 +387,23 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	TESTQ   CX, CX
 	CMOVQEQ CX, R15
 	ADDQ    R15, AX
-	MOVQ    AX, 24(SP)
+	MOVQ    AX, (R10)
 
 	// Fill bitreader for state updates
-	CMPQ    BX, $0x20
-	JL      sequenceDecs_decodeSync_amd64_fill_3_end
-	CMPQ    SI, $0x04
-	JL      sequenceDecs_decodeSync_amd64_fill_3_byte_by_byte
-	SHLQ    $0x20, DX
-	SUBQ    $0x04, R14
-	SUBQ    $0x04, SI
-	SUBQ    $0x20, BX
-	MOVLQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decodeSync_amd64_fill_3_end
-
-sequenceDecs_decodeSync_amd64_fill_3_byte_by_byte:
-	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decodeSync_amd64_fill_3_end
-	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
-	SUBQ    $0x01, SI
-	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decodeSync_amd64_fill_3_byte_by_byte
-
-sequenceDecs_decodeSync_amd64_fill_3_end:
 	MOVQ    R14, (SP)
 	MOVQ    R9, AX
 	SHRQ    $0x08, AX
 	MOVBQZX AL, AX
 	MOVQ    ctx+16(FP), CX
 	CMPQ    96(CX), $0x00
-	JZ      sequenceDecs_decodeSync_amd64_skip_update
+	JZ      sequenceDecs_decode_56_amd64_skip_update
 
 	// Update Literal Length State
 	MOVBQZX DI, R14
 	SHRQ    $0x10, DI
 	MOVWQZX DI, DI
 	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero
+	JZ      sequenceDecs_decode_56_amd64_llState_updateState_skip_zero
 	MOVQ    BX, CX
 	ADDQ    R14, BX
 	MOVQ    DX, R15
@@ -887,7 +413,7 @@ sequenceDecs_decodeSync_amd64_fill_3_end:
 	SHRQ    CL, R15
 	ADDQ    R15, DI
 
-sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
+sequenceDecs_decode_56_amd64_llState_updateState_skip_zero:
 	// Load ctx.llTable
 	MOVQ ctx+16(FP), CX
 	MOVQ (CX), CX
@@ -898,7 +424,7 @@ sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	SHRQ    $0x10, R8
 	MOVWQZX R8, R8
 	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero
+	JZ      sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero
 	MOVQ    BX, CX
 	ADDQ    R14, BX
 	MOVQ    DX, R15
@@ -908,7 +434,7 @@ sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	SHRQ    CL, R15
 	ADDQ    R15, R8
 
-sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
+sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero:
 	// Load ctx.mlTable
 	MOVQ ctx+16(FP), CX
 	MOVQ 24(CX), CX
@@ -919,7 +445,7 @@ sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	SHRQ    $0x10, R9
 	MOVWQZX R9, R9
 	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero
+	JZ      sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero
 	MOVQ    BX, CX
 	ADDQ    R14, BX
 	MOVQ    DX, R15
@@ -929,207 +455,118 @@ sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	SHRQ    CL, R15
 	ADDQ    R15, R9
 
-sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
+sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero:
 	// Load ctx.ofTable
 	MOVQ ctx+16(FP), CX
 	MOVQ 48(CX), CX
 	MOVQ (CX)(R9*8), R9
 
-sequenceDecs_decodeSync_amd64_skip_update:
+sequenceDecs_decode_56_amd64_skip_update:
 	// Adjust offset
-	MOVQ   s+0(FP), CX
-	MOVQ   8(SP), R14
-	CMPQ   AX, $0x01
-	JBE    sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
-	MOVUPS 144(CX), X0
-	MOVQ   R14, 144(CX)
-	MOVUPS X0, 152(CX)
-	JMP    sequenceDecs_decodeSync_amd64_adjust_end
+	MOVQ 16(R10), CX
+	CMPQ AX, $0x01
+	JBE  sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0
+	MOVQ R12, R13
+	MOVQ R11, R12
+	MOVQ CX, R11
+	JMP  sequenceDecs_decode_56_amd64_adjust_end
 
-sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
-	CMPQ 24(SP), $0x00000000
-	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
-	INCQ R14
-	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
+sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0:
+	CMPQ (R10), $0x00000000
+	JNE  sequenceDecs_decode_56_amd64_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decode_56_amd64_adjust_offset_nonzero
 
-sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
-	TESTQ R14, R14
-	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
-	MOVQ  144(CX), R14
-	JMP   sequenceDecs_decodeSync_amd64_adjust_end
+sequenceDecs_decode_56_amd64_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_amd64_adjust_offset_nonzero
+	MOVQ  R11, CX
+	JMP   sequenceDecs_decode_56_amd64_adjust_end
 
-sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
-	MOVQ    R14, AX
-	XORQ    R15, R15
-	MOVQ    $-1, BP
-	CMPQ    R14, $0x03
-	CMOVQEQ R15, AX
-	CMOVQEQ BP, R15
-	LEAQ    144(CX), BP
-	ADDQ    (BP)(AX*8), R15
-	JNZ     sequenceDecs_decodeSync_amd64_adjust_temp_valid
-	MOVQ    $0x00000001, R15
+sequenceDecs_decode_56_amd64_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_56_amd64_adjust_zero
+	JEQ  sequenceDecs_decode_56_amd64_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_56_amd64_adjust_three
+	JMP  sequenceDecs_decode_56_amd64_adjust_two
 
-sequenceDecs_decodeSync_amd64_adjust_temp_valid:
-	CMPQ R14, $0x01
-	JZ   sequenceDecs_decodeSync_amd64_adjust_skip
-	MOVQ 152(CX), AX
-	MOVQ AX, 160(CX)
+sequenceDecs_decode_56_amd64_adjust_zero:
+	MOVQ R11, AX
+	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
 
-sequenceDecs_decodeSync_amd64_adjust_skip:
-	MOVQ 144(CX), AX
-	MOVQ AX, 152(CX)
-	MOVQ R15, 144(CX)
-	MOVQ R15, R14
+sequenceDecs_decode_56_amd64_adjust_one:
+	MOVQ R12, AX
+	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
 
-sequenceDecs_decodeSync_amd64_adjust_end:
-	MOVQ R14, 8(SP)
+sequenceDecs_decode_56_amd64_adjust_two:
+	MOVQ R13, AX
+	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_56_amd64_adjust_three:
+	LEAQ -1(R11), AX
+
+sequenceDecs_decode_56_amd64_adjust_test_temp_valid:
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decode_56_amd64_adjust_temp_valid
+	MOVQ  $0x00000001, AX
+
+sequenceDecs_decode_56_amd64_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R12, R13
+	MOVQ    R11, R12
+	MOVQ    AX, R11
+	MOVQ    AX, CX
+
+sequenceDecs_decode_56_amd64_adjust_end:
+	MOVQ CX, 16(R10)
 
 	// Check values
-	MOVQ  16(SP), AX
-	MOVQ  24(SP), CX
-	LEAQ  (AX)(CX*1), R15
+	MOVQ  8(R10), AX
+	MOVQ  (R10), R14
+	LEAQ  (AX)(R14*1), R15
 	MOVQ  s+0(FP), BP
 	ADDQ  R15, 256(BP)
 	MOVQ  ctx+16(FP), R15
-	SUBQ  CX, 104(R15)
+	SUBQ  R14, 128(R15)
 	CMPQ  AX, $0x00020002
-	JA    sequenceDecs_decodeSync_amd64_error_match_len_too_big
-	TESTQ R14, R14
-	JNZ   sequenceDecs_decodeSync_amd64_match_len_ofs_ok
+	JA    sequenceDecs_decode_56_amd64_error_match_len_too_big
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_amd64_match_len_ofs_ok
 	TESTQ AX, AX
-	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
+	JNZ   sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch
 
-sequenceDecs_decodeSync_amd64_match_len_ofs_ok:
-execute_single_triple:
-	// Check if ll + ml < cap(out)
-	MOVQ 32(SP), AX
-	MOVQ 24(SP), CX
-	ADDQ 16(SP), CX
-	CMPQ CX, AX
-	JA   error_out_of_capacity
-
-	// Copy literals
-	MOVQ  24(SP), AX
-	TESTQ AX, AX
-	JZ    copy_match
-	XORQ  CX, CX
-
-copy_1:
-	MOVUPS (R12)(CX*1), X0
-	MOVUPS X0, (R11)(CX*1)
-	ADDQ   $0x10, CX
-	CMPQ   CX, AX
-	JB     copy_1
-	ADDQ   AX, R12
-	ADDQ   AX, R11
-	ADDQ   AX, R13
-
-	// Copy match
-copy_match:
-	MOVQ  16(SP), AX
-	TESTQ AX, AX
-	JZ    handle_loop
-	MOVQ  8(SP), CX
-
-	// Malformed input if seq.mo > t || seq.mo > s.windowSize
-	CMPQ CX, R13
-	JG   error_match_off_too_big
-	MOVQ R11, R14
-	SUBQ CX, R14
-
-	// ml <= mo
-	CMPQ AX, CX
-	JA   copy_overlapping_match
-
-	// Copy non-overlapping match
-	XORQ CX, CX
-
-copy_2:
-	MOVUPS (R14)(CX*1), X0
-	MOVUPS X0, (R11)(CX*1)
-	ADDQ   $0x10, CX
-	CMPQ   CX, AX
-	JB     copy_2
-	ADDQ   AX, R11
-	ADDQ   AX, R13
-	JMP    handle_loop
-
-	// Copy overlapping match
-copy_overlapping_match:
-	XORQ CX, CX
-
-copy_slow_3:
-	MOVB (R14)(CX*1), R15
-	MOVB R15, (R11)(CX*1)
-	INCQ CX
-	CMPQ CX, AX
-	JB   copy_slow_3
-	ADDQ AX, R11
-	ADDQ AX, R13
-
-handle_loop:
+sequenceDecs_decode_56_amd64_match_len_ofs_ok:
 	ADDQ $0x18, R10
 	MOVQ ctx+16(FP), AX
 	DECQ 96(AX)
-	JNS  sequenceDecs_decodeSync_amd64_main_loop
+	JNS  sequenceDecs_decode_56_amd64_main_loop
+	MOVQ s+0(FP), AX
+	MOVQ R11, 144(AX)
+	MOVQ R12, 152(AX)
+	MOVQ R13, 160(AX)
 	MOVQ br+8(FP), AX
 	MOVQ DX, 32(AX)
 	MOVB BL, 40(AX)
 	MOVQ SI, 24(AX)
-
-	// Update the context
-	MOVQ ctx+16(FP), AX
-	MOVQ R13, 136(AX)
-	MOVQ 144(AX), CX
-	SUBQ CX, R12
-	MOVQ R12, 168(AX)
 
 	// Return success
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
 	// Return with match length error
-sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch:
-	MOVQ 16(SP), AX
-	MOVQ ctx+16(FP), CX
-	MOVQ AX, 200(CX)
+sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch:
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
-	// Return with match length too long error
-sequenceDecs_decodeSync_amd64_error_match_len_too_big:
-	MOVQ 16(SP), AX
-	MOVQ ctx+16(FP), CX
-	MOVQ AX, 200(CX)
+	// Return with match too long error
+sequenceDecs_decode_56_amd64_error_match_len_too_big:
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
-	// Return with match offset too long error
-error_match_off_too_big:
-	MOVQ ctx+16(FP), AX
-	MOVQ 8(SP), CX
-	MOVQ CX, 208(AX)
-	MOVQ R13, 136(AX)
-	MOVQ $0x00000003, ret+24(FP)
-	RET
-
-	// Return request to resize `out` by at least ll + ml bytes
-error_out_of_capacity:
-	MOVQ ctx+16(FP), AX
-	MOVQ 24(SP), CX
-	MOVQ CX, 192(AX)
-	MOVQ 16(SP), CX
-	MOVQ CX, 200(AX)
-	MOVQ R13, 136(AX)
-	MOVQ br+8(FP), AX
-	MOVQ DX, 32(AX)
-	MOVB BL, 40(AX)
-	MOVQ SI, 24(AX)
-
-// func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
-// Requires: BMI, BMI2, CMOV, SSE
-TEXT ·sequenceDecs_decodeSync_bmi2(SB), $40-32
+// func sequenceDecs_decode_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
+// Requires: BMI, BMI2, CMOV
+TEXT ·sequenceDecs_decode_bmi2(SB), $8-32
 	MOVQ    br+8(FP), CX
 	MOVQ    32(CX), AX
 	MOVBQZX 40(CX), DX
@@ -1137,59 +574,44 @@ TEXT ·sequenceDecs_decodeSync_bmi2(SB), $40-32
 	MOVQ    (CX), CX
 	ADDQ    BX, CX
 	MOVQ    CX, (SP)
-	MOVQ    ctx+16(FP), R13
-	MOVQ    72(R13), SI
-	MOVQ    80(R13), DI
-	MOVQ    88(R13), R8
-	MOVQ    112(R13), R10
-	MOVQ    144(R13), R11
-	MOVQ    136(R13), R12
-	MOVQ    176(R13), CX
-	MOVQ    128(R13), CX
-	MOVQ    CX, 32(SP)
+	MOVQ    ctx+16(FP), CX
+	MOVQ    72(CX), SI
+	MOVQ    80(CX), DI
+	MOVQ    88(CX), R8
+	MOVQ    104(CX), R9
+	MOVQ    s+0(FP), CX
+	MOVQ    144(CX), R10
+	MOVQ    152(CX), R11
+	MOVQ    160(CX), R12
 
-	// outBase += outPosition
-	ADDQ R12, R10
-
-	// Check if we're retrying after `out` resize
-	CMPQ 184(R13), $0x01
-	JNE  sequenceDecs_decodeSync_bmi2_main_loop
-	MOVQ 192(R13), CX
-	MOVQ CX, 24(SP)
-	MOVQ 208(R13), CX
-	MOVQ CX, 8(SP)
-	MOVQ 200(R13), CX
-	MOVQ CX, 16(SP)
-	JMP  execute_single_triple
-
-sequenceDecs_decodeSync_bmi2_main_loop:
+sequenceDecs_decode_bmi2_main_loop:
 	MOVQ (SP), R13
 
-	// Fill bitreader to have enough for the offset.
-	CMPQ    DX, $0x20
-	JL      sequenceDecs_decodeSync_bmi2_fill_end
-	CMPQ    BX, $0x04
-	JL      sequenceDecs_decodeSync_bmi2_fill_byte_by_byte
-	SHLQ    $0x20, AX
-	SUBQ    $0x04, R13
-	SUBQ    $0x04, BX
-	SUBQ    $0x20, DX
-	MOVLQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decodeSync_bmi2_fill_end
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decode_bmi2_fill_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R13
+	MOVQ (R13), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decode_bmi2_fill_end
 
-sequenceDecs_decodeSync_bmi2_fill_byte_by_byte:
+sequenceDecs_decode_bmi2_fill_byte_by_byte:
 	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decodeSync_bmi2_fill_end
+	JLE     sequenceDecs_decode_bmi2_fill_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decode_bmi2_fill_end
 	SHLQ    $0x08, AX
 	SUBQ    $0x01, R13
 	SUBQ    $0x01, BX
 	SUBQ    $0x08, DX
 	MOVBQZX (R13), CX
 	ORQ     CX, AX
-	JMP     sequenceDecs_decodeSync_bmi2_fill_byte_by_byte
+	JMP     sequenceDecs_decode_bmi2_fill_byte_by_byte
 
-sequenceDecs_decodeSync_bmi2_fill_end:
+sequenceDecs_decode_bmi2_fill_end:
 	// Update offset
 	MOVQ   $0x00000808, CX
 	BEXTRQ CX, R8, R14
@@ -1201,33 +623,8 @@ sequenceDecs_decodeSync_bmi2_fill_end:
 	MOVQ   R8, CX
 	SHRQ   $0x20, CX
 	ADDQ   R15, CX
-	MOVQ   CX, 8(SP)
+	MOVQ   CX, 16(R9)
 
-	// Fill bitreader for match and literal
-	CMPQ    DX, $0x20
-	JL      sequenceDecs_decodeSync_bmi2_fill_2_end
-	CMPQ    BX, $0x04
-	JL      sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte
-	SHLQ    $0x20, AX
-	SUBQ    $0x04, R13
-	SUBQ    $0x04, BX
-	SUBQ    $0x20, DX
-	MOVLQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decodeSync_bmi2_fill_2_end
-
-sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decodeSync_bmi2_fill_2_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R13
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte
-
-sequenceDecs_decodeSync_bmi2_fill_2_end:
 	// Update match length
 	MOVQ   $0x00000808, CX
 	BEXTRQ CX, DI, R14
@@ -1239,8 +636,33 @@ sequenceDecs_decodeSync_bmi2_fill_2_end:
 	MOVQ   DI, CX
 	SHRQ   $0x20, CX
 	ADDQ   R15, CX
-	MOVQ   CX, 16(SP)
+	MOVQ   CX, 8(R9)
 
+	// Fill bitreader to have enough for the remaining
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decode_bmi2_fill_2_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R13
+	MOVQ (R13), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decode_bmi2_fill_2_end
+
+sequenceDecs_decode_bmi2_fill_2_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decode_bmi2_fill_2_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decode_bmi2_fill_2_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_bmi2_fill_2_byte_by_byte
+
+sequenceDecs_decode_bmi2_fill_2_end:
 	// Update literal length
 	MOVQ   $0x00000808, CX
 	BEXTRQ CX, SI, R14
@@ -1252,39 +674,15 @@ sequenceDecs_decodeSync_bmi2_fill_2_end:
 	MOVQ   SI, CX
 	SHRQ   $0x20, CX
 	ADDQ   R15, CX
-	MOVQ   CX, 24(SP)
+	MOVQ   CX, (R9)
 
 	// Fill bitreader for state updates
-	CMPQ    DX, $0x20
-	JL      sequenceDecs_decodeSync_bmi2_fill_3_end
-	CMPQ    BX, $0x04
-	JL      sequenceDecs_decodeSync_bmi2_fill_3_byte_by_byte
-	SHLQ    $0x20, AX
-	SUBQ    $0x04, R13
-	SUBQ    $0x04, BX
-	SUBQ    $0x20, DX
-	MOVLQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decodeSync_bmi2_fill_3_end
-
-sequenceDecs_decodeSync_bmi2_fill_3_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decodeSync_bmi2_fill_3_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R13
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decodeSync_bmi2_fill_3_byte_by_byte
-
-sequenceDecs_decodeSync_bmi2_fill_3_end:
 	MOVQ   R13, (SP)
 	MOVQ   $0x00000808, CX
 	BEXTRQ CX, R8, R13
 	MOVQ   ctx+16(FP), CX
 	CMPQ   96(CX), $0x00
-	JZ     sequenceDecs_decodeSync_bmi2_skip_update
+	JZ     sequenceDecs_decode_bmi2_skip_update
 
 	// Update Literal Length State
 	MOVBQZX SI, R14
@@ -1334,194 +732,603 @@ sequenceDecs_decodeSync_bmi2_fill_3_end:
 	MOVQ 48(CX), CX
 	MOVQ (CX)(R8*8), R8
 
-sequenceDecs_decodeSync_bmi2_skip_update:
+sequenceDecs_decode_bmi2_skip_update:
 	// Adjust offset
-	MOVQ   s+0(FP), CX
-	MOVQ   8(SP), R14
-	CMPQ   R13, $0x01
-	JBE    sequenceDecs_decodeSync_bmi2_adjust_offsetB_1_or_0
-	MOVUPS 144(CX), X0
-	MOVQ   R14, 144(CX)
-	MOVUPS X0, 152(CX)
-	JMP    sequenceDecs_decodeSync_bmi2_adjust_end
+	MOVQ 16(R9), CX
+	CMPQ R13, $0x01
+	JBE  sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0
+	MOVQ R11, R12
+	MOVQ R10, R11
+	MOVQ CX, R10
+	JMP  sequenceDecs_decode_bmi2_adjust_end
 
-sequenceDecs_decodeSync_bmi2_adjust_offsetB_1_or_0:
-	CMPQ 24(SP), $0x00000000
-	JNE  sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero
-	INCQ R14
-	JMP  sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
+sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0:
+	CMPQ (R9), $0x00000000
+	JNE  sequenceDecs_decode_bmi2_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decode_bmi2_adjust_offset_nonzero
 
-sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero:
-	TESTQ R14, R14
-	JNZ   sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
-	MOVQ  144(CX), R14
-	JMP   sequenceDecs_decodeSync_bmi2_adjust_end
+sequenceDecs_decode_bmi2_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_bmi2_adjust_offset_nonzero
+	MOVQ  R10, CX
+	JMP   sequenceDecs_decode_bmi2_adjust_end
 
-sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero:
-	MOVQ    R14, R13
-	XORQ    R15, R15
-	MOVQ    $-1, BP
-	CMPQ    R14, $0x03
-	CMOVQEQ R15, R13
-	CMOVQEQ BP, R15
-	LEAQ    144(CX), BP
-	ADDQ    (BP)(R13*8), R15
-	JNZ     sequenceDecs_decodeSync_bmi2_adjust_temp_valid
-	MOVQ    $0x00000001, R15
+sequenceDecs_decode_bmi2_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_bmi2_adjust_zero
+	JEQ  sequenceDecs_decode_bmi2_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_bmi2_adjust_three
+	JMP  sequenceDecs_decode_bmi2_adjust_two
 
-sequenceDecs_decodeSync_bmi2_adjust_temp_valid:
-	CMPQ R14, $0x01
-	JZ   sequenceDecs_decodeSync_bmi2_adjust_skip
-	MOVQ 152(CX), R13
-	MOVQ R13, 160(CX)
+sequenceDecs_decode_bmi2_adjust_zero:
+	MOVQ R10, R13
+	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
 
-sequenceDecs_decodeSync_bmi2_adjust_skip:
-	MOVQ 144(CX), R13
-	MOVQ R13, 152(CX)
-	MOVQ R15, 144(CX)
-	MOVQ R15, R14
+sequenceDecs_decode_bmi2_adjust_one:
+	MOVQ R11, R13
+	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
 
-sequenceDecs_decodeSync_bmi2_adjust_end:
-	MOVQ R14, 8(SP)
+sequenceDecs_decode_bmi2_adjust_two:
+	MOVQ R12, R13
+	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_bmi2_adjust_three:
+	LEAQ -1(R10), R13
+
+sequenceDecs_decode_bmi2_adjust_test_temp_valid:
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_bmi2_adjust_temp_valid
+	MOVQ  $0x00000001, R13
+
+sequenceDecs_decode_bmi2_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R11, R12
+	MOVQ    R10, R11
+	MOVQ    R13, R10
+	MOVQ    R13, CX
+
+sequenceDecs_decode_bmi2_adjust_end:
+	MOVQ CX, 16(R9)
 
 	// Check values
-	MOVQ  16(SP), CX
-	MOVQ  24(SP), R13
-	LEAQ  (CX)(R13*1), R15
+	MOVQ  8(R9), R13
+	MOVQ  (R9), R14
+	LEAQ  (R13)(R14*1), R15
 	MOVQ  s+0(FP), BP
 	ADDQ  R15, 256(BP)
 	MOVQ  ctx+16(FP), R15
-	SUBQ  R13, 104(R15)
-	CMPQ  CX, $0x00020002
-	JA    sequenceDecs_decodeSync_bmi2_error_match_len_too_big
-	TESTQ R14, R14
-	JNZ   sequenceDecs_decodeSync_bmi2_match_len_ofs_ok
+	SUBQ  R14, 128(R15)
+	CMPQ  R13, $0x00020002
+	JA    sequenceDecs_decode_bmi2_error_match_len_too_big
 	TESTQ CX, CX
-	JNZ   sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch
+	JNZ   sequenceDecs_decode_bmi2_match_len_ofs_ok
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch
 
-sequenceDecs_decodeSync_bmi2_match_len_ofs_ok:
-execute_single_triple:
-	// Check if ll + ml < cap(out)
-	MOVQ 32(SP), CX
-	MOVQ 24(SP), R13
-	ADDQ 16(SP), R13
-	CMPQ R13, CX
-	JA   error_out_of_capacity
-
-	// Copy literals
-	MOVQ  24(SP), CX
-	TESTQ CX, CX
-	JZ    copy_match
-	XORQ  R13, R13
-
-copy_1:
-	MOVUPS (R11)(R13*1), X0
-	MOVUPS X0, (R10)(R13*1)
-	ADDQ   $0x10, R13
-	CMPQ   R13, CX
-	JB     copy_1
-	ADDQ   CX, R11
-	ADDQ   CX, R10
-	ADDQ   CX, R12
-
-	// Copy match
-copy_match:
-	MOVQ  16(SP), CX
-	TESTQ CX, CX
-	JZ    handle_loop
-	MOVQ  8(SP), R13
-
-	// Malformed input if seq.mo > t || seq.mo > s.windowSize
-	CMPQ R13, R12
-	JG   error_match_off_too_big
-	MOVQ R10, R14
-	SUBQ R13, R14
-
-	// ml <= mo
-	CMPQ CX, R13
-	JA   copy_overlapping_match
-
-	// Copy non-overlapping match
-	XORQ R13, R13
-
-copy_2:
-	MOVUPS (R14)(R13*1), X0
-	MOVUPS X0, (R10)(R13*1)
-	ADDQ   $0x10, R13
-	CMPQ   R13, CX
-	JB     copy_2
-	ADDQ   CX, R10
-	ADDQ   CX, R12
-	JMP    handle_loop
-
-	// Copy overlapping match
-copy_overlapping_match:
-	XORQ R13, R13
-
-copy_slow_3:
-	MOVB (R14)(R13*1), R15
-	MOVB R15, (R10)(R13*1)
-	INCQ R13
-	CMPQ R13, CX
-	JB   copy_slow_3
-	ADDQ CX, R10
-	ADDQ CX, R12
-
-handle_loop:
+sequenceDecs_decode_bmi2_match_len_ofs_ok:
 	ADDQ $0x18, R9
 	MOVQ ctx+16(FP), CX
 	DECQ 96(CX)
-	JNS  sequenceDecs_decodeSync_bmi2_main_loop
+	JNS  sequenceDecs_decode_bmi2_main_loop
+	MOVQ s+0(FP), CX
+	MOVQ R10, 144(CX)
+	MOVQ R11, 152(CX)
+	MOVQ R12, 160(CX)
 	MOVQ br+8(FP), CX
 	MOVQ AX, 32(CX)
 	MOVB DL, 40(CX)
 	MOVQ BX, 24(CX)
-
-	// Update the context
-	MOVQ ctx+16(FP), AX
-	MOVQ R12, 136(AX)
-	MOVQ 144(AX), CX
-	SUBQ CX, R11
-	MOVQ R11, 168(AX)
 
 	// Return success
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
 	// Return with match length error
-sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch:
-	MOVQ 16(SP), AX
-	MOVQ ctx+16(FP), CX
-	MOVQ AX, 200(CX)
+sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch:
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
-	// Return with match length too long error
-sequenceDecs_decodeSync_bmi2_error_match_len_too_big:
-	MOVQ 16(SP), AX
-	MOVQ ctx+16(FP), CX
-	MOVQ AX, 200(CX)
+	// Return with match too long error
+sequenceDecs_decode_bmi2_error_match_len_too_big:
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
-	// Return with match offset too long error
-error_match_off_too_big:
-	MOVQ ctx+16(FP), AX
-	MOVQ 8(SP), CX
-	MOVQ CX, 208(AX)
-	MOVQ R12, 136(AX)
-	MOVQ $0x00000003, ret+24(FP)
-	RET
+// func sequenceDecs_decode_56_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
+// Requires: BMI, BMI2, CMOV
+TEXT ·sequenceDecs_decode_56_bmi2(SB), $8-32
+	MOVQ    br+8(FP), CX
+	MOVQ    32(CX), AX
+	MOVBQZX 40(CX), DX
+	MOVQ    24(CX), BX
+	MOVQ    (CX), CX
+	ADDQ    BX, CX
+	MOVQ    CX, (SP)
+	MOVQ    ctx+16(FP), CX
+	MOVQ    72(CX), SI
+	MOVQ    80(CX), DI
+	MOVQ    88(CX), R8
+	MOVQ    104(CX), R9
+	MOVQ    s+0(FP), CX
+	MOVQ    144(CX), R10
+	MOVQ    152(CX), R11
+	MOVQ    160(CX), R12
 
-	// Return request to resize `out` by at least ll + ml bytes
-error_out_of_capacity:
+sequenceDecs_decode_56_bmi2_main_loop:
+	MOVQ (SP), R13
+
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decode_56_bmi2_fill_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R13
+	MOVQ (R13), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decode_56_bmi2_fill_end
+
+sequenceDecs_decode_56_bmi2_fill_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decode_56_bmi2_fill_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decode_56_bmi2_fill_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_56_bmi2_fill_byte_by_byte
+
+sequenceDecs_decode_56_bmi2_fill_end:
+	// Update offset
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   R8, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, 16(R9)
+
+	// Update match length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, DI, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   DI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, 8(R9)
+
+	// Update literal length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, SI, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   SI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, (R9)
+
+	// Fill bitreader for state updates
+	MOVQ   R13, (SP)
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R13
+	MOVQ   ctx+16(FP), CX
+	CMPQ   96(CX), $0x00
+	JZ     sequenceDecs_decode_56_bmi2_skip_update
+
+	// Update Literal Length State
+	MOVBQZX SI, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, SI, SI
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, SI
+
+	// Load ctx.llTable
 	MOVQ ctx+16(FP), CX
-	MOVQ 24(SP), SI
-	MOVQ SI, 192(CX)
-	MOVQ 16(SP), SI
-	MOVQ SI, 200(CX)
-	MOVQ R12, 136(CX)
+	MOVQ (CX), CX
+	MOVQ (CX)(SI*8), SI
+
+	// Update Match Length State
+	MOVBQZX DI, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, DI, DI
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, DI
+
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Offset State
+	MOVBQZX R8, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, R8, R8
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, R8
+
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+sequenceDecs_decode_56_bmi2_skip_update:
+	// Adjust offset
+	MOVQ 16(R9), CX
+	CMPQ R13, $0x01
+	JBE  sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0
+	MOVQ R11, R12
+	MOVQ R10, R11
+	MOVQ CX, R10
+	JMP  sequenceDecs_decode_56_bmi2_adjust_end
+
+sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0:
+	CMPQ (R9), $0x00000000
+	JNE  sequenceDecs_decode_56_bmi2_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
+
+sequenceDecs_decode_56_bmi2_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
+	MOVQ  R10, CX
+	JMP   sequenceDecs_decode_56_bmi2_adjust_end
+
+sequenceDecs_decode_56_bmi2_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_56_bmi2_adjust_zero
+	JEQ  sequenceDecs_decode_56_bmi2_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_56_bmi2_adjust_three
+	JMP  sequenceDecs_decode_56_bmi2_adjust_two
+
+sequenceDecs_decode_56_bmi2_adjust_zero:
+	MOVQ R10, R13
+	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_56_bmi2_adjust_one:
+	MOVQ R11, R13
+	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_56_bmi2_adjust_two:
+	MOVQ R12, R13
+	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_56_bmi2_adjust_three:
+	LEAQ -1(R10), R13
+
+sequenceDecs_decode_56_bmi2_adjust_test_temp_valid:
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_56_bmi2_adjust_temp_valid
+	MOVQ  $0x00000001, R13
+
+sequenceDecs_decode_56_bmi2_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R11, R12
+	MOVQ    R10, R11
+	MOVQ    R13, R10
+	MOVQ    R13, CX
+
+sequenceDecs_decode_56_bmi2_adjust_end:
+	MOVQ CX, 16(R9)
+
+	// Check values
+	MOVQ  8(R9), R13
+	MOVQ  (R9), R14
+	LEAQ  (R13)(R14*1), R15
+	MOVQ  s+0(FP), BP
+	ADDQ  R15, 256(BP)
+	MOVQ  ctx+16(FP), R15
+	SUBQ  R14, 128(R15)
+	CMPQ  R13, $0x00020002
+	JA    sequenceDecs_decode_56_bmi2_error_match_len_too_big
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_bmi2_match_len_ofs_ok
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch
+
+sequenceDecs_decode_56_bmi2_match_len_ofs_ok:
+	ADDQ $0x18, R9
+	MOVQ ctx+16(FP), CX
+	DECQ 96(CX)
+	JNS  sequenceDecs_decode_56_bmi2_main_loop
+	MOVQ s+0(FP), CX
+	MOVQ R10, 144(CX)
+	MOVQ R11, 152(CX)
+	MOVQ R12, 160(CX)
 	MOVQ br+8(FP), CX
 	MOVQ AX, 32(CX)
 	MOVB DL, 40(CX)
 	MOVQ BX, 24(CX)
+
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
+	RET
+
+	// Return with match length error
+sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch:
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match too long error
+sequenceDecs_decode_56_bmi2_error_match_len_too_big:
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+// func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
+// Requires: SSE
+TEXT ·sequenceDecs_executeSimple_amd64(SB), $8-9
+	MOVQ  ctx+0(FP), DI
+	MOVQ  8(DI), CX
+	TESTQ CX, CX
+	JZ    empty_seqs
+	MOVQ  (DI), AX
+	MOVQ  24(DI), DX
+	MOVQ  32(DI), BX
+	MOVQ  40(DI), SI
+	MOVQ  80(DI), SI
+	MOVQ  104(DI), R8
+	MOVQ  120(DI), R9
+	MOVQ  56(DI), R10
+	MOVQ  64(DI), DI
+	ADDQ  DI, R10
+
+	// seqsBase += 24 * seqIndex
+	LEAQ (DX)(DX*2), R11
+	SHLQ $0x03, R11
+	ADDQ R11, AX
+
+	// outBase += outPosition
+	ADDQ R8, BX
+
+main_loop:
+	MOVQ (AX), R13
+	MOVQ 8(AX), R11
+	MOVQ 16(AX), R12
+
+	// Copy literals
+	TESTQ R13, R13
+	JZ    check_offset
+	XORQ  R14, R14
+	TESTQ $0x00000001, R13
+	JZ    copy_1_word
+	MOVB  (SI)(R14*1), R15
+	MOVB  R15, (BX)(R14*1)
+	ADDQ  $0x01, R14
+
+copy_1_word:
+	TESTQ $0x00000002, R13
+	JZ    copy_1_dword
+	MOVW  (SI)(R14*1), R15
+	MOVW  R15, (BX)(R14*1)
+	ADDQ  $0x02, R14
+
+copy_1_dword:
+	TESTQ $0x00000004, R13
+	JZ    copy_1_qword
+	MOVL  (SI)(R14*1), R15
+	MOVL  R15, (BX)(R14*1)
+	ADDQ  $0x04, R14
+
+copy_1_qword:
+	TESTQ $0x00000008, R13
+	JZ    copy_1_test
+	MOVQ  (SI)(R14*1), R15
+	MOVQ  R15, (BX)(R14*1)
+	ADDQ  $0x08, R14
+	JMP   copy_1_test
+
+copy_1:
+	MOVUPS (SI)(R14*1), X0
+	MOVUPS X0, (BX)(R14*1)
+	ADDQ   $0x10, R14
+
+copy_1_test:
+	CMPQ R14, R13
+	JB   copy_1
+	ADDQ R13, SI
+	ADDQ R13, BX
+	ADDQ R13, R8
+
+	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
+check_offset:
+	LEAQ (R8)(DI*1), R13
+	CMPQ R12, R13
+	JG   error_match_off_too_big
+	CMPQ R12, R9
+	JG   error_match_off_too_big
+
+	// Copy match from history
+	MOVQ  R12, R13
+	SUBQ  R8, R13
+	JLS   copy_match
+	MOVQ  R10, R14
+	SUBQ  R13, R14
+	CMPQ  R11, R13
+	JGE   copy_all_from_history
+	XORQ  R12, R12
+	TESTQ $0x00000001, R11
+	JZ    copy_4_word
+	MOVB  (R14)(R12*1), R13
+	MOVB  R13, (BX)(R12*1)
+	ADDQ  $0x01, R12
+
+copy_4_word:
+	TESTQ $0x00000002, R11
+	JZ    copy_4_dword
+	MOVW  (R14)(R12*1), R13
+	MOVW  R13, (BX)(R12*1)
+	ADDQ  $0x02, R12
+
+copy_4_dword:
+	TESTQ $0x00000004, R11
+	JZ    copy_4_qword
+	MOVL  (R14)(R12*1), R13
+	MOVL  R13, (BX)(R12*1)
+	ADDQ  $0x04, R12
+
+copy_4_qword:
+	TESTQ $0x00000008, R11
+	JZ    copy_4_test
+	MOVQ  (R14)(R12*1), R13
+	MOVQ  R13, (BX)(R12*1)
+	ADDQ  $0x08, R12
+	JMP   copy_4_test
+
+copy_4:
+	MOVUPS (R14)(R12*1), X0
+	MOVUPS X0, (BX)(R12*1)
+	ADDQ   $0x10, R12
+
+copy_4_test:
+	CMPQ R12, R11
+	JB   copy_4
+	ADDQ R11, R8
+	ADDQ R11, BX
+	ADDQ $0x18, AX
+	INCQ DX
+	CMPQ DX, CX
+	JB   main_loop
+	JMP  loop_finished
+
+copy_all_from_history:
+	XORQ  R15, R15
+	TESTQ $0x00000001, R13
+	JZ    copy_5_word
+	MOVB  (R14)(R15*1), BP
+	MOVB  BP, (BX)(R15*1)
+	ADDQ  $0x01, R15
+
+copy_5_word:
+	TESTQ $0x00000002, R13
+	JZ    copy_5_dword
+	MOVW  (R14)(R15*1), BP
+	MOVW  BP, (BX)(R15*1)
+	ADDQ  $0x02, R15
+
+copy_5_dword:
+	TESTQ $0x00000004, R13
+	JZ    copy_5_qword
+	MOVL  (R14)(R15*1), BP
+	MOVL  BP, (BX)(R15*1)
+	ADDQ  $0x04, R15
+
+copy_5_qword:
+	TESTQ $0x00000008, R13
+	JZ    copy_5_test
+	MOVQ  (R14)(R15*1), BP
+	MOVQ  BP, (BX)(R15*1)
+	ADDQ  $0x08, R15
+	JMP   copy_5_test
+
+copy_5:
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (BX)(R15*1)
+	ADDQ   $0x10, R15
+
+copy_5_test:
+	CMPQ R15, R13
+	JB   copy_5
+	ADDQ R13, BX
+	ADDQ R13, R8
+	SUBQ R13, R11
+
+	// Copy match from the current buffer
+copy_match:
+	TESTQ R11, R11
+	JZ    handle_loop
+	MOVQ  BX, R13
+	SUBQ  R12, R13
+
+	// ml <= mo
+	CMPQ R11, R12
+	JA   copy_overlapping_match
+
+	// Copy non-overlapping match
+	XORQ R12, R12
+
+copy_2:
+	MOVUPS (R13)(R12*1), X0
+	MOVUPS X0, (BX)(R12*1)
+	ADDQ   $0x10, R12
+	CMPQ   R12, R11
+	JB     copy_2
+	ADDQ   R11, BX
+	ADDQ   R11, R8
+	JMP    handle_loop
+
+	// Copy overlapping match
+copy_overlapping_match:
+	XORQ R12, R12
+
+copy_slow_3:
+	MOVB (R13)(R12*1), R14
+	MOVB R14, (BX)(R12*1)
+	INCQ R12
+	CMPQ R12, R11
+	JB   copy_slow_3
+	ADDQ R11, BX
+	ADDQ R11, R8
+
+handle_loop:
+	ADDQ $0x18, AX
+	INCQ DX
+	CMPQ DX, CX
+	JB   main_loop
+
+loop_finished:
+	// Return value
+	MOVB $0x01, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R8, 104(AX)
+	MOVQ 80(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 112(AX)
+	RET
+
+error_match_off_too_big:
+	// Return value
+	MOVB $0x00, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R8, 104(AX)
+	MOVQ 80(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 112(AX)
+	RET
+
+empty_seqs:
+	// Return value
+	MOVB $0x01, ret+8(FP)
+	RET

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -5,7 +5,7 @@
 
 // func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
 // Requires: CMOV, SSE
-TEXT ·sequenceDecs_decodeSync_amd64(SB), $80-32
+TEXT ·sequenceDecs_decodeSync_amd64(SB), $72-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
 	MOVBQZX 40(AX), BX
@@ -20,19 +20,18 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $80-32
 	MOVQ    112(AX), R10
 	MOVQ    144(AX), CX
 	MOVQ    CX, 40(SP)
-	MOVQ    136(AX), CX
-	MOVQ    CX, 48(SP)
+	MOVQ    136(AX), R11
 	MOVQ    200(AX), CX
-	MOVQ    CX, 72(SP)
-	MOVQ    176(AX), CX
 	MOVQ    CX, 64(SP)
-	MOVQ    184(AX), CX
+	MOVQ    176(AX), CX
 	MOVQ    CX, 56(SP)
-	MOVQ    56(SP), CX
-	ADDQ    CX, 64(SP)
+	MOVQ    184(AX), CX
+	MOVQ    CX, 48(SP)
+	MOVQ    48(SP), CX
+	ADDQ    CX, 56(SP)
 
 	// outBase += outPosition
-	ADDQ 48(SP), R10
+	ADDQ R11, R10
 	MOVQ 128(AX), CX
 	MOVQ CX, 32(SP)
 
@@ -49,15 +48,15 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $80-32
 	MOVQ s+0(FP), AX
 
 sequenceDecs_decodeSync_amd64_main_loop:
-	MOVQ (SP), R11
+	MOVQ (SP), R12
 
 	// Fill bitreader to have enough for the offset and match length.
 	CMPQ SI, $0x08
 	JL   sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R11
-	MOVQ (R11), DX
+	SUBQ AX, R12
+	MOVQ (R12), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_end
@@ -68,10 +67,10 @@ sequenceDecs_decodeSync_amd64_fill_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R11
+	SUBQ    $0x01, R12
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R11), AX
+	MOVBQZX (R12), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 
@@ -79,31 +78,31 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	// Update offset
 	MOVQ    R9, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
+	MOVQ    DX, R13
+	SHLQ    CL, R13
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R12
+	SHRQ    CL, R13
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R12
-	ADDQ    R12, AX
+	CMOVQEQ CX, R13
+	ADDQ    R13, AX
 	MOVQ    AX, 8(SP)
 
 	// Update match length
 	MOVQ    R8, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
+	MOVQ    DX, R13
+	SHLQ    CL, R13
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R12
+	SHRQ    CL, R13
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R12
-	ADDQ    R12, AX
+	CMOVQEQ CX, R13
+	ADDQ    R13, AX
 	MOVQ    AX, 16(SP)
 
 	// Fill bitreader to have enough for the remaining
@@ -111,8 +110,8 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	JL   sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R11
-	MOVQ (R11), DX
+	SUBQ AX, R12
+	MOVQ (R12), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_2_end
@@ -123,10 +122,10 @@ sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R11
+	SUBQ    $0x01, R12
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R11), AX
+	MOVBQZX (R12), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 
@@ -134,20 +133,20 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	// Update literal length
 	MOVQ    DI, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
+	MOVQ    DX, R13
+	SHLQ    CL, R13
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R12
+	SHRQ    CL, R13
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R12
-	ADDQ    R12, AX
+	CMOVQEQ CX, R13
+	ADDQ    R13, AX
 	MOVQ    AX, 24(SP)
 
 	// Fill bitreader for state updates
-	MOVQ    R11, (SP)
+	MOVQ    R12, (SP)
 	MOVQ    R9, AX
 	SHRQ    $0x08, AX
 	MOVBQZX AL, AX
@@ -156,19 +155,19 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	JZ      sequenceDecs_decodeSync_amd64_skip_update
 
 	// Update Literal Length State
-	MOVBQZX DI, R11
+	MOVBQZX DI, R12
 	SHRQ    $0x10, DI
 	MOVWQZX DI, DI
-	CMPQ    R11, $0x00
+	CMPQ    R12, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R11, BX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
-	MOVQ    R11, CX
+	ADDQ    R12, BX
+	MOVQ    DX, R13
+	SHLQ    CL, R13
+	MOVQ    R12, CX
 	NEGQ    CX
-	SHRQ    CL, R12
-	ADDQ    R12, DI
+	SHRQ    CL, R13
+	ADDQ    R13, DI
 
 sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	// Load ctx.llTable
@@ -177,19 +176,19 @@ sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	MOVQ (CX)(DI*8), DI
 
 	// Update Match Length State
-	MOVBQZX R8, R11
+	MOVBQZX R8, R12
 	SHRQ    $0x10, R8
 	MOVWQZX R8, R8
-	CMPQ    R11, $0x00
+	CMPQ    R12, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R11, BX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
-	MOVQ    R11, CX
+	ADDQ    R12, BX
+	MOVQ    DX, R13
+	SHLQ    CL, R13
+	MOVQ    R12, CX
 	NEGQ    CX
-	SHRQ    CL, R12
-	ADDQ    R12, R8
+	SHRQ    CL, R13
+	ADDQ    R13, R8
 
 sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	// Load ctx.mlTable
@@ -198,19 +197,19 @@ sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	MOVQ (CX)(R8*8), R8
 
 	// Update Offset State
-	MOVBQZX R9, R11
+	MOVBQZX R9, R12
 	SHRQ    $0x10, R9
 	MOVWQZX R9, R9
-	CMPQ    R11, $0x00
+	CMPQ    R12, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R11, BX
-	MOVQ    DX, R12
-	SHLQ    CL, R12
-	MOVQ    R11, CX
+	ADDQ    R12, BX
+	MOVQ    DX, R13
+	SHLQ    CL, R13
+	MOVQ    R12, CX
 	NEGQ    CX
-	SHRQ    CL, R12
-	ADDQ    R12, R9
+	SHRQ    CL, R13
+	ADDQ    R13, R9
 
 sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 	// Load ctx.ofTable
@@ -221,40 +220,40 @@ sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 sequenceDecs_decodeSync_amd64_skip_update:
 	// Adjust offset
 	MOVQ   s+0(FP), CX
-	MOVQ   8(SP), R11
+	MOVQ   8(SP), R12
 	CMPQ   AX, $0x01
 	JBE    sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
 	MOVUPS 144(CX), X0
-	MOVQ   R11, 144(CX)
+	MOVQ   R12, 144(CX)
 	MOVUPS X0, 152(CX)
 	JMP    sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
 	CMPQ 24(SP), $0x00000000
 	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
-	INCQ R11
+	INCQ R12
 	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
 
 sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
-	TESTQ R11, R11
+	TESTQ R12, R12
 	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
-	MOVQ  144(CX), R11
+	MOVQ  144(CX), R12
 	JMP   sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
-	MOVQ    R11, AX
-	XORQ    R12, R12
-	MOVQ    $-1, R14
-	CMPQ    R11, $0x03
-	CMOVQEQ R12, AX
-	CMOVQEQ R14, R12
-	LEAQ    144(CX), R14
-	ADDQ    (R14)(AX*8), R12
+	MOVQ    R12, AX
+	XORQ    R13, R13
+	MOVQ    $-1, R15
+	CMPQ    R12, $0x03
+	CMOVQEQ R13, AX
+	CMOVQEQ R15, R13
+	LEAQ    144(CX), R15
+	ADDQ    (R15)(AX*8), R13
 	JNZ     sequenceDecs_decodeSync_amd64_adjust_temp_valid
-	MOVQ    $0x00000001, R12
+	MOVQ    $0x00000001, R13
 
 sequenceDecs_decodeSync_amd64_adjust_temp_valid:
-	CMPQ R11, $0x01
+	CMPQ R12, $0x01
 	JZ   sequenceDecs_decodeSync_amd64_adjust_skip
 	MOVQ 152(CX), AX
 	MOVQ AX, 160(CX)
@@ -262,23 +261,23 @@ sequenceDecs_decodeSync_amd64_adjust_temp_valid:
 sequenceDecs_decodeSync_amd64_adjust_skip:
 	MOVQ 144(CX), AX
 	MOVQ AX, 152(CX)
-	MOVQ R12, 144(CX)
-	MOVQ R12, R11
+	MOVQ R13, 144(CX)
+	MOVQ R13, R12
 
 sequenceDecs_decodeSync_amd64_adjust_end:
-	MOVQ R11, 8(SP)
+	MOVQ R12, 8(SP)
 
 	// Check values
 	MOVQ  16(SP), AX
 	MOVQ  24(SP), CX
-	LEAQ  (AX)(CX*1), R12
-	MOVQ  s+0(FP), R14
-	ADDQ  R12, 256(R14)
-	MOVQ  ctx+16(FP), R12
-	SUBQ  CX, 104(R12)
+	LEAQ  (AX)(CX*1), R13
+	MOVQ  s+0(FP), R15
+	ADDQ  R13, 256(R15)
+	MOVQ  ctx+16(FP), R13
+	SUBQ  CX, 104(R13)
 	CMPQ  AX, $0x00020002
 	JA    sequenceDecs_decodeSync_amd64_error_match_len_too_big
-	TESTQ R11, R11
+	TESTQ R12, R12
 	JNZ   sequenceDecs_decodeSync_amd64_match_len_ofs_ok
 	TESTQ AX, AX
 	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
@@ -297,148 +296,148 @@ execute_single_triple:
 	TESTQ AX, AX
 	JZ    check_offset
 	MOVQ  40(SP), CX
-	XORQ  R11, R11
+	XORQ  R12, R12
 	TESTQ $0x00000001, AX
 	JZ    copy_1_word
-	MOVB  (CX)(R11*1), R12
-	MOVB  R12, (R10)(R11*1)
-	ADDQ  $0x01, R11
+	MOVB  (CX)(R12*1), R13
+	MOVB  R13, (R10)(R12*1)
+	ADDQ  $0x01, R12
 
 copy_1_word:
 	TESTQ $0x00000002, AX
 	JZ    copy_1_dword
-	MOVW  (CX)(R11*1), R12
-	MOVW  R12, (R10)(R11*1)
-	ADDQ  $0x02, R11
+	MOVW  (CX)(R12*1), R13
+	MOVW  R13, (R10)(R12*1)
+	ADDQ  $0x02, R12
 
 copy_1_dword:
 	TESTQ $0x00000004, AX
 	JZ    copy_1_qword
-	MOVL  (CX)(R11*1), R12
-	MOVL  R12, (R10)(R11*1)
-	ADDQ  $0x04, R11
+	MOVL  (CX)(R12*1), R13
+	MOVL  R13, (R10)(R12*1)
+	ADDQ  $0x04, R12
 
 copy_1_qword:
 	TESTQ $0x00000008, AX
 	JZ    copy_1_test
-	MOVQ  (CX)(R11*1), R12
-	MOVQ  R12, (R10)(R11*1)
-	ADDQ  $0x08, R11
+	MOVQ  (CX)(R12*1), R13
+	MOVQ  R13, (R10)(R12*1)
+	ADDQ  $0x08, R12
 	JMP   copy_1_test
 
 copy_1:
-	MOVUPS (CX)(R11*1), X0
-	MOVUPS X0, (R10)(R11*1)
-	ADDQ   $0x10, R11
+	MOVUPS (CX)(R12*1), X0
+	MOVUPS X0, (R10)(R12*1)
+	ADDQ   $0x10, R12
 
 copy_1_test:
-	CMPQ R11, AX
+	CMPQ R12, AX
 	JB   copy_1
 	ADDQ AX, 40(SP)
 	ADDQ AX, R10
-	ADDQ AX, 48(SP)
-	MOVQ 8(SP), R13
+	ADDQ AX, R11
+	MOVQ 8(SP), R14
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
 check_offset:
-	MOVQ 48(SP), AX
-	ADDQ 56(SP), AX
-	CMPQ R13, AX
+	MOVQ R11, AX
+	ADDQ 48(SP), AX
+	CMPQ R14, AX
 	JG   error_match_off_too_big
-	CMPQ R13, 72(SP)
+	CMPQ R14, 64(SP)
 	JG   error_match_off_too_big
 	MOVQ 16(SP), AX
 
 	// Copy match from history
-	MOVQ  R13, CX
-	SUBQ  48(SP), CX
+	MOVQ  R14, CX
+	SUBQ  R11, CX
 	JLS   copy_match
-	MOVQ  64(SP), R11
-	SUBQ  CX, R11
+	MOVQ  56(SP), R12
+	SUBQ  CX, R12
 	CMPQ  AX, CX
 	JGE   copy_all_from_history
 	XORQ  CX, CX
 	TESTQ $0x00000001, AX
 	JZ    copy_4_word
-	MOVB  (R11)(CX*1), R12
-	MOVB  R12, (R10)(CX*1)
+	MOVB  (R12)(CX*1), R13
+	MOVB  R13, (R10)(CX*1)
 	ADDQ  $0x01, CX
 
 copy_4_word:
 	TESTQ $0x00000002, AX
 	JZ    copy_4_dword
-	MOVW  (R11)(CX*1), R12
-	MOVW  R12, (R10)(CX*1)
+	MOVW  (R12)(CX*1), R13
+	MOVW  R13, (R10)(CX*1)
 	ADDQ  $0x02, CX
 
 copy_4_dword:
 	TESTQ $0x00000004, AX
 	JZ    copy_4_qword
-	MOVL  (R11)(CX*1), R12
-	MOVL  R12, (R10)(CX*1)
+	MOVL  (R12)(CX*1), R13
+	MOVL  R13, (R10)(CX*1)
 	ADDQ  $0x04, CX
 
 copy_4_qword:
 	TESTQ $0x00000008, AX
 	JZ    copy_4_test
-	MOVQ  (R11)(CX*1), R12
-	MOVQ  R12, (R10)(CX*1)
+	MOVQ  (R12)(CX*1), R13
+	MOVQ  R13, (R10)(CX*1)
 	ADDQ  $0x08, CX
 	JMP   copy_4_test
 
 copy_4:
-	MOVUPS (R11)(CX*1), X0
+	MOVUPS (R12)(CX*1), X0
 	MOVUPS X0, (R10)(CX*1)
 	ADDQ   $0x10, CX
 
 copy_4_test:
 	CMPQ CX, AX
 	JB   copy_4
-	ADDQ AX, 48(SP)
+	ADDQ AX, R11
 	ADDQ AX, R10
 	JMP  handle_loop
 	JMP loop_finished
 
 copy_all_from_history:
-	XORQ  R12, R12
+	XORQ  R13, R13
 	TESTQ $0x00000001, CX
 	JZ    copy_5_word
-	MOVB  (R11)(R12*1), R14
-	MOVB  R14, (R10)(R12*1)
-	ADDQ  $0x01, R12
+	MOVB  (R12)(R13*1), R15
+	MOVB  R15, (R10)(R13*1)
+	ADDQ  $0x01, R13
 
 copy_5_word:
 	TESTQ $0x00000002, CX
 	JZ    copy_5_dword
-	MOVW  (R11)(R12*1), R14
-	MOVW  R14, (R10)(R12*1)
-	ADDQ  $0x02, R12
+	MOVW  (R12)(R13*1), R15
+	MOVW  R15, (R10)(R13*1)
+	ADDQ  $0x02, R13
 
 copy_5_dword:
 	TESTQ $0x00000004, CX
 	JZ    copy_5_qword
-	MOVL  (R11)(R12*1), R14
-	MOVL  R14, (R10)(R12*1)
-	ADDQ  $0x04, R12
+	MOVL  (R12)(R13*1), R15
+	MOVL  R15, (R10)(R13*1)
+	ADDQ  $0x04, R13
 
 copy_5_qword:
 	TESTQ $0x00000008, CX
 	JZ    copy_5_test
-	MOVQ  (R11)(R12*1), R14
-	MOVQ  R14, (R10)(R12*1)
-	ADDQ  $0x08, R12
+	MOVQ  (R12)(R13*1), R15
+	MOVQ  R15, (R10)(R13*1)
+	ADDQ  $0x08, R13
 	JMP   copy_5_test
 
 copy_5:
-	MOVUPS (R11)(R12*1), X0
-	MOVUPS X0, (R10)(R12*1)
-	ADDQ   $0x10, R12
+	MOVUPS (R12)(R13*1), X0
+	MOVUPS X0, (R10)(R13*1)
+	ADDQ   $0x10, R13
 
 copy_5_test:
-	CMPQ R12, CX
+	CMPQ R13, CX
 	JB   copy_5
 	ADDQ CX, R10
-	ADDQ CX, 48(SP)
+	ADDQ CX, R11
 	SUBQ CX, AX
 
 	// Copy match from the current buffer
@@ -446,37 +445,37 @@ copy_match:
 	TESTQ AX, AX
 	JZ    handle_loop
 	MOVQ  R10, CX
-	SUBQ  R13, CX
+	SUBQ  R14, CX
 
 	// ml <= mo
-	CMPQ AX, R13
+	CMPQ AX, R14
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R11, R11
+	XORQ R12, R12
 
 copy_2:
-	MOVUPS (CX)(R11*1), X0
-	MOVUPS X0, (R10)(R11*1)
-	ADDQ   $0x10, R11
-	CMPQ   R11, AX
+	MOVUPS (CX)(R12*1), X0
+	MOVUPS X0, (R10)(R12*1)
+	ADDQ   $0x10, R12
+	CMPQ   R12, AX
 	JB     copy_2
 	ADDQ   AX, R10
-	ADDQ   AX, 48(SP)
+	ADDQ   AX, R11
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ R11, R11
+	XORQ R12, R12
 
 copy_slow_3:
-	MOVB (CX)(R11*1), R12
-	MOVB R12, (R10)(R11*1)
-	INCQ R11
-	CMPQ R11, AX
+	MOVB (CX)(R12*1), R13
+	MOVB R13, (R10)(R12*1)
+	INCQ R12
+	CMPQ R12, AX
 	JB   copy_slow_3
 	ADDQ AX, R10
-	ADDQ AX, 48(SP)
+	ADDQ AX, R11
 
 handle_loop:
 	MOVQ ctx+16(FP), AX
@@ -515,8 +514,7 @@ error_match_off_too_big:
 	MOVQ ctx+16(FP), AX
 	MOVQ 8(SP), CX
 	MOVQ CX, 232(AX)
-	MOVQ 48(SP), CX
-	MOVQ CX, 136(AX)
+	MOVQ R11, 136(AX)
 	MOVQ $0x00000003, ret+24(FP)
 	RET
 
@@ -527,8 +525,7 @@ error_out_of_capacity:
 	MOVQ CX, 216(AX)
 	MOVQ 16(SP), CX
 	MOVQ CX, 224(AX)
-	MOVQ 48(SP), CX
-	MOVQ CX, 136(AX)
+	MOVQ R11, 136(AX)
 	MOVQ br+8(FP), AX
 	MOVQ DX, 32(AX)
 	MOVB BL, 40(AX)

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -303,7 +303,7 @@ sequenceDecs_decode_amd64_error_match_len_too_big:
 
 	// Return with not enough literals error
 error_not_enough_literals:
-	MOVQ $0x00000005, ret+24(FP)
+	MOVQ $0x00000004, ret+24(FP)
 	RET
 
 // func sequenceDecs_decode_56_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
@@ -581,7 +581,7 @@ sequenceDecs_decode_56_amd64_error_match_len_too_big:
 
 	// Return with not enough literals error
 error_not_enough_literals:
-	MOVQ $0x00000005, ret+24(FP)
+	MOVQ $0x00000004, ret+24(FP)
 	RET
 
 // func sequenceDecs_decode_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
@@ -862,7 +862,7 @@ sequenceDecs_decode_bmi2_error_match_len_too_big:
 
 	// Return with not enough literals error
 error_not_enough_literals:
-	MOVQ $0x00000005, ret+24(FP)
+	MOVQ $0x00000004, ret+24(FP)
 	RET
 
 // func sequenceDecs_decode_56_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
@@ -1118,7 +1118,7 @@ sequenceDecs_decode_56_bmi2_error_match_len_too_big:
 
 	// Return with not enough literals error
 error_not_enough_literals:
-	MOVQ $0x00000005, ret+24(FP)
+	MOVQ $0x00000004, ret+24(FP)
 	RET
 
 // func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
@@ -1403,7 +1403,7 @@ empty_seqs:
 
 // func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
 // Requires: CMOV, SSE
-TEXT ·sequenceDecs_decodeSync_amd64(SB), $64-32
+TEXT ·sequenceDecs_decodeSync_amd64(SB), $56-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
 	MOVBQZX 40(AX), BX
@@ -1416,34 +1416,19 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $64-32
 	MOVQ    80(AX), R8
 	MOVQ    88(AX), R9
 	MOVQ    112(AX), R10
-	MOVQ    128(AX), CX
-	MOVQ    CX, 32(SP)
 	MOVQ    144(AX), R11
 	MOVQ    136(AX), R12
 	MOVQ    200(AX), CX
-	MOVQ    CX, 56(SP)
-	MOVQ    176(AX), CX
 	MOVQ    CX, 48(SP)
-	MOVQ    184(AX), CX
+	MOVQ    176(AX), CX
 	MOVQ    CX, 40(SP)
-	MOVQ    40(SP), CX
-	ADDQ    CX, 48(SP)
+	MOVQ    184(AX), AX
+	MOVQ    AX, 32(SP)
+	MOVQ    32(SP), AX
+	ADDQ    AX, 40(SP)
 
 	// outBase += outPosition
 	ADDQ R12, R10
-
-	// Check if we're retrying after `out` resize
-	CMPQ 208(AX), $0x01
-	JNE  sequenceDecs_decodeSync_amd64_main_loop
-	MOVQ 216(AX), CX
-	MOVQ CX, 24(SP)
-	MOVQ 232(AX), CX
-	MOVQ CX, 8(SP)
-	MOVQ 224(AX), CX
-	MOVQ CX, 16(SP)
-	MOVQ 168(AX), AX
-	ADDQ AX, R11
-	JMP  execute_single_triple
 
 sequenceDecs_decodeSync_amd64_main_loop:
 	MOVQ (SP), R13
@@ -1682,16 +1667,9 @@ sequenceDecs_decodeSync_amd64_adjust_end:
 	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
 
 sequenceDecs_decodeSync_amd64_match_len_ofs_ok:
-execute_single_triple:
 	MOVQ 24(SP), AX
 	MOVQ 8(SP), CX
 	MOVQ 16(SP), R13
-
-	// Check if ll + ml + outPosition < cap(out)
-	LEAQ (AX)(R13*1), R14
-	ADDQ R12, R14
-	CMPQ R14, 32(SP)
-	JA   error_out_of_capacity
 
 	// Copy literals
 	TESTQ AX, AX
@@ -1740,17 +1718,17 @@ copy_1_test:
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
 check_offset:
 	MOVQ R12, AX
-	ADDQ 40(SP), AX
+	ADDQ 32(SP), AX
 	CMPQ CX, AX
 	JG   error_match_off_too_big
-	CMPQ CX, 56(SP)
+	CMPQ CX, 48(SP)
 	JG   error_match_off_too_big
 
 	// Copy match from history
 	MOVQ  CX, AX
 	SUBQ  R12, AX
 	JLS   copy_match
-	MOVQ  48(SP), R14
+	MOVQ  40(SP), R14
 	SUBQ  AX, R14
 	CMPQ  R13, AX
 	JGE   copy_all_from_history
@@ -1930,7 +1908,7 @@ loop_finished:
 sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch:
 	MOVQ 16(SP), AX
 	MOVQ ctx+16(FP), CX
-	MOVQ AX, 224(CX)
+	MOVQ AX, 216(CX)
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
@@ -1938,7 +1916,7 @@ sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch:
 sequenceDecs_decodeSync_amd64_error_match_len_too_big:
 	MOVQ ctx+16(FP), AX
 	MOVQ 16(SP), CX
-	MOVQ CX, 224(AX)
+	MOVQ CX, 216(AX)
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
@@ -1946,7 +1924,7 @@ sequenceDecs_decodeSync_amd64_error_match_len_too_big:
 error_match_off_too_big:
 	MOVQ ctx+16(FP), AX
 	MOVQ 8(SP), CX
-	MOVQ CX, 232(AX)
+	MOVQ CX, 224(AX)
 	MOVQ R12, 136(AX)
 	MOVQ $0x00000003, ret+24(FP)
 	RET
@@ -1955,36 +1933,13 @@ error_match_off_too_big:
 error_not_enough_literals:
 	MOVQ ctx+16(FP), AX
 	MOVQ 24(SP), CX
-	MOVQ CX, 216(AX)
-	MOVQ $0x00000005, ret+24(FP)
-	RET
-
-	// Return request to resize `out` by at least ll + ml bytes
-error_out_of_capacity:
-	MOVQ ctx+16(FP), AX
-	MOVQ 24(SP), CX
-	MOVQ CX, 216(AX)
-	MOVQ 8(SP), CX
-	MOVQ CX, 232(AX)
-	MOVQ 16(SP), CX
-	MOVQ CX, 224(AX)
-	MOVQ R12, 136(AX)
-	MOVQ DI, 72(AX)
-	MOVQ R8, 80(AX)
-	MOVQ R9, 88(AX)
-	MOVQ 144(AX), CX
-	SUBQ CX, R11
-	MOVQ R11, 168(AX)
-	MOVQ br+8(FP), AX
-	MOVQ DX, 32(AX)
-	MOVB BL, 40(AX)
-	MOVQ SI, 24(AX)
+	MOVQ CX, 208(AX)
 	MOVQ $0x00000004, ret+24(FP)
 	RET
 
 // func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
 // Requires: BMI, BMI2, CMOV, SSE
-TEXT ·sequenceDecs_decodeSync_bmi2(SB), $64-32
+TEXT ·sequenceDecs_decodeSync_bmi2(SB), $56-32
 	MOVQ    br+8(FP), CX
 	MOVQ    32(CX), AX
 	MOVBQZX 40(CX), DX
@@ -1997,34 +1952,19 @@ TEXT ·sequenceDecs_decodeSync_bmi2(SB), $64-32
 	MOVQ    80(CX), DI
 	MOVQ    88(CX), R8
 	MOVQ    112(CX), R9
-	MOVQ    128(CX), R10
-	MOVQ    R10, 32(SP)
 	MOVQ    144(CX), R10
 	MOVQ    136(CX), R11
 	MOVQ    200(CX), R12
-	MOVQ    R12, 56(SP)
-	MOVQ    176(CX), R12
 	MOVQ    R12, 48(SP)
-	MOVQ    184(CX), R12
+	MOVQ    176(CX), R12
 	MOVQ    R12, 40(SP)
-	MOVQ    40(SP), R12
-	ADDQ    R12, 48(SP)
+	MOVQ    184(CX), CX
+	MOVQ    CX, 32(SP)
+	MOVQ    32(SP), CX
+	ADDQ    CX, 40(SP)
 
 	// outBase += outPosition
 	ADDQ R11, R9
-
-	// Check if we're retrying after `out` resize
-	CMPQ 208(CX), $0x01
-	JNE  sequenceDecs_decodeSync_bmi2_main_loop
-	MOVQ 216(CX), R12
-	MOVQ R12, 24(SP)
-	MOVQ 232(CX), R12
-	MOVQ R12, 8(SP)
-	MOVQ 224(CX), R12
-	MOVQ R12, 16(SP)
-	MOVQ 168(CX), CX
-	ADDQ CX, R10
-	JMP  execute_single_triple
 
 sequenceDecs_decodeSync_bmi2_main_loop:
 	MOVQ (SP), R12
@@ -2241,16 +2181,9 @@ sequenceDecs_decodeSync_bmi2_adjust_end:
 	JNZ   sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch
 
 sequenceDecs_decodeSync_bmi2_match_len_ofs_ok:
-execute_single_triple:
 	MOVQ 24(SP), CX
 	MOVQ 8(SP), R12
 	MOVQ 16(SP), R13
-
-	// Check if ll + ml + outPosition < cap(out)
-	LEAQ (CX)(R13*1), R14
-	ADDQ R11, R14
-	CMPQ R14, 32(SP)
-	JA   error_out_of_capacity
 
 	// Copy literals
 	TESTQ CX, CX
@@ -2299,17 +2232,17 @@ copy_1_test:
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
 check_offset:
 	MOVQ R11, CX
-	ADDQ 40(SP), CX
+	ADDQ 32(SP), CX
 	CMPQ R12, CX
 	JG   error_match_off_too_big
-	CMPQ R12, 56(SP)
+	CMPQ R12, 48(SP)
 	JG   error_match_off_too_big
 
 	// Copy match from history
 	MOVQ  R12, CX
 	SUBQ  R11, CX
 	JLS   copy_match
-	MOVQ  48(SP), R14
+	MOVQ  40(SP), R14
 	SUBQ  CX, R14
 	CMPQ  R13, CX
 	JGE   copy_all_from_history
@@ -2489,7 +2422,7 @@ loop_finished:
 sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch:
 	MOVQ 16(SP), AX
 	MOVQ ctx+16(FP), CX
-	MOVQ AX, 224(CX)
+	MOVQ AX, 216(CX)
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
@@ -2497,7 +2430,7 @@ sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch:
 sequenceDecs_decodeSync_bmi2_error_match_len_too_big:
 	MOVQ ctx+16(FP), AX
 	MOVQ 16(SP), CX
-	MOVQ CX, 224(AX)
+	MOVQ CX, 216(AX)
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
@@ -2505,7 +2438,7 @@ sequenceDecs_decodeSync_bmi2_error_match_len_too_big:
 error_match_off_too_big:
 	MOVQ ctx+16(FP), AX
 	MOVQ 8(SP), CX
-	MOVQ CX, 232(AX)
+	MOVQ CX, 224(AX)
 	MOVQ R11, 136(AX)
 	MOVQ $0x00000003, ret+24(FP)
 	RET
@@ -2514,29 +2447,6 @@ error_match_off_too_big:
 error_not_enough_literals:
 	MOVQ ctx+16(FP), AX
 	MOVQ 24(SP), CX
-	MOVQ CX, 216(AX)
-	MOVQ $0x00000005, ret+24(FP)
-	RET
-
-	// Return request to resize `out` by at least ll + ml bytes
-error_out_of_capacity:
-	MOVQ ctx+16(FP), CX
-	MOVQ 24(SP), R9
-	MOVQ R9, 216(CX)
-	MOVQ 8(SP), R9
-	MOVQ R9, 232(CX)
-	MOVQ 16(SP), R9
-	MOVQ R9, 224(CX)
-	MOVQ R11, 136(CX)
-	MOVQ SI, 72(CX)
-	MOVQ DI, 80(CX)
-	MOVQ R8, 88(CX)
-	MOVQ 144(CX), R9
-	SUBQ R9, R10
-	MOVQ R10, 168(CX)
-	MOVQ br+8(FP), CX
-	MOVQ AX, 32(CX)
-	MOVB DL, 40(CX)
-	MOVQ BX, 24(CX)
+	MOVQ CX, 208(AX)
 	MOVQ $0x00000004, ret+24(FP)
 	RET

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -4,7 +4,7 @@
 // +build !appengine,!noasm,gc,!noasm
 
 // func sequenceDecs_decode_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: CMOV
+// Requires: CMOV, SSE
 TEXT ·sequenceDecs_decode_amd64(SB), $8-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
@@ -18,35 +18,31 @@ TEXT ·sequenceDecs_decode_amd64(SB), $8-32
 	MOVQ    80(AX), R8
 	MOVQ    88(AX), R9
 	MOVQ    104(AX), R10
-	MOVQ    s+0(FP), AX
-	MOVQ    144(AX), R11
-	MOVQ    152(AX), R12
-	MOVQ    160(AX), R13
 
 sequenceDecs_decode_amd64_main_loop:
-	MOVQ (SP), R14
+	MOVQ (SP), R11
 
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ SI, $0x08
-	JL   sequenceDecs_decode_amd64_fill_byte_by_byte
-	MOVQ BX, AX
-	SHRQ $0x03, AX
-	SUBQ AX, R14
-	MOVQ (R14), DX
-	SUBQ AX, SI
-	ANDQ $0x07, BX
-	JMP  sequenceDecs_decode_amd64_fill_end
+	// Fill bitreader to have enough for the offset.
+	CMPQ    BX, $0x20
+	JL      sequenceDecs_decode_amd64_fill_end
+	CMPQ    SI, $0x04
+	JL      sequenceDecs_decode_amd64_fill_byte_by_byte
+	SHLQ    $0x20, DX
+	SUBQ    $0x04, R11
+	SUBQ    $0x04, SI
+	SUBQ    $0x20, BX
+	MOVLQZX (R11), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decode_amd64_fill_end
 
 sequenceDecs_decode_amd64_fill_byte_by_byte:
 	CMPQ    SI, $0x00
 	JLE     sequenceDecs_decode_amd64_fill_end
-	CMPQ    BX, $0x07
-	JLE     sequenceDecs_decode_amd64_fill_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
+	SUBQ    $0x01, R11
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
+	MOVBQZX (R11), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decode_amd64_fill_byte_by_byte
 
@@ -54,75 +50,99 @@ sequenceDecs_decode_amd64_fill_end:
 	// Update offset
 	MOVQ    R9, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
+	MOVQ    DX, R12
+	SHLQ    CL, R12
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R15
+	SHRQ    CL, R12
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
+	CMOVQEQ CX, R12
+	ADDQ    R12, AX
 	MOVQ    AX, 16(R10)
 
-	// Update match length
-	MOVQ    R8, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, 8(R10)
-
-	// Fill bitreader to have enough for the remaining
-	CMPQ SI, $0x08
-	JL   sequenceDecs_decode_amd64_fill_2_byte_by_byte
-	MOVQ BX, AX
-	SHRQ $0x03, AX
-	SUBQ AX, R14
-	MOVQ (R14), DX
-	SUBQ AX, SI
-	ANDQ $0x07, BX
-	JMP  sequenceDecs_decode_amd64_fill_2_end
+	// Fill bitreader for match and literal
+	CMPQ    BX, $0x20
+	JL      sequenceDecs_decode_amd64_fill_2_end
+	CMPQ    SI, $0x04
+	JL      sequenceDecs_decode_amd64_fill_2_byte_by_byte
+	SHLQ    $0x20, DX
+	SUBQ    $0x04, R11
+	SUBQ    $0x04, SI
+	SUBQ    $0x20, BX
+	MOVLQZX (R11), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decode_amd64_fill_2_end
 
 sequenceDecs_decode_amd64_fill_2_byte_by_byte:
 	CMPQ    SI, $0x00
 	JLE     sequenceDecs_decode_amd64_fill_2_end
-	CMPQ    BX, $0x07
-	JLE     sequenceDecs_decode_amd64_fill_2_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
+	SUBQ    $0x01, R11
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
+	MOVBQZX (R11), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decode_amd64_fill_2_byte_by_byte
 
 sequenceDecs_decode_amd64_fill_2_end:
-	// Update literal length
-	MOVQ    DI, AX
+	// Update match length
+	MOVQ    R8, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
+	MOVQ    DX, R12
+	SHLQ    CL, R12
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R15
+	SHRQ    CL, R12
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
+	CMOVQEQ CX, R12
+	ADDQ    R12, AX
+	MOVQ    AX, 8(R10)
+
+	// Update literal length
+	MOVQ    DI, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R12
+	SHLQ    CL, R12
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R12
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R12
+	ADDQ    R12, AX
 	MOVQ    AX, (R10)
 
 	// Fill bitreader for state updates
-	MOVQ    R14, (SP)
+	CMPQ    BX, $0x20
+	JL      sequenceDecs_decode_amd64_fill_3_end
+	CMPQ    SI, $0x04
+	JL      sequenceDecs_decode_amd64_fill_3_byte_by_byte
+	SHLQ    $0x20, DX
+	SUBQ    $0x04, R11
+	SUBQ    $0x04, SI
+	SUBQ    $0x20, BX
+	MOVLQZX (R11), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decode_amd64_fill_3_end
+
+sequenceDecs_decode_amd64_fill_3_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decode_amd64_fill_3_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R11
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R11), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decode_amd64_fill_3_byte_by_byte
+
+sequenceDecs_decode_amd64_fill_3_end:
+	MOVQ    R11, (SP)
 	MOVQ    R9, AX
 	SHRQ    $0x08, AX
 	MOVBQZX AL, AX
@@ -131,19 +151,19 @@ sequenceDecs_decode_amd64_fill_2_end:
 	JZ      sequenceDecs_decode_amd64_skip_update
 
 	// Update Literal Length State
-	MOVBQZX DI, R14
+	MOVBQZX DI, R11
 	SHRQ    $0x10, DI
 	MOVWQZX DI, DI
-	CMPQ    R14, $0x00
+	CMPQ    R11, $0x00
 	JZ      sequenceDecs_decode_amd64_llState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
+	ADDQ    R11, BX
+	MOVQ    DX, R12
+	SHLQ    CL, R12
+	MOVQ    R11, CX
 	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, DI
+	SHRQ    CL, R12
+	ADDQ    R12, DI
 
 sequenceDecs_decode_amd64_llState_updateState_skip_zero:
 	// Load ctx.llTable
@@ -152,19 +172,19 @@ sequenceDecs_decode_amd64_llState_updateState_skip_zero:
 	MOVQ (CX)(DI*8), DI
 
 	// Update Match Length State
-	MOVBQZX R8, R14
+	MOVBQZX R8, R11
 	SHRQ    $0x10, R8
 	MOVWQZX R8, R8
-	CMPQ    R14, $0x00
+	CMPQ    R11, $0x00
 	JZ      sequenceDecs_decode_amd64_mlState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
+	ADDQ    R11, BX
+	MOVQ    DX, R12
+	SHLQ    CL, R12
+	MOVQ    R11, CX
 	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R8
+	SHRQ    CL, R12
+	ADDQ    R12, R8
 
 sequenceDecs_decode_amd64_mlState_updateState_skip_zero:
 	// Load ctx.mlTable
@@ -173,19 +193,19 @@ sequenceDecs_decode_amd64_mlState_updateState_skip_zero:
 	MOVQ (CX)(R8*8), R8
 
 	// Update Offset State
-	MOVBQZX R9, R14
+	MOVBQZX R9, R11
 	SHRQ    $0x10, R9
 	MOVWQZX R9, R9
-	CMPQ    R14, $0x00
+	CMPQ    R11, $0x00
 	JZ      sequenceDecs_decode_amd64_ofState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
+	ADDQ    R11, BX
+	MOVQ    DX, R12
+	SHLQ    CL, R12
+	MOVQ    R11, CX
 	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R9
+	SHRQ    CL, R12
+	ADDQ    R12, R9
 
 sequenceDecs_decode_amd64_ofState_updateState_skip_zero:
 	// Load ctx.ofTable
@@ -195,75 +215,65 @@ sequenceDecs_decode_amd64_ofState_updateState_skip_zero:
 
 sequenceDecs_decode_amd64_skip_update:
 	// Adjust offset
-	MOVQ 16(R10), CX
-	CMPQ AX, $0x01
-	JBE  sequenceDecs_decode_amd64_adjust_offsetB_1_or_0
-	MOVQ R12, R13
-	MOVQ R11, R12
-	MOVQ CX, R11
-	JMP  sequenceDecs_decode_amd64_adjust_end
+	MOVQ   s+0(FP), CX
+	MOVQ   16(R10), R11
+	CMPQ   AX, $0x01
+	JBE    sequenceDecs_decode_amd64_adjust_offsetB_1_or_0
+	MOVUPS 144(CX), X0
+	MOVQ   R11, 144(CX)
+	MOVUPS X0, 152(CX)
+	JMP    sequenceDecs_decode_amd64_adjust_end
 
 sequenceDecs_decode_amd64_adjust_offsetB_1_or_0:
 	CMPQ (R10), $0x00000000
 	JNE  sequenceDecs_decode_amd64_adjust_offset_maybezero
-	INCQ CX
+	INCQ R11
 	JMP  sequenceDecs_decode_amd64_adjust_offset_nonzero
 
 sequenceDecs_decode_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
+	TESTQ R11, R11
 	JNZ   sequenceDecs_decode_amd64_adjust_offset_nonzero
-	MOVQ  R11, CX
+	MOVQ  144(CX), R11
 	JMP   sequenceDecs_decode_amd64_adjust_end
 
 sequenceDecs_decode_amd64_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_amd64_adjust_zero
-	JEQ  sequenceDecs_decode_amd64_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_amd64_adjust_three
-	JMP  sequenceDecs_decode_amd64_adjust_two
-
-sequenceDecs_decode_amd64_adjust_zero:
-	MOVQ R11, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_one:
-	MOVQ R12, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_two:
-	MOVQ R13, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_three:
-	LEAQ -1(R11), AX
-
-sequenceDecs_decode_amd64_adjust_test_temp_valid:
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_amd64_adjust_temp_valid
-	MOVQ  $0x00000001, AX
+	MOVQ    R11, AX
+	XORQ    R12, R12
+	MOVQ    $-1, R13
+	CMPQ    R11, $0x03
+	CMOVQEQ R12, AX
+	CMOVQEQ R13, R12
+	LEAQ    144(CX), R13
+	ADDQ    (R13)(AX*8), R12
+	JNZ     sequenceDecs_decode_amd64_adjust_temp_valid
+	MOVQ    $0x00000001, R12
 
 sequenceDecs_decode_amd64_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R12, R13
-	MOVQ    R11, R12
-	MOVQ    AX, R11
-	MOVQ    AX, CX
+	CMPQ R11, $0x01
+	JZ   sequenceDecs_decode_amd64_adjust_skip
+	MOVQ 152(CX), AX
+	MOVQ AX, 160(CX)
+
+sequenceDecs_decode_amd64_adjust_skip:
+	MOVQ 144(CX), AX
+	MOVQ AX, 152(CX)
+	MOVQ R12, 144(CX)
+	MOVQ R12, R11
 
 sequenceDecs_decode_amd64_adjust_end:
-	MOVQ CX, 16(R10)
+	MOVQ R11, 16(R10)
 
 	// Check values
 	MOVQ  8(R10), AX
-	MOVQ  (R10), R14
-	LEAQ  (AX)(R14*1), R15
-	MOVQ  s+0(FP), BP
-	ADDQ  R15, 256(BP)
-	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
+	MOVQ  (R10), CX
+	LEAQ  (AX)(CX*1), R12
+	MOVQ  s+0(FP), R13
+	ADDQ  R12, 256(R13)
+	MOVQ  ctx+16(FP), R12
+	SUBQ  CX, 128(R12)
 	CMPQ  AX, $0x00020002
 	JA    sequenceDecs_decode_amd64_error_match_len_too_big
-	TESTQ CX, CX
+	TESTQ R11, R11
 	JNZ   sequenceDecs_decode_amd64_match_len_ofs_ok
 	TESTQ AX, AX
 	JNZ   sequenceDecs_decode_amd64_error_match_len_ofs_mismatch
@@ -273,10 +283,6 @@ sequenceDecs_decode_amd64_match_len_ofs_ok:
 	MOVQ ctx+16(FP), AX
 	DECQ 96(AX)
 	JNS  sequenceDecs_decode_amd64_main_loop
-	MOVQ s+0(FP), AX
-	MOVQ R11, 144(AX)
-	MOVQ R12, 152(AX)
-	MOVQ R13, 160(AX)
 	MOVQ br+8(FP), AX
 	MOVQ DX, 32(AX)
 	MOVB BL, 40(AX)
@@ -291,281 +297,17 @@ sequenceDecs_decode_amd64_error_match_len_ofs_mismatch:
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
-	// Return with match too long error
+	// Return with match length too long error
 sequenceDecs_decode_amd64_error_match_len_too_big:
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
-// func sequenceDecs_decode_56_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: CMOV
-TEXT ·sequenceDecs_decode_56_amd64(SB), $8-32
-	MOVQ    br+8(FP), AX
-	MOVQ    32(AX), DX
-	MOVBQZX 40(AX), BX
-	MOVQ    24(AX), SI
-	MOVQ    (AX), AX
-	ADDQ    SI, AX
-	MOVQ    AX, (SP)
-	MOVQ    ctx+16(FP), AX
-	MOVQ    72(AX), DI
-	MOVQ    80(AX), R8
-	MOVQ    88(AX), R9
-	MOVQ    104(AX), R10
-	MOVQ    s+0(FP), AX
-	MOVQ    144(AX), R11
-	MOVQ    152(AX), R12
-	MOVQ    160(AX), R13
-
-sequenceDecs_decode_56_amd64_main_loop:
-	MOVQ (SP), R14
-
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ SI, $0x08
-	JL   sequenceDecs_decode_56_amd64_fill_byte_by_byte
-	MOVQ BX, AX
-	SHRQ $0x03, AX
-	SUBQ AX, R14
-	MOVQ (R14), DX
-	SUBQ AX, SI
-	ANDQ $0x07, BX
-	JMP  sequenceDecs_decode_56_amd64_fill_end
-
-sequenceDecs_decode_56_amd64_fill_byte_by_byte:
-	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decode_56_amd64_fill_end
-	CMPQ    BX, $0x07
-	JLE     sequenceDecs_decode_56_amd64_fill_end
-	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
-	SUBQ    $0x01, SI
-	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_56_amd64_fill_byte_by_byte
-
-sequenceDecs_decode_56_amd64_fill_end:
-	// Update offset
-	MOVQ    R9, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, 16(R10)
-
-	// Update match length
-	MOVQ    R8, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, 8(R10)
-
-	// Update literal length
-	MOVQ    DI, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, (R10)
-
-	// Fill bitreader for state updates
-	MOVQ    R14, (SP)
-	MOVQ    R9, AX
-	SHRQ    $0x08, AX
-	MOVBQZX AL, AX
-	MOVQ    ctx+16(FP), CX
-	CMPQ    96(CX), $0x00
-	JZ      sequenceDecs_decode_56_amd64_skip_update
-
-	// Update Literal Length State
-	MOVBQZX DI, R14
-	SHRQ    $0x10, DI
-	MOVWQZX DI, DI
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_56_amd64_llState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, DI
-
-sequenceDecs_decode_56_amd64_llState_updateState_skip_zero:
-	// Load ctx.llTable
-	MOVQ ctx+16(FP), CX
-	MOVQ (CX), CX
-	MOVQ (CX)(DI*8), DI
-
-	// Update Match Length State
-	MOVBQZX R8, R14
-	SHRQ    $0x10, R8
-	MOVWQZX R8, R8
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R8
-
-sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero:
-	// Load ctx.mlTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 24(CX), CX
-	MOVQ (CX)(R8*8), R8
-
-	// Update Offset State
-	MOVBQZX R9, R14
-	SHRQ    $0x10, R9
-	MOVWQZX R9, R9
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R9
-
-sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero:
-	// Load ctx.ofTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 48(CX), CX
-	MOVQ (CX)(R9*8), R9
-
-sequenceDecs_decode_56_amd64_skip_update:
-	// Adjust offset
-	MOVQ 16(R10), CX
-	CMPQ AX, $0x01
-	JBE  sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0
-	MOVQ R12, R13
-	MOVQ R11, R12
-	MOVQ CX, R11
-	JMP  sequenceDecs_decode_56_amd64_adjust_end
-
-sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0:
-	CMPQ (R10), $0x00000000
-	JNE  sequenceDecs_decode_56_amd64_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_amd64_adjust_offset_nonzero
-
-sequenceDecs_decode_56_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_amd64_adjust_offset_nonzero
-	MOVQ  R11, CX
-	JMP   sequenceDecs_decode_56_amd64_adjust_end
-
-sequenceDecs_decode_56_amd64_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_56_amd64_adjust_zero
-	JEQ  sequenceDecs_decode_56_amd64_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_56_amd64_adjust_three
-	JMP  sequenceDecs_decode_56_amd64_adjust_two
-
-sequenceDecs_decode_56_amd64_adjust_zero:
-	MOVQ R11, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_one:
-	MOVQ R12, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_two:
-	MOVQ R13, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_three:
-	LEAQ -1(R11), AX
-
-sequenceDecs_decode_56_amd64_adjust_test_temp_valid:
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_56_amd64_adjust_temp_valid
-	MOVQ  $0x00000001, AX
-
-sequenceDecs_decode_56_amd64_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R12, R13
-	MOVQ    R11, R12
-	MOVQ    AX, R11
-	MOVQ    AX, CX
-
-sequenceDecs_decode_56_amd64_adjust_end:
-	MOVQ CX, 16(R10)
-
-	// Check values
-	MOVQ  8(R10), AX
-	MOVQ  (R10), R14
-	LEAQ  (AX)(R14*1), R15
-	MOVQ  s+0(FP), BP
-	ADDQ  R15, 256(BP)
-	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
-	CMPQ  AX, $0x00020002
-	JA    sequenceDecs_decode_56_amd64_error_match_len_too_big
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_amd64_match_len_ofs_ok
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch
-
-sequenceDecs_decode_56_amd64_match_len_ofs_ok:
-	ADDQ $0x18, R10
-	MOVQ ctx+16(FP), AX
-	DECQ 96(AX)
-	JNS  sequenceDecs_decode_56_amd64_main_loop
-	MOVQ s+0(FP), AX
-	MOVQ R11, 144(AX)
-	MOVQ R12, 152(AX)
-	MOVQ R13, 160(AX)
-	MOVQ br+8(FP), AX
-	MOVQ DX, 32(AX)
-	MOVB BL, 40(AX)
-	MOVQ SI, 24(AX)
-
-	// Return success
-	MOVQ $0x00000000, ret+24(FP)
-	RET
-
-	// Return with match length error
-sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch:
-	MOVQ $0x00000001, ret+24(FP)
-	RET
-
-	// Return with match too long error
-sequenceDecs_decode_56_amd64_error_match_len_too_big:
-	MOVQ $0x00000002, ret+24(FP)
+	// Return with match offset too long error
+	MOVQ $0x00000003, ret+24(FP)
 	RET
 
 // func sequenceDecs_decode_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: BMI, BMI2, CMOV
+// Requires: BMI, BMI2, CMOV, SSE
 TEXT ·sequenceDecs_decode_bmi2(SB), $8-32
 	MOVQ    br+8(FP), CX
 	MOVQ    32(CX), AX
@@ -579,121 +321,141 @@ TEXT ·sequenceDecs_decode_bmi2(SB), $8-32
 	MOVQ    80(CX), DI
 	MOVQ    88(CX), R8
 	MOVQ    104(CX), R9
-	MOVQ    s+0(FP), CX
-	MOVQ    144(CX), R10
-	MOVQ    152(CX), R11
-	MOVQ    160(CX), R12
 
 sequenceDecs_decode_bmi2_main_loop:
-	MOVQ (SP), R13
+	MOVQ (SP), R10
 
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ BX, $0x08
-	JL   sequenceDecs_decode_bmi2_fill_byte_by_byte
-	MOVQ DX, CX
-	SHRQ $0x03, CX
-	SUBQ CX, R13
-	MOVQ (R13), AX
-	SUBQ CX, BX
-	ANDQ $0x07, DX
-	JMP  sequenceDecs_decode_bmi2_fill_end
+	// Fill bitreader to have enough for the offset.
+	CMPQ    DX, $0x20
+	JL      sequenceDecs_decode_bmi2_fill_end
+	CMPQ    BX, $0x04
+	JL      sequenceDecs_decode_bmi2_fill_byte_by_byte
+	SHLQ    $0x20, AX
+	SUBQ    $0x04, R10
+	SUBQ    $0x04, BX
+	SUBQ    $0x20, DX
+	MOVLQZX (R10), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_bmi2_fill_end
 
 sequenceDecs_decode_bmi2_fill_byte_by_byte:
 	CMPQ    BX, $0x00
 	JLE     sequenceDecs_decode_bmi2_fill_end
-	CMPQ    DX, $0x07
-	JLE     sequenceDecs_decode_bmi2_fill_end
 	SHLQ    $0x08, AX
-	SUBQ    $0x01, R13
+	SUBQ    $0x01, R10
 	SUBQ    $0x01, BX
 	SUBQ    $0x08, DX
-	MOVBQZX (R13), CX
+	MOVBQZX (R10), CX
 	ORQ     CX, AX
 	JMP     sequenceDecs_decode_bmi2_fill_byte_by_byte
 
 sequenceDecs_decode_bmi2_fill_end:
 	// Update offset
 	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
+	BEXTRQ CX, R8, R11
+	MOVQ   AX, R12
+	LEAQ   (DX)(R11*1), CX
+	ROLQ   CL, R12
+	BZHIQ  R11, R12, R12
 	MOVQ   CX, DX
 	MOVQ   R8, CX
 	SHRQ   $0x20, CX
-	ADDQ   R15, CX
+	ADDQ   R12, CX
 	MOVQ   CX, 16(R9)
 
-	// Update match length
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, DI, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
-	MOVQ   CX, DX
-	MOVQ   DI, CX
-	SHRQ   $0x20, CX
-	ADDQ   R15, CX
-	MOVQ   CX, 8(R9)
-
-	// Fill bitreader to have enough for the remaining
-	CMPQ BX, $0x08
-	JL   sequenceDecs_decode_bmi2_fill_2_byte_by_byte
-	MOVQ DX, CX
-	SHRQ $0x03, CX
-	SUBQ CX, R13
-	MOVQ (R13), AX
-	SUBQ CX, BX
-	ANDQ $0x07, DX
-	JMP  sequenceDecs_decode_bmi2_fill_2_end
+	// Fill bitreader for match and literal
+	CMPQ    DX, $0x20
+	JL      sequenceDecs_decode_bmi2_fill_2_end
+	CMPQ    BX, $0x04
+	JL      sequenceDecs_decode_bmi2_fill_2_byte_by_byte
+	SHLQ    $0x20, AX
+	SUBQ    $0x04, R10
+	SUBQ    $0x04, BX
+	SUBQ    $0x20, DX
+	MOVLQZX (R10), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_bmi2_fill_2_end
 
 sequenceDecs_decode_bmi2_fill_2_byte_by_byte:
 	CMPQ    BX, $0x00
 	JLE     sequenceDecs_decode_bmi2_fill_2_end
-	CMPQ    DX, $0x07
-	JLE     sequenceDecs_decode_bmi2_fill_2_end
 	SHLQ    $0x08, AX
-	SUBQ    $0x01, R13
+	SUBQ    $0x01, R10
 	SUBQ    $0x01, BX
 	SUBQ    $0x08, DX
-	MOVBQZX (R13), CX
+	MOVBQZX (R10), CX
 	ORQ     CX, AX
 	JMP     sequenceDecs_decode_bmi2_fill_2_byte_by_byte
 
 sequenceDecs_decode_bmi2_fill_2_end:
+	// Update match length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, DI, R11
+	MOVQ   AX, R12
+	LEAQ   (DX)(R11*1), CX
+	ROLQ   CL, R12
+	BZHIQ  R11, R12, R12
+	MOVQ   CX, DX
+	MOVQ   DI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R12, CX
+	MOVQ   CX, 8(R9)
+
 	// Update literal length
 	MOVQ   $0x00000808, CX
-	BEXTRQ CX, SI, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
+	BEXTRQ CX, SI, R11
+	MOVQ   AX, R12
+	LEAQ   (DX)(R11*1), CX
+	ROLQ   CL, R12
+	BZHIQ  R11, R12, R12
 	MOVQ   CX, DX
 	MOVQ   SI, CX
 	SHRQ   $0x20, CX
-	ADDQ   R15, CX
+	ADDQ   R12, CX
 	MOVQ   CX, (R9)
 
 	// Fill bitreader for state updates
-	MOVQ   R13, (SP)
+	CMPQ    DX, $0x20
+	JL      sequenceDecs_decode_bmi2_fill_3_end
+	CMPQ    BX, $0x04
+	JL      sequenceDecs_decode_bmi2_fill_3_byte_by_byte
+	SHLQ    $0x20, AX
+	SUBQ    $0x04, R10
+	SUBQ    $0x04, BX
+	SUBQ    $0x20, DX
+	MOVLQZX (R10), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_bmi2_fill_3_end
+
+sequenceDecs_decode_bmi2_fill_3_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decode_bmi2_fill_3_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R10
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R10), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_bmi2_fill_3_byte_by_byte
+
+sequenceDecs_decode_bmi2_fill_3_end:
+	MOVQ   R10, (SP)
 	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R13
+	BEXTRQ CX, R8, R10
 	MOVQ   ctx+16(FP), CX
 	CMPQ   96(CX), $0x00
 	JZ     sequenceDecs_decode_bmi2_skip_update
 
 	// Update Literal Length State
-	MOVBQZX SI, R14
+	MOVBQZX SI, R11
 	MOVQ    $0x00001010, CX
 	BEXTRQ  CX, SI, SI
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
+	LEAQ    (DX)(R11*1), CX
+	MOVQ    AX, R12
 	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, SI
+	ROLQ    CL, R12
+	BZHIQ   R11, R12, R12
+	ADDQ    R12, SI
 
 	// Load ctx.llTable
 	MOVQ ctx+16(FP), CX
@@ -701,15 +463,15 @@ sequenceDecs_decode_bmi2_fill_2_end:
 	MOVQ (CX)(SI*8), SI
 
 	// Update Match Length State
-	MOVBQZX DI, R14
+	MOVBQZX DI, R11
 	MOVQ    $0x00001010, CX
 	BEXTRQ  CX, DI, DI
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
+	LEAQ    (DX)(R11*1), CX
+	MOVQ    AX, R12
 	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, DI
+	ROLQ    CL, R12
+	BZHIQ   R11, R12, R12
+	ADDQ    R12, DI
 
 	// Load ctx.mlTable
 	MOVQ ctx+16(FP), CX
@@ -717,15 +479,15 @@ sequenceDecs_decode_bmi2_fill_2_end:
 	MOVQ (CX)(DI*8), DI
 
 	// Update Offset State
-	MOVBQZX R8, R14
+	MOVBQZX R8, R11
 	MOVQ    $0x00001010, CX
 	BEXTRQ  CX, R8, R8
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
+	LEAQ    (DX)(R11*1), CX
+	MOVQ    AX, R12
 	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, R8
+	ROLQ    CL, R12
+	BZHIQ   R11, R12, R12
+	ADDQ    R12, R8
 
 	// Load ctx.ofTable
 	MOVQ ctx+16(FP), CX
@@ -734,77 +496,67 @@ sequenceDecs_decode_bmi2_fill_2_end:
 
 sequenceDecs_decode_bmi2_skip_update:
 	// Adjust offset
-	MOVQ 16(R9), CX
-	CMPQ R13, $0x01
-	JBE  sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0
-	MOVQ R11, R12
-	MOVQ R10, R11
-	MOVQ CX, R10
-	JMP  sequenceDecs_decode_bmi2_adjust_end
+	MOVQ   s+0(FP), CX
+	MOVQ   16(R9), R11
+	CMPQ   R10, $0x01
+	JBE    sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0
+	MOVUPS 144(CX), X0
+	MOVQ   R11, 144(CX)
+	MOVUPS X0, 152(CX)
+	JMP    sequenceDecs_decode_bmi2_adjust_end
 
 sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0:
 	CMPQ (R9), $0x00000000
 	JNE  sequenceDecs_decode_bmi2_adjust_offset_maybezero
-	INCQ CX
+	INCQ R11
 	JMP  sequenceDecs_decode_bmi2_adjust_offset_nonzero
 
 sequenceDecs_decode_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
+	TESTQ R11, R11
 	JNZ   sequenceDecs_decode_bmi2_adjust_offset_nonzero
-	MOVQ  R10, CX
+	MOVQ  144(CX), R11
 	JMP   sequenceDecs_decode_bmi2_adjust_end
 
 sequenceDecs_decode_bmi2_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_bmi2_adjust_zero
-	JEQ  sequenceDecs_decode_bmi2_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_bmi2_adjust_three
-	JMP  sequenceDecs_decode_bmi2_adjust_two
-
-sequenceDecs_decode_bmi2_adjust_zero:
-	MOVQ R10, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_one:
-	MOVQ R11, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_two:
-	MOVQ R12, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_three:
-	LEAQ -1(R10), R13
-
-sequenceDecs_decode_bmi2_adjust_test_temp_valid:
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_bmi2_adjust_temp_valid
-	MOVQ  $0x00000001, R13
+	MOVQ    R11, R10
+	XORQ    R12, R12
+	MOVQ    $-1, R13
+	CMPQ    R11, $0x03
+	CMOVQEQ R12, R10
+	CMOVQEQ R13, R12
+	LEAQ    144(CX), R13
+	ADDQ    (R13)(R10*8), R12
+	JNZ     sequenceDecs_decode_bmi2_adjust_temp_valid
+	MOVQ    $0x00000001, R12
 
 sequenceDecs_decode_bmi2_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R11, R12
-	MOVQ    R10, R11
-	MOVQ    R13, R10
-	MOVQ    R13, CX
+	CMPQ R11, $0x01
+	JZ   sequenceDecs_decode_bmi2_adjust_skip
+	MOVQ 152(CX), R10
+	MOVQ R10, 160(CX)
+
+sequenceDecs_decode_bmi2_adjust_skip:
+	MOVQ 144(CX), R10
+	MOVQ R10, 152(CX)
+	MOVQ R12, 144(CX)
+	MOVQ R12, R11
 
 sequenceDecs_decode_bmi2_adjust_end:
-	MOVQ CX, 16(R9)
+	MOVQ R11, 16(R9)
 
 	// Check values
-	MOVQ  8(R9), R13
-	MOVQ  (R9), R14
-	LEAQ  (R13)(R14*1), R15
-	MOVQ  s+0(FP), BP
-	ADDQ  R15, 256(BP)
-	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
-	CMPQ  R13, $0x00020002
+	MOVQ  8(R9), CX
+	MOVQ  (R9), R10
+	LEAQ  (CX)(R10*1), R12
+	MOVQ  s+0(FP), R13
+	ADDQ  R12, 256(R13)
+	MOVQ  ctx+16(FP), R12
+	SUBQ  R10, 128(R12)
+	CMPQ  CX, $0x00020002
 	JA    sequenceDecs_decode_bmi2_error_match_len_too_big
-	TESTQ CX, CX
+	TESTQ R11, R11
 	JNZ   sequenceDecs_decode_bmi2_match_len_ofs_ok
-	TESTQ R13, R13
+	TESTQ CX, CX
 	JNZ   sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch
 
 sequenceDecs_decode_bmi2_match_len_ofs_ok:
@@ -812,10 +564,6 @@ sequenceDecs_decode_bmi2_match_len_ofs_ok:
 	MOVQ ctx+16(FP), CX
 	DECQ 96(CX)
 	JNS  sequenceDecs_decode_bmi2_main_loop
-	MOVQ s+0(FP), CX
-	MOVQ R10, 144(CX)
-	MOVQ R11, 152(CX)
-	MOVQ R12, 160(CX)
 	MOVQ br+8(FP), CX
 	MOVQ AX, 32(CX)
 	MOVB DL, 40(CX)
@@ -830,14 +578,509 @@ sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch:
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
-	// Return with match too long error
+	// Return with match length too long error
 sequenceDecs_decode_bmi2_error_match_len_too_big:
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
-// func sequenceDecs_decode_56_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: BMI, BMI2, CMOV
-TEXT ·sequenceDecs_decode_56_bmi2(SB), $8-32
+	// Return with match offset too long error
+	MOVQ $0x00000003, ret+24(FP)
+	RET
+
+// func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
+// Requires: SSE
+TEXT ·sequenceDecs_executeSimple_amd64(SB), $0-9
+	MOVQ  ctx+0(FP), DI
+	MOVQ  8(DI), CX
+	TESTQ CX, CX
+	JZ    empty_seqs
+	MOVQ  (DI), AX
+	MOVQ  24(DI), DX
+	MOVQ  32(DI), BX
+	MOVQ  40(DI), SI
+	MOVQ  56(DI), SI
+	MOVQ  80(DI), R8
+	MOVQ  96(DI), DI
+
+	// seqsBase += 24 * seqIndex
+	LEAQ (DX)(DX*2), DI
+	SHLQ $0x03, DI
+	ADDQ DI, AX
+
+	// outBase += outPosition
+	ADDQ R8, BX
+
+main_loop:
+	// Copy literals
+	MOVQ  (AX), DI
+	TESTQ DI, DI
+	JZ    copy_match
+	XORQ  R9, R9
+
+copy_1:
+	MOVUPS (SI)(R9*1), X0
+	MOVUPS X0, (BX)(R9*1)
+	ADDQ   $0x10, R9
+	CMPQ   R9, DI
+	JB     copy_1
+	ADDQ   DI, SI
+	ADDQ   DI, BX
+	ADDQ   DI, R8
+
+	// Copy match
+copy_match:
+	MOVQ  8(AX), DI
+	TESTQ DI, DI
+	JZ    handle_loop
+	MOVQ  16(AX), R9
+
+	// Malformed input if seq.mo > t || seq.mo > s.windowSize
+	CMPQ R9, R8
+	JG   error_match_off_too_big
+	MOVQ BX, R10
+	SUBQ R9, R10
+
+	// ml <= mo
+	CMPQ DI, R9
+	JA   copy_overlapping_match
+
+	// Copy non-overlapping match
+	XORQ R9, R9
+
+copy_2:
+	MOVUPS (R10)(R9*1), X0
+	MOVUPS X0, (BX)(R9*1)
+	ADDQ   $0x10, R9
+	CMPQ   R9, DI
+	JB     copy_2
+	ADDQ   DI, BX
+	ADDQ   DI, R8
+	JMP    handle_loop
+
+	// Copy overlapping match
+copy_overlapping_match:
+	XORQ R9, R9
+
+copy_slow_3:
+	MOVB (R10)(R9*1), R11
+	MOVB R11, (BX)(R9*1)
+	INCQ R9
+	CMPQ R9, DI
+	JB   copy_slow_3
+	ADDQ DI, BX
+	ADDQ DI, R8
+
+handle_loop:
+	ADDQ $0x18, AX
+	INCQ DX
+	CMPQ DX, CX
+	JB   main_loop
+
+	// Return value
+	MOVB $0x01, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R8, 80(AX)
+	MOVQ 56(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 88(AX)
+	RET
+
+error_match_off_too_big:
+	// Return value
+	MOVB $0x00, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R8, 80(AX)
+	MOVQ 56(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 88(AX)
+	RET
+
+empty_seqs:
+	// Return value
+	MOVB $0x01, ret+8(FP)
+	RET
+
+// func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
+// Requires: CMOV, SSE
+TEXT ·sequenceDecs_decodeSync_amd64(SB), $32-32
+	MOVQ    br+8(FP), AX
+	MOVQ    32(AX), DX
+	MOVBQZX 40(AX), BX
+	MOVQ    24(AX), SI
+	MOVQ    (AX), AX
+	ADDQ    SI, AX
+	MOVQ    AX, (SP)
+	MOVQ    ctx+16(FP), AX
+	MOVQ    72(AX), DI
+	MOVQ    80(AX), R8
+	MOVQ    88(AX), R9
+	MOVQ    112(AX), R11
+	MOVQ    120(AX), CX
+	MOVQ    136(AX), R12
+	MOVQ    160(AX), R13
+	MOVQ    168(AX), AX
+
+	// outBase += outPosition
+	ADDQ R13, R11
+
+sequenceDecs_decodeSync_amd64_main_loop:
+	MOVQ (SP), R14
+
+	// Fill bitreader to have enough for the offset.
+	CMPQ    BX, $0x20
+	JL      sequenceDecs_decodeSync_amd64_fill_end
+	CMPQ    SI, $0x04
+	JL      sequenceDecs_decodeSync_amd64_fill_byte_by_byte
+	SHLQ    $0x20, DX
+	SUBQ    $0x04, R14
+	SUBQ    $0x04, SI
+	SUBQ    $0x20, BX
+	MOVLQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_end
+
+sequenceDecs_decodeSync_amd64_fill_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decodeSync_amd64_fill_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R14
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_byte_by_byte
+
+sequenceDecs_decodeSync_amd64_fill_end:
+	// Update offset
+	MOVQ    R9, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 8(SP)
+
+	// Fill bitreader for match and literal
+	CMPQ    BX, $0x20
+	JL      sequenceDecs_decodeSync_amd64_fill_2_end
+	CMPQ    SI, $0x04
+	JL      sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
+	SHLQ    $0x20, DX
+	SUBQ    $0x04, R14
+	SUBQ    $0x04, SI
+	SUBQ    $0x20, BX
+	MOVLQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_2_end
+
+sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R14
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
+
+sequenceDecs_decodeSync_amd64_fill_2_end:
+	// Update match length
+	MOVQ    R8, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 16(SP)
+
+	// Update literal length
+	MOVQ    DI, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 24(SP)
+
+	// Fill bitreader for state updates
+	CMPQ    BX, $0x20
+	JL      sequenceDecs_decodeSync_amd64_fill_3_end
+	CMPQ    SI, $0x04
+	JL      sequenceDecs_decodeSync_amd64_fill_3_byte_by_byte
+	SHLQ    $0x20, DX
+	SUBQ    $0x04, R14
+	SUBQ    $0x04, SI
+	SUBQ    $0x20, BX
+	MOVLQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_3_end
+
+sequenceDecs_decodeSync_amd64_fill_3_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decodeSync_amd64_fill_3_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R14
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_3_byte_by_byte
+
+sequenceDecs_decodeSync_amd64_fill_3_end:
+	MOVQ    R14, (SP)
+	MOVQ    R9, AX
+	SHRQ    $0x08, AX
+	MOVBQZX AL, AX
+	MOVQ    ctx+16(FP), CX
+	CMPQ    96(CX), $0x00
+	JZ      sequenceDecs_decodeSync_amd64_skip_update
+
+	// Update Literal Length State
+	MOVBQZX DI, R14
+	SHRQ    $0x10, DI
+	MOVWQZX DI, DI
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, DI
+
+sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
+	// Load ctx.llTable
+	MOVQ ctx+16(FP), CX
+	MOVQ (CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Match Length State
+	MOVBQZX R8, R14
+	SHRQ    $0x10, R8
+	MOVWQZX R8, R8
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, R8
+
+sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+	// Update Offset State
+	MOVBQZX R9, R14
+	SHRQ    $0x10, R9
+	MOVWQZX R9, R9
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, R9
+
+sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R9*8), R9
+
+sequenceDecs_decodeSync_amd64_skip_update:
+	// Adjust offset
+	MOVQ   s+0(FP), CX
+	MOVQ   8(SP), R14
+	CMPQ   AX, $0x01
+	JBE    sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
+	MOVUPS 144(CX), X0
+	MOVQ   R14, 144(CX)
+	MOVUPS X0, 152(CX)
+	JMP    sequenceDecs_decodeSync_amd64_adjust_end
+
+sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
+	CMPQ 24(SP), $0x00000000
+	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
+	INCQ R14
+	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
+
+sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
+	TESTQ R14, R14
+	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
+	MOVQ  144(CX), R14
+	JMP   sequenceDecs_decodeSync_amd64_adjust_end
+
+sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
+	MOVQ    R14, AX
+	XORQ    R15, R15
+	MOVQ    $-1, BP
+	CMPQ    R14, $0x03
+	CMOVQEQ R15, AX
+	CMOVQEQ BP, R15
+	LEAQ    144(CX), BP
+	ADDQ    (BP)(AX*8), R15
+	JNZ     sequenceDecs_decodeSync_amd64_adjust_temp_valid
+	MOVQ    $0x00000001, R15
+
+sequenceDecs_decodeSync_amd64_adjust_temp_valid:
+	CMPQ R14, $0x01
+	JZ   sequenceDecs_decodeSync_amd64_adjust_skip
+	MOVQ 152(CX), AX
+	MOVQ AX, 160(CX)
+
+sequenceDecs_decodeSync_amd64_adjust_skip:
+	MOVQ 144(CX), AX
+	MOVQ AX, 152(CX)
+	MOVQ R15, 144(CX)
+	MOVQ R15, R14
+
+sequenceDecs_decodeSync_amd64_adjust_end:
+	MOVQ R14, 8(SP)
+
+	// Check values
+	MOVQ  16(SP), AX
+	MOVQ  24(SP), CX
+	LEAQ  (AX)(CX*1), R15
+	MOVQ  s+0(FP), BP
+	ADDQ  R15, 256(BP)
+	MOVQ  ctx+16(FP), R15
+	SUBQ  CX, 104(R15)
+	CMPQ  AX, $0x00020002
+	JA    sequenceDecs_decodeSync_amd64_error_match_len_too_big
+	TESTQ R14, R14
+	JNZ   sequenceDecs_decodeSync_amd64_match_len_ofs_ok
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
+
+sequenceDecs_decodeSync_amd64_match_len_ofs_ok:
+	// Copy literals
+	MOVQ  24(SP), AX
+	TESTQ AX, AX
+	JZ    copy_match
+	XORQ  CX, CX
+
+copy_1:
+	MOVUPS (R12)(CX*1), X0
+	MOVUPS X0, (R11)(CX*1)
+	ADDQ   $0x10, CX
+	CMPQ   CX, AX
+	JB     copy_1
+	ADDQ   AX, R12
+	ADDQ   AX, R11
+	ADDQ   AX, R13
+
+	// Copy match
+copy_match:
+	MOVQ  16(SP), AX
+	TESTQ AX, AX
+	JZ    handle_loop
+	MOVQ  8(SP), CX
+
+	// Malformed input if seq.mo > t || seq.mo > s.windowSize
+	CMPQ CX, R13
+	JG   error_match_off_too_big
+	MOVQ R11, R14
+	SUBQ CX, R14
+
+	// ml <= mo
+	CMPQ AX, CX
+	JA   copy_overlapping_match
+
+	// Copy non-overlapping match
+	XORQ CX, CX
+
+copy_2:
+	MOVUPS (R14)(CX*1), X0
+	MOVUPS X0, (R11)(CX*1)
+	ADDQ   $0x10, CX
+	CMPQ   CX, AX
+	JB     copy_2
+	ADDQ   AX, R11
+	ADDQ   AX, R13
+	JMP    handle_loop
+
+	// Copy overlapping match
+copy_overlapping_match:
+	XORQ CX, CX
+
+copy_slow_3:
+	MOVB (R14)(CX*1), R15
+	MOVB R15, (R11)(CX*1)
+	INCQ CX
+	CMPQ CX, AX
+	JB   copy_slow_3
+	ADDQ AX, R11
+	ADDQ AX, R13
+
+handle_loop:
+	ADDQ $0x18, R10
+	MOVQ ctx+16(FP), AX
+	DECQ 96(AX)
+	JNS  sequenceDecs_decodeSync_amd64_main_loop
+	MOVQ br+8(FP), AX
+	MOVQ DX, 32(AX)
+	MOVB BL, 40(AX)
+	MOVQ SI, 24(AX)
+
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
+	RET
+
+	// Return with match length error
+sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch:
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match length too long error
+sequenceDecs_decodeSync_amd64_error_match_len_too_big:
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+	// Return with match offset too long error
+error_match_off_too_big:
+	MOVQ $0x00000003, ret+24(FP)
+	RET
+	RET
+
+// func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
+// Requires: BMI, BMI2, CMOV, SSE
+TEXT ·sequenceDecs_decodeSync_bmi2(SB), $32-32
 	MOVQ    br+8(FP), CX
 	MOVQ    32(CX), AX
 	MOVBQZX 40(CX), DX
@@ -849,40 +1092,43 @@ TEXT ·sequenceDecs_decode_56_bmi2(SB), $8-32
 	MOVQ    72(CX), SI
 	MOVQ    80(CX), DI
 	MOVQ    88(CX), R8
-	MOVQ    104(CX), R9
-	MOVQ    s+0(FP), CX
-	MOVQ    144(CX), R10
-	MOVQ    152(CX), R11
+	MOVQ    112(CX), R10
+	MOVQ    120(CX), R11
+	MOVQ    136(CX), R11
 	MOVQ    160(CX), R12
+	MOVQ    168(CX), CX
 
-sequenceDecs_decode_56_bmi2_main_loop:
+	// outBase += outPosition
+	ADDQ R12, R10
+
+sequenceDecs_decodeSync_bmi2_main_loop:
 	MOVQ (SP), R13
 
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ BX, $0x08
-	JL   sequenceDecs_decode_56_bmi2_fill_byte_by_byte
-	MOVQ DX, CX
-	SHRQ $0x03, CX
-	SUBQ CX, R13
-	MOVQ (R13), AX
-	SUBQ CX, BX
-	ANDQ $0x07, DX
-	JMP  sequenceDecs_decode_56_bmi2_fill_end
+	// Fill bitreader to have enough for the offset.
+	CMPQ    DX, $0x20
+	JL      sequenceDecs_decodeSync_bmi2_fill_end
+	CMPQ    BX, $0x04
+	JL      sequenceDecs_decodeSync_bmi2_fill_byte_by_byte
+	SHLQ    $0x20, AX
+	SUBQ    $0x04, R13
+	SUBQ    $0x04, BX
+	SUBQ    $0x20, DX
+	MOVLQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decodeSync_bmi2_fill_end
 
-sequenceDecs_decode_56_bmi2_fill_byte_by_byte:
+sequenceDecs_decodeSync_bmi2_fill_byte_by_byte:
 	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decode_56_bmi2_fill_end
-	CMPQ    DX, $0x07
-	JLE     sequenceDecs_decode_56_bmi2_fill_end
+	JLE     sequenceDecs_decodeSync_bmi2_fill_end
 	SHLQ    $0x08, AX
 	SUBQ    $0x01, R13
 	SUBQ    $0x01, BX
 	SUBQ    $0x08, DX
 	MOVBQZX (R13), CX
 	ORQ     CX, AX
-	JMP     sequenceDecs_decode_56_bmi2_fill_byte_by_byte
+	JMP     sequenceDecs_decodeSync_bmi2_fill_byte_by_byte
 
-sequenceDecs_decode_56_bmi2_fill_end:
+sequenceDecs_decodeSync_bmi2_fill_end:
 	// Update offset
 	MOVQ   $0x00000808, CX
 	BEXTRQ CX, R8, R14
@@ -894,8 +1140,33 @@ sequenceDecs_decode_56_bmi2_fill_end:
 	MOVQ   R8, CX
 	SHRQ   $0x20, CX
 	ADDQ   R15, CX
-	MOVQ   CX, 16(R9)
+	MOVQ   CX, 8(SP)
 
+	// Fill bitreader for match and literal
+	CMPQ    DX, $0x20
+	JL      sequenceDecs_decodeSync_bmi2_fill_2_end
+	CMPQ    BX, $0x04
+	JL      sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte
+	SHLQ    $0x20, AX
+	SUBQ    $0x04, R13
+	SUBQ    $0x04, BX
+	SUBQ    $0x20, DX
+	MOVLQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decodeSync_bmi2_fill_2_end
+
+sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decodeSync_bmi2_fill_2_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte
+
+sequenceDecs_decodeSync_bmi2_fill_2_end:
 	// Update match length
 	MOVQ   $0x00000808, CX
 	BEXTRQ CX, DI, R14
@@ -907,7 +1178,7 @@ sequenceDecs_decode_56_bmi2_fill_end:
 	MOVQ   DI, CX
 	SHRQ   $0x20, CX
 	ADDQ   R15, CX
-	MOVQ   CX, 8(R9)
+	MOVQ   CX, 16(SP)
 
 	// Update literal length
 	MOVQ   $0x00000808, CX
@@ -920,15 +1191,39 @@ sequenceDecs_decode_56_bmi2_fill_end:
 	MOVQ   SI, CX
 	SHRQ   $0x20, CX
 	ADDQ   R15, CX
-	MOVQ   CX, (R9)
+	MOVQ   CX, 24(SP)
 
 	// Fill bitreader for state updates
+	CMPQ    DX, $0x20
+	JL      sequenceDecs_decodeSync_bmi2_fill_3_end
+	CMPQ    BX, $0x04
+	JL      sequenceDecs_decodeSync_bmi2_fill_3_byte_by_byte
+	SHLQ    $0x20, AX
+	SUBQ    $0x04, R13
+	SUBQ    $0x04, BX
+	SUBQ    $0x20, DX
+	MOVLQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decodeSync_bmi2_fill_3_end
+
+sequenceDecs_decodeSync_bmi2_fill_3_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decodeSync_bmi2_fill_3_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decodeSync_bmi2_fill_3_byte_by_byte
+
+sequenceDecs_decodeSync_bmi2_fill_3_end:
 	MOVQ   R13, (SP)
 	MOVQ   $0x00000808, CX
 	BEXTRQ CX, R8, R13
 	MOVQ   ctx+16(FP), CX
 	CMPQ   96(CX), $0x00
-	JZ     sequenceDecs_decode_56_bmi2_skip_update
+	JZ     sequenceDecs_decodeSync_bmi2_skip_update
 
 	// Update Literal Length State
 	MOVBQZX SI, R14
@@ -978,90 +1273,136 @@ sequenceDecs_decode_56_bmi2_fill_end:
 	MOVQ 48(CX), CX
 	MOVQ (CX)(R8*8), R8
 
-sequenceDecs_decode_56_bmi2_skip_update:
+sequenceDecs_decodeSync_bmi2_skip_update:
 	// Adjust offset
-	MOVQ 16(R9), CX
-	CMPQ R13, $0x01
-	JBE  sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0
-	MOVQ R11, R12
-	MOVQ R10, R11
-	MOVQ CX, R10
-	JMP  sequenceDecs_decode_56_bmi2_adjust_end
+	MOVQ   s+0(FP), CX
+	MOVQ   8(SP), R14
+	CMPQ   R13, $0x01
+	JBE    sequenceDecs_decodeSync_bmi2_adjust_offsetB_1_or_0
+	MOVUPS 144(CX), X0
+	MOVQ   R14, 144(CX)
+	MOVUPS X0, 152(CX)
+	JMP    sequenceDecs_decodeSync_bmi2_adjust_end
 
-sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_56_bmi2_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
+sequenceDecs_decodeSync_bmi2_adjust_offsetB_1_or_0:
+	CMPQ 24(SP), $0x00000000
+	JNE  sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero
+	INCQ R14
+	JMP  sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
 
-sequenceDecs_decode_56_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
-	MOVQ  R10, CX
-	JMP   sequenceDecs_decode_56_bmi2_adjust_end
+sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero:
+	TESTQ R14, R14
+	JNZ   sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
+	MOVQ  144(CX), R14
+	JMP   sequenceDecs_decodeSync_bmi2_adjust_end
 
-sequenceDecs_decode_56_bmi2_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_56_bmi2_adjust_zero
-	JEQ  sequenceDecs_decode_56_bmi2_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_56_bmi2_adjust_three
-	JMP  sequenceDecs_decode_56_bmi2_adjust_two
+sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero:
+	MOVQ    R14, R13
+	XORQ    R15, R15
+	MOVQ    $-1, BP
+	CMPQ    R14, $0x03
+	CMOVQEQ R15, R13
+	CMOVQEQ BP, R15
+	LEAQ    144(CX), BP
+	ADDQ    (BP)(R13*8), R15
+	JNZ     sequenceDecs_decodeSync_bmi2_adjust_temp_valid
+	MOVQ    $0x00000001, R15
 
-sequenceDecs_decode_56_bmi2_adjust_zero:
-	MOVQ R10, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+sequenceDecs_decodeSync_bmi2_adjust_temp_valid:
+	CMPQ R14, $0x01
+	JZ   sequenceDecs_decodeSync_bmi2_adjust_skip
+	MOVQ 152(CX), R13
+	MOVQ R13, 160(CX)
 
-sequenceDecs_decode_56_bmi2_adjust_one:
-	MOVQ R11, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+sequenceDecs_decodeSync_bmi2_adjust_skip:
+	MOVQ 144(CX), R13
+	MOVQ R13, 152(CX)
+	MOVQ R15, 144(CX)
+	MOVQ R15, R14
 
-sequenceDecs_decode_56_bmi2_adjust_two:
-	MOVQ R12, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_56_bmi2_adjust_three:
-	LEAQ -1(R10), R13
-
-sequenceDecs_decode_56_bmi2_adjust_test_temp_valid:
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_56_bmi2_adjust_temp_valid
-	MOVQ  $0x00000001, R13
-
-sequenceDecs_decode_56_bmi2_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R11, R12
-	MOVQ    R10, R11
-	MOVQ    R13, R10
-	MOVQ    R13, CX
-
-sequenceDecs_decode_56_bmi2_adjust_end:
-	MOVQ CX, 16(R9)
+sequenceDecs_decodeSync_bmi2_adjust_end:
+	MOVQ R14, 8(SP)
 
 	// Check values
-	MOVQ  8(R9), R13
-	MOVQ  (R9), R14
-	LEAQ  (R13)(R14*1), R15
+	MOVQ  16(SP), CX
+	MOVQ  24(SP), R13
+	LEAQ  (CX)(R13*1), R15
 	MOVQ  s+0(FP), BP
 	ADDQ  R15, 256(BP)
 	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
-	CMPQ  R13, $0x00020002
-	JA    sequenceDecs_decode_56_bmi2_error_match_len_too_big
+	SUBQ  R13, 104(R15)
+	CMPQ  CX, $0x00020002
+	JA    sequenceDecs_decodeSync_bmi2_error_match_len_too_big
+	TESTQ R14, R14
+	JNZ   sequenceDecs_decodeSync_bmi2_match_len_ofs_ok
 	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_bmi2_match_len_ofs_ok
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch
+	JNZ   sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch
 
-sequenceDecs_decode_56_bmi2_match_len_ofs_ok:
+sequenceDecs_decodeSync_bmi2_match_len_ofs_ok:
+	// Copy literals
+	MOVQ  24(SP), CX
+	TESTQ CX, CX
+	JZ    copy_match
+	XORQ  R13, R13
+
+copy_1:
+	MOVUPS (R11)(R13*1), X0
+	MOVUPS X0, (R10)(R13*1)
+	ADDQ   $0x10, R13
+	CMPQ   R13, CX
+	JB     copy_1
+	ADDQ   CX, R11
+	ADDQ   CX, R10
+	ADDQ   CX, R12
+
+	// Copy match
+copy_match:
+	MOVQ  16(SP), CX
+	TESTQ CX, CX
+	JZ    handle_loop
+	MOVQ  8(SP), R13
+
+	// Malformed input if seq.mo > t || seq.mo > s.windowSize
+	CMPQ R13, R12
+	JG   error_match_off_too_big
+	MOVQ R10, R14
+	SUBQ R13, R14
+
+	// ml <= mo
+	CMPQ CX, R13
+	JA   copy_overlapping_match
+
+	// Copy non-overlapping match
+	XORQ R13, R13
+
+copy_2:
+	MOVUPS (R14)(R13*1), X0
+	MOVUPS X0, (R10)(R13*1)
+	ADDQ   $0x10, R13
+	CMPQ   R13, CX
+	JB     copy_2
+	ADDQ   CX, R10
+	ADDQ   CX, R12
+	JMP    handle_loop
+
+	// Copy overlapping match
+copy_overlapping_match:
+	XORQ R13, R13
+
+copy_slow_3:
+	MOVB (R14)(R13*1), R15
+	MOVB R15, (R10)(R13*1)
+	INCQ R13
+	CMPQ R13, CX
+	JB   copy_slow_3
+	ADDQ CX, R10
+	ADDQ CX, R12
+
+handle_loop:
 	ADDQ $0x18, R9
 	MOVQ ctx+16(FP), CX
 	DECQ 96(CX)
-	JNS  sequenceDecs_decode_56_bmi2_main_loop
-	MOVQ s+0(FP), CX
-	MOVQ R10, 144(CX)
-	MOVQ R11, 152(CX)
-	MOVQ R12, 160(CX)
+	JNS  sequenceDecs_decodeSync_bmi2_main_loop
 	MOVQ br+8(FP), CX
 	MOVQ AX, 32(CX)
 	MOVB DL, 40(CX)
@@ -1072,263 +1413,17 @@ sequenceDecs_decode_56_bmi2_match_len_ofs_ok:
 	RET
 
 	// Return with match length error
-sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch:
+sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch:
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
-	// Return with match too long error
-sequenceDecs_decode_56_bmi2_error_match_len_too_big:
+	// Return with match length too long error
+sequenceDecs_decodeSync_bmi2_error_match_len_too_big:
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
-// func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
-// Requires: SSE
-TEXT ·sequenceDecs_executeSimple_amd64(SB), $8-9
-	MOVQ  ctx+0(FP), DI
-	MOVQ  8(DI), CX
-	TESTQ CX, CX
-	JZ    empty_seqs
-	MOVQ  (DI), AX
-	MOVQ  24(DI), DX
-	MOVQ  32(DI), BX
-	MOVQ  40(DI), SI
-	MOVQ  80(DI), SI
-	MOVQ  104(DI), R8
-	MOVQ  120(DI), R9
-	MOVQ  56(DI), R10
-	MOVQ  64(DI), DI
-	ADDQ  DI, R10
-
-	// seqsBase += 24 * seqIndex
-	LEAQ (DX)(DX*2), R11
-	SHLQ $0x03, R11
-	ADDQ R11, AX
-
-	// outBase += outPosition
-	ADDQ R8, BX
-
-main_loop:
-	MOVQ (AX), R13
-	MOVQ 8(AX), R11
-	MOVQ 16(AX), R12
-
-	// Copy literals
-	TESTQ R13, R13
-	JZ    check_offset
-	XORQ  R14, R14
-	TESTQ $0x00000001, R13
-	JZ    copy_1_word
-	MOVB  (SI)(R14*1), R15
-	MOVB  R15, (BX)(R14*1)
-	ADDQ  $0x01, R14
-
-copy_1_word:
-	TESTQ $0x00000002, R13
-	JZ    copy_1_dword
-	MOVW  (SI)(R14*1), R15
-	MOVW  R15, (BX)(R14*1)
-	ADDQ  $0x02, R14
-
-copy_1_dword:
-	TESTQ $0x00000004, R13
-	JZ    copy_1_qword
-	MOVL  (SI)(R14*1), R15
-	MOVL  R15, (BX)(R14*1)
-	ADDQ  $0x04, R14
-
-copy_1_qword:
-	TESTQ $0x00000008, R13
-	JZ    copy_1_test
-	MOVQ  (SI)(R14*1), R15
-	MOVQ  R15, (BX)(R14*1)
-	ADDQ  $0x08, R14
-	JMP   copy_1_test
-
-copy_1:
-	MOVUPS (SI)(R14*1), X0
-	MOVUPS X0, (BX)(R14*1)
-	ADDQ   $0x10, R14
-
-copy_1_test:
-	CMPQ R14, R13
-	JB   copy_1
-	ADDQ R13, SI
-	ADDQ R13, BX
-	ADDQ R13, R8
-
-	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
-check_offset:
-	LEAQ (R8)(DI*1), R13
-	CMPQ R12, R13
-	JG   error_match_off_too_big
-	CMPQ R12, R9
-	JG   error_match_off_too_big
-
-	// Copy match from history
-	MOVQ  R12, R13
-	SUBQ  R8, R13
-	JLS   copy_match
-	MOVQ  R10, R14
-	SUBQ  R13, R14
-	CMPQ  R11, R13
-	JGE   copy_all_from_history
-	XORQ  R12, R12
-	TESTQ $0x00000001, R11
-	JZ    copy_4_word
-	MOVB  (R14)(R12*1), R13
-	MOVB  R13, (BX)(R12*1)
-	ADDQ  $0x01, R12
-
-copy_4_word:
-	TESTQ $0x00000002, R11
-	JZ    copy_4_dword
-	MOVW  (R14)(R12*1), R13
-	MOVW  R13, (BX)(R12*1)
-	ADDQ  $0x02, R12
-
-copy_4_dword:
-	TESTQ $0x00000004, R11
-	JZ    copy_4_qword
-	MOVL  (R14)(R12*1), R13
-	MOVL  R13, (BX)(R12*1)
-	ADDQ  $0x04, R12
-
-copy_4_qword:
-	TESTQ $0x00000008, R11
-	JZ    copy_4_test
-	MOVQ  (R14)(R12*1), R13
-	MOVQ  R13, (BX)(R12*1)
-	ADDQ  $0x08, R12
-	JMP   copy_4_test
-
-copy_4:
-	MOVUPS (R14)(R12*1), X0
-	MOVUPS X0, (BX)(R12*1)
-	ADDQ   $0x10, R12
-
-copy_4_test:
-	CMPQ R12, R11
-	JB   copy_4
-	ADDQ R11, R8
-	ADDQ R11, BX
-	ADDQ $0x18, AX
-	INCQ DX
-	CMPQ DX, CX
-	JB   main_loop
-	JMP  loop_finished
-
-copy_all_from_history:
-	XORQ  R15, R15
-	TESTQ $0x00000001, R13
-	JZ    copy_5_word
-	MOVB  (R14)(R15*1), BP
-	MOVB  BP, (BX)(R15*1)
-	ADDQ  $0x01, R15
-
-copy_5_word:
-	TESTQ $0x00000002, R13
-	JZ    copy_5_dword
-	MOVW  (R14)(R15*1), BP
-	MOVW  BP, (BX)(R15*1)
-	ADDQ  $0x02, R15
-
-copy_5_dword:
-	TESTQ $0x00000004, R13
-	JZ    copy_5_qword
-	MOVL  (R14)(R15*1), BP
-	MOVL  BP, (BX)(R15*1)
-	ADDQ  $0x04, R15
-
-copy_5_qword:
-	TESTQ $0x00000008, R13
-	JZ    copy_5_test
-	MOVQ  (R14)(R15*1), BP
-	MOVQ  BP, (BX)(R15*1)
-	ADDQ  $0x08, R15
-	JMP   copy_5_test
-
-copy_5:
-	MOVUPS (R14)(R15*1), X0
-	MOVUPS X0, (BX)(R15*1)
-	ADDQ   $0x10, R15
-
-copy_5_test:
-	CMPQ R15, R13
-	JB   copy_5
-	ADDQ R13, BX
-	ADDQ R13, R8
-	SUBQ R13, R11
-
-	// Copy match from the current buffer
-copy_match:
-	TESTQ R11, R11
-	JZ    handle_loop
-	MOVQ  BX, R13
-	SUBQ  R12, R13
-
-	// ml <= mo
-	CMPQ R11, R12
-	JA   copy_overlapping_match
-
-	// Copy non-overlapping match
-	XORQ R12, R12
-
-copy_2:
-	MOVUPS (R13)(R12*1), X0
-	MOVUPS X0, (BX)(R12*1)
-	ADDQ   $0x10, R12
-	CMPQ   R12, R11
-	JB     copy_2
-	ADDQ   R11, BX
-	ADDQ   R11, R8
-	JMP    handle_loop
-
-	// Copy overlapping match
-copy_overlapping_match:
-	XORQ R12, R12
-
-copy_slow_3:
-	MOVB (R13)(R12*1), R14
-	MOVB R14, (BX)(R12*1)
-	INCQ R12
-	CMPQ R12, R11
-	JB   copy_slow_3
-	ADDQ R11, BX
-	ADDQ R11, R8
-
-handle_loop:
-	ADDQ $0x18, AX
-	INCQ DX
-	CMPQ DX, CX
-	JB   main_loop
-
-loop_finished:
-	// Return value
-	MOVB $0x01, ret+8(FP)
-
-	// Update the context
-	MOVQ ctx+0(FP), AX
-	MOVQ DX, 24(AX)
-	MOVQ R8, 104(AX)
-	MOVQ 80(AX), CX
-	SUBQ CX, SI
-	MOVQ SI, 112(AX)
-	RET
-
+	// Return with match offset too long error
 error_match_off_too_big:
-	// Return value
-	MOVB $0x00, ret+8(FP)
-
-	// Update the context
-	MOVQ ctx+0(FP), AX
-	MOVQ DX, 24(AX)
-	MOVQ R8, 104(AX)
-	MOVQ 80(AX), CX
-	SUBQ CX, SI
-	MOVQ SI, 112(AX)
+	MOVQ $0x00000003, ret+24(FP)
 	RET
-
-empty_seqs:
-	// Return value
-	MOVB $0x01, ret+8(FP)
 	RET

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -3,6 +3,1351 @@
 //go:build !appengine && !noasm && gc && !noasm
 // +build !appengine,!noasm,gc,!noasm
 
+// func sequenceDecs_decode_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
+// Requires: CMOV
+TEXT ·sequenceDecs_decode_amd64(SB), $8-32
+	MOVQ    br+8(FP), AX
+	MOVQ    32(AX), DX
+	MOVBQZX 40(AX), BX
+	MOVQ    24(AX), SI
+	MOVQ    (AX), AX
+	ADDQ    SI, AX
+	MOVQ    AX, (SP)
+	MOVQ    ctx+16(FP), AX
+	MOVQ    72(AX), DI
+	MOVQ    80(AX), R8
+	MOVQ    88(AX), R9
+	MOVQ    104(AX), R10
+	MOVQ    s+0(FP), AX
+	MOVQ    144(AX), R11
+	MOVQ    152(AX), R12
+	MOVQ    160(AX), R13
+
+sequenceDecs_decode_amd64_main_loop:
+	MOVQ (SP), R14
+
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decode_amd64_fill_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R14
+	MOVQ (R14), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decode_amd64_fill_end
+
+sequenceDecs_decode_amd64_fill_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decode_amd64_fill_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decode_amd64_fill_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R14
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decode_amd64_fill_byte_by_byte
+
+sequenceDecs_decode_amd64_fill_end:
+	// Update offset
+	MOVQ    R9, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 16(R10)
+
+	// Update match length
+	MOVQ    R8, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 8(R10)
+
+	// Fill bitreader to have enough for the remaining
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decode_amd64_fill_2_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R14
+	MOVQ (R14), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decode_amd64_fill_2_end
+
+sequenceDecs_decode_amd64_fill_2_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decode_amd64_fill_2_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decode_amd64_fill_2_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R14
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decode_amd64_fill_2_byte_by_byte
+
+sequenceDecs_decode_amd64_fill_2_end:
+	// Update literal length
+	MOVQ    DI, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, (R10)
+
+	// Fill bitreader for state updates
+	MOVQ    R14, (SP)
+	MOVQ    R9, AX
+	SHRQ    $0x08, AX
+	MOVBQZX AL, AX
+	MOVQ    ctx+16(FP), CX
+	CMPQ    96(CX), $0x00
+	JZ      sequenceDecs_decode_amd64_skip_update
+
+	// Update Literal Length State
+	MOVBQZX DI, R14
+	SHRQ    $0x10, DI
+	MOVWQZX DI, DI
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decode_amd64_llState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, DI
+
+sequenceDecs_decode_amd64_llState_updateState_skip_zero:
+	// Load ctx.llTable
+	MOVQ ctx+16(FP), CX
+	MOVQ (CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Match Length State
+	MOVBQZX R8, R14
+	SHRQ    $0x10, R8
+	MOVWQZX R8, R8
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decode_amd64_mlState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, R8
+
+sequenceDecs_decode_amd64_mlState_updateState_skip_zero:
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+	// Update Offset State
+	MOVBQZX R9, R14
+	SHRQ    $0x10, R9
+	MOVWQZX R9, R9
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decode_amd64_ofState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, R9
+
+sequenceDecs_decode_amd64_ofState_updateState_skip_zero:
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R9*8), R9
+
+sequenceDecs_decode_amd64_skip_update:
+	// Adjust offset
+	MOVQ 16(R10), CX
+	CMPQ AX, $0x01
+	JBE  sequenceDecs_decode_amd64_adjust_offsetB_1_or_0
+	MOVQ R12, R13
+	MOVQ R11, R12
+	MOVQ CX, R11
+	JMP  sequenceDecs_decode_amd64_adjust_end
+
+sequenceDecs_decode_amd64_adjust_offsetB_1_or_0:
+	CMPQ (R10), $0x00000000
+	JNE  sequenceDecs_decode_amd64_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decode_amd64_adjust_offset_nonzero
+
+sequenceDecs_decode_amd64_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_amd64_adjust_offset_nonzero
+	MOVQ  R11, CX
+	JMP   sequenceDecs_decode_amd64_adjust_end
+
+sequenceDecs_decode_amd64_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_amd64_adjust_zero
+	JEQ  sequenceDecs_decode_amd64_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_amd64_adjust_three
+	JMP  sequenceDecs_decode_amd64_adjust_two
+
+sequenceDecs_decode_amd64_adjust_zero:
+	MOVQ R11, AX
+	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_amd64_adjust_one:
+	MOVQ R12, AX
+	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_amd64_adjust_two:
+	MOVQ R13, AX
+	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_amd64_adjust_three:
+	LEAQ -1(R11), AX
+
+sequenceDecs_decode_amd64_adjust_test_temp_valid:
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decode_amd64_adjust_temp_valid
+	MOVQ  $0x00000001, AX
+
+sequenceDecs_decode_amd64_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R12, R13
+	MOVQ    R11, R12
+	MOVQ    AX, R11
+	MOVQ    AX, CX
+
+sequenceDecs_decode_amd64_adjust_end:
+	MOVQ CX, 16(R10)
+
+	// Check values
+	MOVQ  8(R10), AX
+	MOVQ  (R10), R14
+	LEAQ  (AX)(R14*1), R15
+	MOVQ  s+0(FP), BP
+	ADDQ  R15, 256(BP)
+	MOVQ  ctx+16(FP), R15
+	SUBQ  R14, 128(R15)
+	CMPQ  AX, $0x00020002
+	JA    sequenceDecs_decode_amd64_error_match_len_too_big
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_amd64_match_len_ofs_ok
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decode_amd64_error_match_len_ofs_mismatch
+
+sequenceDecs_decode_amd64_match_len_ofs_ok:
+	ADDQ $0x18, R10
+	MOVQ ctx+16(FP), AX
+	DECQ 96(AX)
+	JNS  sequenceDecs_decode_amd64_main_loop
+	MOVQ s+0(FP), AX
+	MOVQ R11, 144(AX)
+	MOVQ R12, 152(AX)
+	MOVQ R13, 160(AX)
+	MOVQ br+8(FP), AX
+	MOVQ DX, 32(AX)
+	MOVB BL, 40(AX)
+	MOVQ SI, 24(AX)
+
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
+	RET
+
+	// Return with match length error
+sequenceDecs_decode_amd64_error_match_len_ofs_mismatch:
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match too long error
+sequenceDecs_decode_amd64_error_match_len_too_big:
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+	// Return with match offset too long error
+	MOVQ $0x00000003, ret+24(FP)
+	RET
+
+// func sequenceDecs_decode_56_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
+// Requires: CMOV
+TEXT ·sequenceDecs_decode_56_amd64(SB), $8-32
+	MOVQ    br+8(FP), AX
+	MOVQ    32(AX), DX
+	MOVBQZX 40(AX), BX
+	MOVQ    24(AX), SI
+	MOVQ    (AX), AX
+	ADDQ    SI, AX
+	MOVQ    AX, (SP)
+	MOVQ    ctx+16(FP), AX
+	MOVQ    72(AX), DI
+	MOVQ    80(AX), R8
+	MOVQ    88(AX), R9
+	MOVQ    104(AX), R10
+	MOVQ    s+0(FP), AX
+	MOVQ    144(AX), R11
+	MOVQ    152(AX), R12
+	MOVQ    160(AX), R13
+
+sequenceDecs_decode_56_amd64_main_loop:
+	MOVQ (SP), R14
+
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decode_56_amd64_fill_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R14
+	MOVQ (R14), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decode_56_amd64_fill_end
+
+sequenceDecs_decode_56_amd64_fill_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decode_56_amd64_fill_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decode_56_amd64_fill_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R14
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R14), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decode_56_amd64_fill_byte_by_byte
+
+sequenceDecs_decode_56_amd64_fill_end:
+	// Update offset
+	MOVQ    R9, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 16(R10)
+
+	// Update match length
+	MOVQ    R8, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, 8(R10)
+
+	// Update literal length
+	MOVQ    DI, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R15
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R15
+	ADDQ    R15, AX
+	MOVQ    AX, (R10)
+
+	// Fill bitreader for state updates
+	MOVQ    R14, (SP)
+	MOVQ    R9, AX
+	SHRQ    $0x08, AX
+	MOVBQZX AL, AX
+	MOVQ    ctx+16(FP), CX
+	CMPQ    96(CX), $0x00
+	JZ      sequenceDecs_decode_56_amd64_skip_update
+
+	// Update Literal Length State
+	MOVBQZX DI, R14
+	SHRQ    $0x10, DI
+	MOVWQZX DI, DI
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decode_56_amd64_llState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, DI
+
+sequenceDecs_decode_56_amd64_llState_updateState_skip_zero:
+	// Load ctx.llTable
+	MOVQ ctx+16(FP), CX
+	MOVQ (CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Match Length State
+	MOVBQZX R8, R14
+	SHRQ    $0x10, R8
+	MOVWQZX R8, R8
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, R8
+
+sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero:
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+	// Update Offset State
+	MOVBQZX R9, R14
+	SHRQ    $0x10, R9
+	MOVWQZX R9, R9
+	CMPQ    R14, $0x00
+	JZ      sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R14, BX
+	MOVQ    DX, R15
+	SHLQ    CL, R15
+	MOVQ    R14, CX
+	NEGQ    CX
+	SHRQ    CL, R15
+	ADDQ    R15, R9
+
+sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero:
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R9*8), R9
+
+sequenceDecs_decode_56_amd64_skip_update:
+	// Adjust offset
+	MOVQ 16(R10), CX
+	CMPQ AX, $0x01
+	JBE  sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0
+	MOVQ R12, R13
+	MOVQ R11, R12
+	MOVQ CX, R11
+	JMP  sequenceDecs_decode_56_amd64_adjust_end
+
+sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0:
+	CMPQ (R10), $0x00000000
+	JNE  sequenceDecs_decode_56_amd64_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decode_56_amd64_adjust_offset_nonzero
+
+sequenceDecs_decode_56_amd64_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_amd64_adjust_offset_nonzero
+	MOVQ  R11, CX
+	JMP   sequenceDecs_decode_56_amd64_adjust_end
+
+sequenceDecs_decode_56_amd64_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_56_amd64_adjust_zero
+	JEQ  sequenceDecs_decode_56_amd64_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_56_amd64_adjust_three
+	JMP  sequenceDecs_decode_56_amd64_adjust_two
+
+sequenceDecs_decode_56_amd64_adjust_zero:
+	MOVQ R11, AX
+	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_56_amd64_adjust_one:
+	MOVQ R12, AX
+	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_56_amd64_adjust_two:
+	MOVQ R13, AX
+	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
+
+sequenceDecs_decode_56_amd64_adjust_three:
+	LEAQ -1(R11), AX
+
+sequenceDecs_decode_56_amd64_adjust_test_temp_valid:
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decode_56_amd64_adjust_temp_valid
+	MOVQ  $0x00000001, AX
+
+sequenceDecs_decode_56_amd64_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R12, R13
+	MOVQ    R11, R12
+	MOVQ    AX, R11
+	MOVQ    AX, CX
+
+sequenceDecs_decode_56_amd64_adjust_end:
+	MOVQ CX, 16(R10)
+
+	// Check values
+	MOVQ  8(R10), AX
+	MOVQ  (R10), R14
+	LEAQ  (AX)(R14*1), R15
+	MOVQ  s+0(FP), BP
+	ADDQ  R15, 256(BP)
+	MOVQ  ctx+16(FP), R15
+	SUBQ  R14, 128(R15)
+	CMPQ  AX, $0x00020002
+	JA    sequenceDecs_decode_56_amd64_error_match_len_too_big
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_amd64_match_len_ofs_ok
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch
+
+sequenceDecs_decode_56_amd64_match_len_ofs_ok:
+	ADDQ $0x18, R10
+	MOVQ ctx+16(FP), AX
+	DECQ 96(AX)
+	JNS  sequenceDecs_decode_56_amd64_main_loop
+	MOVQ s+0(FP), AX
+	MOVQ R11, 144(AX)
+	MOVQ R12, 152(AX)
+	MOVQ R13, 160(AX)
+	MOVQ br+8(FP), AX
+	MOVQ DX, 32(AX)
+	MOVB BL, 40(AX)
+	MOVQ SI, 24(AX)
+
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
+	RET
+
+	// Return with match length error
+sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch:
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match too long error
+sequenceDecs_decode_56_amd64_error_match_len_too_big:
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+	// Return with match offset too long error
+	MOVQ $0x00000003, ret+24(FP)
+	RET
+
+// func sequenceDecs_decode_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
+// Requires: BMI, BMI2, CMOV
+TEXT ·sequenceDecs_decode_bmi2(SB), $8-32
+	MOVQ    br+8(FP), CX
+	MOVQ    32(CX), AX
+	MOVBQZX 40(CX), DX
+	MOVQ    24(CX), BX
+	MOVQ    (CX), CX
+	ADDQ    BX, CX
+	MOVQ    CX, (SP)
+	MOVQ    ctx+16(FP), CX
+	MOVQ    72(CX), SI
+	MOVQ    80(CX), DI
+	MOVQ    88(CX), R8
+	MOVQ    104(CX), R9
+	MOVQ    s+0(FP), CX
+	MOVQ    144(CX), R10
+	MOVQ    152(CX), R11
+	MOVQ    160(CX), R12
+
+sequenceDecs_decode_bmi2_main_loop:
+	MOVQ (SP), R13
+
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decode_bmi2_fill_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R13
+	MOVQ (R13), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decode_bmi2_fill_end
+
+sequenceDecs_decode_bmi2_fill_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decode_bmi2_fill_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decode_bmi2_fill_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_bmi2_fill_byte_by_byte
+
+sequenceDecs_decode_bmi2_fill_end:
+	// Update offset
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   R8, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, 16(R9)
+
+	// Update match length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, DI, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   DI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, 8(R9)
+
+	// Fill bitreader to have enough for the remaining
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decode_bmi2_fill_2_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R13
+	MOVQ (R13), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decode_bmi2_fill_2_end
+
+sequenceDecs_decode_bmi2_fill_2_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decode_bmi2_fill_2_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decode_bmi2_fill_2_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_bmi2_fill_2_byte_by_byte
+
+sequenceDecs_decode_bmi2_fill_2_end:
+	// Update literal length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, SI, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   SI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, (R9)
+
+	// Fill bitreader for state updates
+	MOVQ   R13, (SP)
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R13
+	MOVQ   ctx+16(FP), CX
+	CMPQ   96(CX), $0x00
+	JZ     sequenceDecs_decode_bmi2_skip_update
+
+	// Update Literal Length State
+	MOVBQZX SI, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, SI, SI
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, SI
+
+	// Load ctx.llTable
+	MOVQ ctx+16(FP), CX
+	MOVQ (CX), CX
+	MOVQ (CX)(SI*8), SI
+
+	// Update Match Length State
+	MOVBQZX DI, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, DI, DI
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, DI
+
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Offset State
+	MOVBQZX R8, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, R8, R8
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, R8
+
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+sequenceDecs_decode_bmi2_skip_update:
+	// Adjust offset
+	MOVQ 16(R9), CX
+	CMPQ R13, $0x01
+	JBE  sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0
+	MOVQ R11, R12
+	MOVQ R10, R11
+	MOVQ CX, R10
+	JMP  sequenceDecs_decode_bmi2_adjust_end
+
+sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0:
+	CMPQ (R9), $0x00000000
+	JNE  sequenceDecs_decode_bmi2_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decode_bmi2_adjust_offset_nonzero
+
+sequenceDecs_decode_bmi2_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_bmi2_adjust_offset_nonzero
+	MOVQ  R10, CX
+	JMP   sequenceDecs_decode_bmi2_adjust_end
+
+sequenceDecs_decode_bmi2_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_bmi2_adjust_zero
+	JEQ  sequenceDecs_decode_bmi2_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_bmi2_adjust_three
+	JMP  sequenceDecs_decode_bmi2_adjust_two
+
+sequenceDecs_decode_bmi2_adjust_zero:
+	MOVQ R10, R13
+	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_bmi2_adjust_one:
+	MOVQ R11, R13
+	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_bmi2_adjust_two:
+	MOVQ R12, R13
+	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_bmi2_adjust_three:
+	LEAQ -1(R10), R13
+
+sequenceDecs_decode_bmi2_adjust_test_temp_valid:
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_bmi2_adjust_temp_valid
+	MOVQ  $0x00000001, R13
+
+sequenceDecs_decode_bmi2_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R11, R12
+	MOVQ    R10, R11
+	MOVQ    R13, R10
+	MOVQ    R13, CX
+
+sequenceDecs_decode_bmi2_adjust_end:
+	MOVQ CX, 16(R9)
+
+	// Check values
+	MOVQ  8(R9), R13
+	MOVQ  (R9), R14
+	LEAQ  (R13)(R14*1), R15
+	MOVQ  s+0(FP), BP
+	ADDQ  R15, 256(BP)
+	MOVQ  ctx+16(FP), R15
+	SUBQ  R14, 128(R15)
+	CMPQ  R13, $0x00020002
+	JA    sequenceDecs_decode_bmi2_error_match_len_too_big
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_bmi2_match_len_ofs_ok
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch
+
+sequenceDecs_decode_bmi2_match_len_ofs_ok:
+	ADDQ $0x18, R9
+	MOVQ ctx+16(FP), CX
+	DECQ 96(CX)
+	JNS  sequenceDecs_decode_bmi2_main_loop
+	MOVQ s+0(FP), CX
+	MOVQ R10, 144(CX)
+	MOVQ R11, 152(CX)
+	MOVQ R12, 160(CX)
+	MOVQ br+8(FP), CX
+	MOVQ AX, 32(CX)
+	MOVB DL, 40(CX)
+	MOVQ BX, 24(CX)
+
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
+	RET
+
+	// Return with match length error
+sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch:
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match too long error
+sequenceDecs_decode_bmi2_error_match_len_too_big:
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+	// Return with match offset too long error
+	MOVQ $0x00000003, ret+24(FP)
+	RET
+
+// func sequenceDecs_decode_56_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
+// Requires: BMI, BMI2, CMOV
+TEXT ·sequenceDecs_decode_56_bmi2(SB), $8-32
+	MOVQ    br+8(FP), CX
+	MOVQ    32(CX), AX
+	MOVBQZX 40(CX), DX
+	MOVQ    24(CX), BX
+	MOVQ    (CX), CX
+	ADDQ    BX, CX
+	MOVQ    CX, (SP)
+	MOVQ    ctx+16(FP), CX
+	MOVQ    72(CX), SI
+	MOVQ    80(CX), DI
+	MOVQ    88(CX), R8
+	MOVQ    104(CX), R9
+	MOVQ    s+0(FP), CX
+	MOVQ    144(CX), R10
+	MOVQ    152(CX), R11
+	MOVQ    160(CX), R12
+
+sequenceDecs_decode_56_bmi2_main_loop:
+	MOVQ (SP), R13
+
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decode_56_bmi2_fill_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R13
+	MOVQ (R13), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decode_56_bmi2_fill_end
+
+sequenceDecs_decode_56_bmi2_fill_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decode_56_bmi2_fill_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decode_56_bmi2_fill_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R13), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decode_56_bmi2_fill_byte_by_byte
+
+sequenceDecs_decode_56_bmi2_fill_end:
+	// Update offset
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   R8, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, 16(R9)
+
+	// Update match length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, DI, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   DI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, 8(R9)
+
+	// Update literal length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, SI, R14
+	MOVQ   AX, R15
+	LEAQ   (DX)(R14*1), CX
+	ROLQ   CL, R15
+	BZHIQ  R14, R15, R15
+	MOVQ   CX, DX
+	MOVQ   SI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R15, CX
+	MOVQ   CX, (R9)
+
+	// Fill bitreader for state updates
+	MOVQ   R13, (SP)
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R13
+	MOVQ   ctx+16(FP), CX
+	CMPQ   96(CX), $0x00
+	JZ     sequenceDecs_decode_56_bmi2_skip_update
+
+	// Update Literal Length State
+	MOVBQZX SI, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, SI, SI
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, SI
+
+	// Load ctx.llTable
+	MOVQ ctx+16(FP), CX
+	MOVQ (CX), CX
+	MOVQ (CX)(SI*8), SI
+
+	// Update Match Length State
+	MOVBQZX DI, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, DI, DI
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, DI
+
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Offset State
+	MOVBQZX R8, R14
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, R8, R8
+	LEAQ    (DX)(R14*1), CX
+	MOVQ    AX, R15
+	MOVQ    CX, DX
+	ROLQ    CL, R15
+	BZHIQ   R14, R15, R15
+	ADDQ    R15, R8
+
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+sequenceDecs_decode_56_bmi2_skip_update:
+	// Adjust offset
+	MOVQ 16(R9), CX
+	CMPQ R13, $0x01
+	JBE  sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0
+	MOVQ R11, R12
+	MOVQ R10, R11
+	MOVQ CX, R10
+	JMP  sequenceDecs_decode_56_bmi2_adjust_end
+
+sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0:
+	CMPQ (R9), $0x00000000
+	JNE  sequenceDecs_decode_56_bmi2_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
+
+sequenceDecs_decode_56_bmi2_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
+	MOVQ  R10, CX
+	JMP   sequenceDecs_decode_56_bmi2_adjust_end
+
+sequenceDecs_decode_56_bmi2_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decode_56_bmi2_adjust_zero
+	JEQ  sequenceDecs_decode_56_bmi2_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decode_56_bmi2_adjust_three
+	JMP  sequenceDecs_decode_56_bmi2_adjust_two
+
+sequenceDecs_decode_56_bmi2_adjust_zero:
+	MOVQ R10, R13
+	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_56_bmi2_adjust_one:
+	MOVQ R11, R13
+	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_56_bmi2_adjust_two:
+	MOVQ R12, R13
+	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
+
+sequenceDecs_decode_56_bmi2_adjust_three:
+	LEAQ -1(R10), R13
+
+sequenceDecs_decode_56_bmi2_adjust_test_temp_valid:
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_56_bmi2_adjust_temp_valid
+	MOVQ  $0x00000001, R13
+
+sequenceDecs_decode_56_bmi2_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R11, R12
+	MOVQ    R10, R11
+	MOVQ    R13, R10
+	MOVQ    R13, CX
+
+sequenceDecs_decode_56_bmi2_adjust_end:
+	MOVQ CX, 16(R9)
+
+	// Check values
+	MOVQ  8(R9), R13
+	MOVQ  (R9), R14
+	LEAQ  (R13)(R14*1), R15
+	MOVQ  s+0(FP), BP
+	ADDQ  R15, 256(BP)
+	MOVQ  ctx+16(FP), R15
+	SUBQ  R14, 128(R15)
+	CMPQ  R13, $0x00020002
+	JA    sequenceDecs_decode_56_bmi2_error_match_len_too_big
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decode_56_bmi2_match_len_ofs_ok
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch
+
+sequenceDecs_decode_56_bmi2_match_len_ofs_ok:
+	ADDQ $0x18, R9
+	MOVQ ctx+16(FP), CX
+	DECQ 96(CX)
+	JNS  sequenceDecs_decode_56_bmi2_main_loop
+	MOVQ s+0(FP), CX
+	MOVQ R10, 144(CX)
+	MOVQ R11, 152(CX)
+	MOVQ R12, 160(CX)
+	MOVQ br+8(FP), CX
+	MOVQ AX, 32(CX)
+	MOVB DL, 40(CX)
+	MOVQ BX, 24(CX)
+
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
+	RET
+
+	// Return with match length error
+sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch:
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match too long error
+sequenceDecs_decode_56_bmi2_error_match_len_too_big:
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+	// Return with match offset too long error
+	MOVQ $0x00000003, ret+24(FP)
+	RET
+
+// func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
+// Requires: SSE
+TEXT ·sequenceDecs_executeSimple_amd64(SB), $8-9
+	MOVQ  ctx+0(FP), DI
+	MOVQ  8(DI), CX
+	TESTQ CX, CX
+	JZ    empty_seqs
+	MOVQ  (DI), AX
+	MOVQ  24(DI), DX
+	MOVQ  32(DI), BX
+	MOVQ  40(DI), SI
+	MOVQ  80(DI), SI
+	MOVQ  104(DI), R9
+	MOVQ  120(DI), R10
+	MOVQ  56(DI), R11
+	MOVQ  64(DI), DI
+	ADDQ  DI, R11
+
+	// seqsBase += 24 * seqIndex
+	LEAQ (DX)(DX*2), R12
+	SHLQ $0x03, R12
+	ADDQ R12, AX
+
+	// outBase += outPosition
+	ADDQ R9, BX
+
+main_loop:
+	// Copy literals
+	MOVQ  (AX), R12
+	TESTQ R12, R12
+	JZ    check_offset
+	XORQ  R8, R8
+	TESTQ $0x00000001, R12
+	JZ    copy_1_word
+	MOVB  (SI)(R8*1), R13
+	MOVB  R13, (BX)(R8*1)
+	ADDQ  $0x01, R8
+
+copy_1_word:
+	TESTQ $0x00000002, R12
+	JZ    copy_1_dword
+	MOVW  (SI)(R8*1), R13
+	MOVW  R13, (BX)(R8*1)
+	ADDQ  $0x02, R8
+
+copy_1_dword:
+	TESTQ $0x00000004, R12
+	JZ    copy_1_qword
+	MOVL  (SI)(R8*1), R13
+	MOVL  R13, (BX)(R8*1)
+	ADDQ  $0x04, R8
+
+copy_1_qword:
+	TESTQ $0x00000008, R12
+	JZ    copy_1_test
+	MOVQ  (SI)(R8*1), R13
+	MOVQ  R13, (BX)(R8*1)
+	ADDQ  $0x08, R8
+	JMP   copy_1_test
+
+copy_1:
+	MOVUPS (SI)(R8*1), X0
+	MOVUPS X0, (BX)(R8*1)
+	ADDQ   $0x10, R8
+
+copy_1_test:
+	CMPQ R8, R12
+	JB   copy_1
+	ADDQ R12, SI
+	ADDQ R12, BX
+	ADDQ R12, R9
+	MOVQ 16(AX), R8
+
+	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
+check_offset:
+	LEAQ (R9)(DI*1), R12
+	CMPQ R8, R12
+	JG   error_match_off_too_big
+	CMPQ R8, R10
+	JG   error_match_off_too_big
+	MOVQ 8(AX), R12
+
+	// Copy match from history
+	MOVQ  R8, R13
+	SUBQ  R9, R13
+	JLS   copy_match
+	MOVQ  R11, R14
+	SUBQ  R13, R14
+	CMPQ  R12, R13
+	JGE   copy_all_from_history
+	XORQ  R13, R13
+	TESTQ $0x00000001, R12
+	JZ    copy_4_word
+	MOVB  (R14)(R13*1), R15
+	MOVB  R15, (BX)(R13*1)
+	ADDQ  $0x01, R13
+
+copy_4_word:
+	TESTQ $0x00000002, R12
+	JZ    copy_4_dword
+	MOVW  (R14)(R13*1), R15
+	MOVW  R15, (BX)(R13*1)
+	ADDQ  $0x02, R13
+
+copy_4_dword:
+	TESTQ $0x00000004, R12
+	JZ    copy_4_qword
+	MOVL  (R14)(R13*1), R15
+	MOVL  R15, (BX)(R13*1)
+	ADDQ  $0x04, R13
+
+copy_4_qword:
+	TESTQ $0x00000008, R12
+	JZ    copy_4_test
+	MOVQ  (R14)(R13*1), R15
+	MOVQ  R15, (BX)(R13*1)
+	ADDQ  $0x08, R13
+	JMP   copy_4_test
+
+copy_4:
+	MOVUPS (R14)(R13*1), X0
+	MOVUPS X0, (BX)(R13*1)
+	ADDQ   $0x10, R13
+
+copy_4_test:
+	CMPQ R13, R12
+	JB   copy_4
+	ADDQ R12, R9
+	ADDQ R12, BX
+	ADDQ $0x18, AX
+	INCQ DX
+	CMPQ DX, CX
+	JB   main_loop
+	JMP  loop_finished
+
+copy_all_from_history:
+	XORQ  R15, R15
+	TESTQ $0x00000001, R13
+	JZ    copy_5_word
+	MOVB  (R14)(R15*1), BP
+	MOVB  BP, (BX)(R15*1)
+	ADDQ  $0x01, R15
+
+copy_5_word:
+	TESTQ $0x00000002, R13
+	JZ    copy_5_dword
+	MOVW  (R14)(R15*1), BP
+	MOVW  BP, (BX)(R15*1)
+	ADDQ  $0x02, R15
+
+copy_5_dword:
+	TESTQ $0x00000004, R13
+	JZ    copy_5_qword
+	MOVL  (R14)(R15*1), BP
+	MOVL  BP, (BX)(R15*1)
+	ADDQ  $0x04, R15
+
+copy_5_qword:
+	TESTQ $0x00000008, R13
+	JZ    copy_5_test
+	MOVQ  (R14)(R15*1), BP
+	MOVQ  BP, (BX)(R15*1)
+	ADDQ  $0x08, R15
+	JMP   copy_5_test
+
+copy_5:
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (BX)(R15*1)
+	ADDQ   $0x10, R15
+
+copy_5_test:
+	CMPQ R15, R13
+	JB   copy_5
+	ADDQ R13, BX
+	ADDQ R13, R9
+	SUBQ R13, R12
+
+	// Copy match from the current buffer
+copy_match:
+	TESTQ R12, R12
+	JZ    handle_loop
+	MOVQ  BX, R13
+	SUBQ  R8, R13
+
+	// ml <= mo
+	CMPQ R12, R8
+	JA   copy_overlapping_match
+
+	// Copy non-overlapping match
+	XORQ R14, R14
+
+copy_2:
+	MOVUPS (R13)(R14*1), X0
+	MOVUPS X0, (BX)(R14*1)
+	ADDQ   $0x10, R14
+	CMPQ   R14, R12
+	JB     copy_2
+	ADDQ   R12, BX
+	ADDQ   R12, R9
+	JMP    handle_loop
+
+	// Copy overlapping match
+copy_overlapping_match:
+	XORQ R14, R14
+
+copy_slow_3:
+	MOVB (R13)(R14*1), R15
+	MOVB R15, (BX)(R14*1)
+	INCQ R14
+	CMPQ R14, R12
+	JB   copy_slow_3
+	ADDQ R12, BX
+	ADDQ R12, R9
+
+handle_loop:
+	ADDQ $0x18, AX
+	INCQ DX
+	CMPQ DX, CX
+	JB   main_loop
+
+loop_finished:
+	// Return value
+	MOVB $0x01, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R9, 104(AX)
+	MOVQ 80(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 112(AX)
+	RET
+
+error_match_off_too_big:
+	// Return value
+	MOVB $0x00, ret+8(FP)
+
+	// Update the context
+	MOVQ ctx+0(FP), AX
+	MOVQ DX, 24(AX)
+	MOVQ R9, 104(AX)
+	MOVQ 80(AX), CX
+	SUBQ CX, SI
+	MOVQ SI, 112(AX)
+	RET
+
+empty_seqs:
+	// Return value
+	MOVB $0x01, ret+8(FP)
+	RET
+
 // func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
 // Requires: CMOV, SSE
 TEXT ·sequenceDecs_decodeSync_amd64(SB), $64-32
@@ -487,6 +1832,13 @@ loop_finished:
 	MOVB BL, 40(AX)
 	MOVQ SI, 24(AX)
 
+	// Update the context
+	MOVQ ctx+16(FP), AX
+	MOVQ R12, 136(AX)
+	MOVQ 144(AX), CX
+	SUBQ CX, R11
+	MOVQ R11, 168(AX)
+
 	// Return success
 	MOVQ $0x00000000, ret+24(FP)
 	RET
@@ -528,5 +1880,518 @@ error_out_of_capacity:
 	MOVQ DX, 32(AX)
 	MOVB BL, 40(AX)
 	MOVQ SI, 24(AX)
+	MOVQ $0x00000004, ret+24(FP)
+	RET
+
+// func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
+// Requires: BMI, BMI2, CMOV, SSE
+TEXT ·sequenceDecs_decodeSync_bmi2(SB), $64-32
+	MOVQ    br+8(FP), CX
+	MOVQ    32(CX), AX
+	MOVBQZX 40(CX), DX
+	MOVQ    24(CX), BX
+	MOVQ    (CX), CX
+	ADDQ    BX, CX
+	MOVQ    CX, (SP)
+	MOVQ    ctx+16(FP), CX
+	MOVQ    72(CX), SI
+	MOVQ    80(CX), DI
+	MOVQ    88(CX), R8
+	MOVQ    112(CX), R9
+	MOVQ    144(CX), R10
+	MOVQ    136(CX), R11
+	MOVQ    200(CX), R12
+	MOVQ    R12, 56(SP)
+	MOVQ    176(CX), R12
+	MOVQ    R12, 48(SP)
+	MOVQ    184(CX), R12
+	MOVQ    R12, 40(SP)
+	MOVQ    40(SP), R12
+	ADDQ    R12, 48(SP)
+
+	// outBase += outPosition
+	ADDQ R11, R9
+	MOVQ 128(CX), R12
+	MOVQ R12, 32(SP)
+
+	// Check if we're retrying after `out` resize
+	CMPQ 208(CX), $0x01
+	JNE  sequenceDecs_decodeSync_bmi2_main_loop
+	MOVQ 216(CX), R12
+	MOVQ R12, 24(SP)
+	MOVQ 232(CX), R12
+	MOVQ R12, 8(SP)
+	MOVQ 224(CX), CX
+	MOVQ CX, 16(SP)
+	JMP  execute_single_triple
+	MOVQ s+0(FP), CX
+
+sequenceDecs_decodeSync_bmi2_main_loop:
+	MOVQ (SP), R12
+
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decodeSync_bmi2_fill_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R12
+	MOVQ (R12), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decodeSync_bmi2_fill_end
+
+sequenceDecs_decodeSync_bmi2_fill_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decodeSync_bmi2_fill_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decodeSync_bmi2_fill_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R12
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R12), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decodeSync_bmi2_fill_byte_by_byte
+
+sequenceDecs_decodeSync_bmi2_fill_end:
+	// Update offset
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R13
+	MOVQ   AX, R14
+	LEAQ   (DX)(R13*1), CX
+	ROLQ   CL, R14
+	BZHIQ  R13, R14, R14
+	MOVQ   CX, DX
+	MOVQ   R8, CX
+	SHRQ   $0x20, CX
+	ADDQ   R14, CX
+	MOVQ   CX, 8(SP)
+
+	// Update match length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, DI, R13
+	MOVQ   AX, R14
+	LEAQ   (DX)(R13*1), CX
+	ROLQ   CL, R14
+	BZHIQ  R13, R14, R14
+	MOVQ   CX, DX
+	MOVQ   DI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R14, CX
+	MOVQ   CX, 16(SP)
+
+	// Fill bitreader to have enough for the remaining
+	CMPQ BX, $0x08
+	JL   sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte
+	MOVQ DX, CX
+	SHRQ $0x03, CX
+	SUBQ CX, R12
+	MOVQ (R12), AX
+	SUBQ CX, BX
+	ANDQ $0x07, DX
+	JMP  sequenceDecs_decodeSync_bmi2_fill_2_end
+
+sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte:
+	CMPQ    BX, $0x00
+	JLE     sequenceDecs_decodeSync_bmi2_fill_2_end
+	CMPQ    DX, $0x07
+	JLE     sequenceDecs_decodeSync_bmi2_fill_2_end
+	SHLQ    $0x08, AX
+	SUBQ    $0x01, R12
+	SUBQ    $0x01, BX
+	SUBQ    $0x08, DX
+	MOVBQZX (R12), CX
+	ORQ     CX, AX
+	JMP     sequenceDecs_decodeSync_bmi2_fill_2_byte_by_byte
+
+sequenceDecs_decodeSync_bmi2_fill_2_end:
+	// Update literal length
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, SI, R13
+	MOVQ   AX, R14
+	LEAQ   (DX)(R13*1), CX
+	ROLQ   CL, R14
+	BZHIQ  R13, R14, R14
+	MOVQ   CX, DX
+	MOVQ   SI, CX
+	SHRQ   $0x20, CX
+	ADDQ   R14, CX
+	MOVQ   CX, 24(SP)
+
+	// Fill bitreader for state updates
+	MOVQ   R12, (SP)
+	MOVQ   $0x00000808, CX
+	BEXTRQ CX, R8, R12
+	MOVQ   ctx+16(FP), CX
+	CMPQ   96(CX), $0x00
+	JZ     sequenceDecs_decodeSync_bmi2_skip_update
+
+	// Update Literal Length State
+	MOVBQZX SI, R13
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, SI, SI
+	LEAQ    (DX)(R13*1), CX
+	MOVQ    AX, R14
+	MOVQ    CX, DX
+	ROLQ    CL, R14
+	BZHIQ   R13, R14, R14
+	ADDQ    R14, SI
+
+	// Load ctx.llTable
+	MOVQ ctx+16(FP), CX
+	MOVQ (CX), CX
+	MOVQ (CX)(SI*8), SI
+
+	// Update Match Length State
+	MOVBQZX DI, R13
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, DI, DI
+	LEAQ    (DX)(R13*1), CX
+	MOVQ    AX, R14
+	MOVQ    CX, DX
+	ROLQ    CL, R14
+	BZHIQ   R13, R14, R14
+	ADDQ    R14, DI
+
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Offset State
+	MOVBQZX R8, R13
+	MOVQ    $0x00001010, CX
+	BEXTRQ  CX, R8, R8
+	LEAQ    (DX)(R13*1), CX
+	MOVQ    AX, R14
+	MOVQ    CX, DX
+	ROLQ    CL, R14
+	BZHIQ   R13, R14, R14
+	ADDQ    R14, R8
+
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+sequenceDecs_decodeSync_bmi2_skip_update:
+	// Adjust offset
+	MOVQ   s+0(FP), CX
+	MOVQ   8(SP), R13
+	CMPQ   R12, $0x01
+	JBE    sequenceDecs_decodeSync_bmi2_adjust_offsetB_1_or_0
+	MOVUPS 144(CX), X0
+	MOVQ   R13, 144(CX)
+	MOVUPS X0, 152(CX)
+	JMP    sequenceDecs_decodeSync_bmi2_adjust_end
+
+sequenceDecs_decodeSync_bmi2_adjust_offsetB_1_or_0:
+	CMPQ 24(SP), $0x00000000
+	JNE  sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero
+	INCQ R13
+	JMP  sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
+
+sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero:
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
+	MOVQ  144(CX), R13
+	JMP   sequenceDecs_decodeSync_bmi2_adjust_end
+
+sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero:
+	MOVQ    R13, R12
+	XORQ    R14, R14
+	MOVQ    $-1, BP
+	CMPQ    R13, $0x03
+	CMOVQEQ R14, R12
+	CMOVQEQ BP, R14
+	LEAQ    144(CX), BP
+	ADDQ    (BP)(R12*8), R14
+	JNZ     sequenceDecs_decodeSync_bmi2_adjust_temp_valid
+	MOVQ    $0x00000001, R14
+
+sequenceDecs_decodeSync_bmi2_adjust_temp_valid:
+	CMPQ R13, $0x01
+	JZ   sequenceDecs_decodeSync_bmi2_adjust_skip
+	MOVQ 152(CX), R12
+	MOVQ R12, 160(CX)
+
+sequenceDecs_decodeSync_bmi2_adjust_skip:
+	MOVQ 144(CX), R12
+	MOVQ R12, 152(CX)
+	MOVQ R14, 144(CX)
+	MOVQ R14, R13
+
+sequenceDecs_decodeSync_bmi2_adjust_end:
+	MOVQ R13, 8(SP)
+
+	// Check values
+	MOVQ  16(SP), CX
+	MOVQ  24(SP), R12
+	LEAQ  (CX)(R12*1), R14
+	MOVQ  s+0(FP), BP
+	ADDQ  R14, 256(BP)
+	MOVQ  ctx+16(FP), R14
+	SUBQ  R12, 104(R14)
+	CMPQ  CX, $0x00020002
+	JA    sequenceDecs_decodeSync_bmi2_error_match_len_too_big
+	TESTQ R13, R13
+	JNZ   sequenceDecs_decodeSync_bmi2_match_len_ofs_ok
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch
+
+sequenceDecs_decodeSync_bmi2_match_len_ofs_ok:
+execute_single_triple:
+	// Check if ll + ml < cap(out)
+	MOVQ 32(SP), CX
+	MOVQ 24(SP), R12
+	ADDQ 16(SP), R12
+	CMPQ R12, CX
+	JA   error_out_of_capacity
+
+	// Copy literals
+	MOVQ  24(SP), CX
+	TESTQ CX, CX
+	JZ    check_offset
+	XORQ  R12, R12
+	TESTQ $0x00000001, CX
+	JZ    copy_1_word
+	MOVB  (R10)(R12*1), R13
+	MOVB  R13, (R9)(R12*1)
+	ADDQ  $0x01, R12
+
+copy_1_word:
+	TESTQ $0x00000002, CX
+	JZ    copy_1_dword
+	MOVW  (R10)(R12*1), R13
+	MOVW  R13, (R9)(R12*1)
+	ADDQ  $0x02, R12
+
+copy_1_dword:
+	TESTQ $0x00000004, CX
+	JZ    copy_1_qword
+	MOVL  (R10)(R12*1), R13
+	MOVL  R13, (R9)(R12*1)
+	ADDQ  $0x04, R12
+
+copy_1_qword:
+	TESTQ $0x00000008, CX
+	JZ    copy_1_test
+	MOVQ  (R10)(R12*1), R13
+	MOVQ  R13, (R9)(R12*1)
+	ADDQ  $0x08, R12
+	JMP   copy_1_test
+
+copy_1:
+	MOVUPS (R10)(R12*1), X0
+	MOVUPS X0, (R9)(R12*1)
+	ADDQ   $0x10, R12
+
+copy_1_test:
+	CMPQ R12, CX
+	JB   copy_1
+	ADDQ CX, R10
+	ADDQ CX, R9
+	ADDQ CX, R11
+	MOVQ 8(SP), R15
+
+	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
+check_offset:
+	MOVQ R11, CX
+	ADDQ 40(SP), CX
+	CMPQ R15, CX
+	JG   error_match_off_too_big
+	CMPQ R15, 56(SP)
+	JG   error_match_off_too_big
+	MOVQ 16(SP), CX
+
+	// Copy match from history
+	MOVQ  R15, R12
+	SUBQ  R11, R12
+	JLS   copy_match
+	MOVQ  48(SP), R13
+	SUBQ  R12, R13
+	CMPQ  CX, R12
+	JGE   copy_all_from_history
+	XORQ  R12, R12
+	TESTQ $0x00000001, CX
+	JZ    copy_4_word
+	MOVB  (R13)(R12*1), R14
+	MOVB  R14, (R9)(R12*1)
+	ADDQ  $0x01, R12
+
+copy_4_word:
+	TESTQ $0x00000002, CX
+	JZ    copy_4_dword
+	MOVW  (R13)(R12*1), R14
+	MOVW  R14, (R9)(R12*1)
+	ADDQ  $0x02, R12
+
+copy_4_dword:
+	TESTQ $0x00000004, CX
+	JZ    copy_4_qword
+	MOVL  (R13)(R12*1), R14
+	MOVL  R14, (R9)(R12*1)
+	ADDQ  $0x04, R12
+
+copy_4_qword:
+	TESTQ $0x00000008, CX
+	JZ    copy_4_test
+	MOVQ  (R13)(R12*1), R14
+	MOVQ  R14, (R9)(R12*1)
+	ADDQ  $0x08, R12
+	JMP   copy_4_test
+
+copy_4:
+	MOVUPS (R13)(R12*1), X0
+	MOVUPS X0, (R9)(R12*1)
+	ADDQ   $0x10, R12
+
+copy_4_test:
+	CMPQ R12, CX
+	JB   copy_4
+	ADDQ CX, R11
+	ADDQ CX, R9
+	JMP  handle_loop
+	JMP loop_finished
+
+copy_all_from_history:
+	XORQ  R14, R14
+	TESTQ $0x00000001, R12
+	JZ    copy_5_word
+	MOVB  (R13)(R14*1), BP
+	MOVB  BP, (R9)(R14*1)
+	ADDQ  $0x01, R14
+
+copy_5_word:
+	TESTQ $0x00000002, R12
+	JZ    copy_5_dword
+	MOVW  (R13)(R14*1), BP
+	MOVW  BP, (R9)(R14*1)
+	ADDQ  $0x02, R14
+
+copy_5_dword:
+	TESTQ $0x00000004, R12
+	JZ    copy_5_qword
+	MOVL  (R13)(R14*1), BP
+	MOVL  BP, (R9)(R14*1)
+	ADDQ  $0x04, R14
+
+copy_5_qword:
+	TESTQ $0x00000008, R12
+	JZ    copy_5_test
+	MOVQ  (R13)(R14*1), BP
+	MOVQ  BP, (R9)(R14*1)
+	ADDQ  $0x08, R14
+	JMP   copy_5_test
+
+copy_5:
+	MOVUPS (R13)(R14*1), X0
+	MOVUPS X0, (R9)(R14*1)
+	ADDQ   $0x10, R14
+
+copy_5_test:
+	CMPQ R14, R12
+	JB   copy_5
+	ADDQ R12, R9
+	ADDQ R12, R11
+	SUBQ R12, CX
+
+	// Copy match from the current buffer
+copy_match:
+	TESTQ CX, CX
+	JZ    handle_loop
+	MOVQ  R9, R12
+	SUBQ  R15, R12
+
+	// ml <= mo
+	CMPQ CX, R15
+	JA   copy_overlapping_match
+
+	// Copy non-overlapping match
+	XORQ R13, R13
+
+copy_2:
+	MOVUPS (R12)(R13*1), X0
+	MOVUPS X0, (R9)(R13*1)
+	ADDQ   $0x10, R13
+	CMPQ   R13, CX
+	JB     copy_2
+	ADDQ   CX, R9
+	ADDQ   CX, R11
+	JMP    handle_loop
+
+	// Copy overlapping match
+copy_overlapping_match:
+	XORQ R13, R13
+
+copy_slow_3:
+	MOVB (R12)(R13*1), R14
+	MOVB R14, (R9)(R13*1)
+	INCQ R13
+	CMPQ R13, CX
+	JB   copy_slow_3
+	ADDQ CX, R9
+	ADDQ CX, R11
+
+handle_loop:
+	MOVQ ctx+16(FP), CX
+	DECQ 96(CX)
+	JNS  sequenceDecs_decodeSync_bmi2_main_loop
+
+loop_finished:
+	MOVQ s+0(FP), CX
+	MOVQ br+8(FP), CX
+	MOVQ AX, 32(CX)
+	MOVB DL, 40(CX)
+	MOVQ BX, 24(CX)
+
+	// Update the context
+	MOVQ ctx+16(FP), AX
+	MOVQ R11, 136(AX)
+	MOVQ 144(AX), CX
+	SUBQ CX, R10
+	MOVQ R10, 168(AX)
+
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
+	RET
+
+	// Return with match length error
+sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 224(CX)
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match too long error
+sequenceDecs_decodeSync_bmi2_error_match_len_too_big:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 224(CX)
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+	// Return with match offset too long error
+error_match_off_too_big:
+	MOVQ ctx+16(FP), AX
+	MOVQ 8(SP), CX
+	MOVQ CX, 232(AX)
+	MOVQ R11, 136(AX)
+	MOVQ $0x00000003, ret+24(FP)
+	RET
+
+	// Return request to resize `out` by at least ll + ml bytes
+error_out_of_capacity:
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(SP), SI
+	MOVQ SI, 216(CX)
+	MOVQ 16(SP), SI
+	MOVQ SI, 224(CX)
+	MOVQ R11, 136(CX)
+	MOVQ br+8(FP), CX
+	MOVQ AX, 32(CX)
+	MOVB DL, 40(CX)
+	MOVQ BX, 24(CX)
 	MOVQ $0x00000004, ret+24(FP)
 	RET

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -3,9 +3,9 @@
 //go:build !appengine && !noasm && gc && !noasm
 // +build !appengine,!noasm,gc,!noasm
 
-// func sequenceDecs_decode_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: CMOV
-TEXT ·sequenceDecs_decode_amd64(SB), $8-32
+// func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
+// Requires: CMOV, SSE
+TEXT ·sequenceDecs_decodeSync_amd64(SB), $88-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
 	MOVBQZX 40(AX), BX
@@ -17,1318 +17,507 @@ TEXT ·sequenceDecs_decode_amd64(SB), $8-32
 	MOVQ    72(AX), DI
 	MOVQ    80(AX), R8
 	MOVQ    88(AX), R9
-	MOVQ    104(AX), R10
-	MOVQ    s+0(FP), AX
-	MOVQ    144(AX), R11
-	MOVQ    152(AX), R12
-	MOVQ    160(AX), R13
-
-sequenceDecs_decode_amd64_main_loop:
-	MOVQ (SP), R14
-
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ SI, $0x08
-	JL   sequenceDecs_decode_amd64_fill_byte_by_byte
-	MOVQ BX, AX
-	SHRQ $0x03, AX
-	SUBQ AX, R14
-	MOVQ (R14), DX
-	SUBQ AX, SI
-	ANDQ $0x07, BX
-	JMP  sequenceDecs_decode_amd64_fill_end
-
-sequenceDecs_decode_amd64_fill_byte_by_byte:
-	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decode_amd64_fill_end
-	CMPQ    BX, $0x07
-	JLE     sequenceDecs_decode_amd64_fill_end
-	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
-	SUBQ    $0x01, SI
-	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_amd64_fill_byte_by_byte
-
-sequenceDecs_decode_amd64_fill_end:
-	// Update offset
-	MOVQ    R9, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, 16(R10)
-
-	// Update match length
-	MOVQ    R8, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, 8(R10)
-
-	// Fill bitreader to have enough for the remaining
-	CMPQ SI, $0x08
-	JL   sequenceDecs_decode_amd64_fill_2_byte_by_byte
-	MOVQ BX, AX
-	SHRQ $0x03, AX
-	SUBQ AX, R14
-	MOVQ (R14), DX
-	SUBQ AX, SI
-	ANDQ $0x07, BX
-	JMP  sequenceDecs_decode_amd64_fill_2_end
-
-sequenceDecs_decode_amd64_fill_2_byte_by_byte:
-	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decode_amd64_fill_2_end
-	CMPQ    BX, $0x07
-	JLE     sequenceDecs_decode_amd64_fill_2_end
-	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
-	SUBQ    $0x01, SI
-	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_amd64_fill_2_byte_by_byte
-
-sequenceDecs_decode_amd64_fill_2_end:
-	// Update literal length
-	MOVQ    DI, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, (R10)
-
-	// Fill bitreader for state updates
-	MOVQ    R14, (SP)
-	MOVQ    R9, AX
-	SHRQ    $0x08, AX
-	MOVBQZX AL, AX
-	MOVQ    ctx+16(FP), CX
-	CMPQ    96(CX), $0x00
-	JZ      sequenceDecs_decode_amd64_skip_update
-
-	// Update Literal Length State
-	MOVBQZX DI, R14
-	SHRQ    $0x10, DI
-	MOVWQZX DI, DI
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_amd64_llState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, DI
-
-sequenceDecs_decode_amd64_llState_updateState_skip_zero:
-	// Load ctx.llTable
-	MOVQ ctx+16(FP), CX
-	MOVQ (CX), CX
-	MOVQ (CX)(DI*8), DI
-
-	// Update Match Length State
-	MOVBQZX R8, R14
-	SHRQ    $0x10, R8
-	MOVWQZX R8, R8
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_amd64_mlState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R8
-
-sequenceDecs_decode_amd64_mlState_updateState_skip_zero:
-	// Load ctx.mlTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 24(CX), CX
-	MOVQ (CX)(R8*8), R8
-
-	// Update Offset State
-	MOVBQZX R9, R14
-	SHRQ    $0x10, R9
-	MOVWQZX R9, R9
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_amd64_ofState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R9
-
-sequenceDecs_decode_amd64_ofState_updateState_skip_zero:
-	// Load ctx.ofTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 48(CX), CX
-	MOVQ (CX)(R9*8), R9
-
-sequenceDecs_decode_amd64_skip_update:
-	// Adjust offset
-	MOVQ 16(R10), CX
-	CMPQ AX, $0x01
-	JBE  sequenceDecs_decode_amd64_adjust_offsetB_1_or_0
-	MOVQ R12, R13
-	MOVQ R11, R12
-	MOVQ CX, R11
-	JMP  sequenceDecs_decode_amd64_adjust_end
-
-sequenceDecs_decode_amd64_adjust_offsetB_1_or_0:
-	CMPQ (R10), $0x00000000
-	JNE  sequenceDecs_decode_amd64_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_amd64_adjust_offset_nonzero
-
-sequenceDecs_decode_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_amd64_adjust_offset_nonzero
-	MOVQ  R11, CX
-	JMP   sequenceDecs_decode_amd64_adjust_end
-
-sequenceDecs_decode_amd64_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_amd64_adjust_zero
-	JEQ  sequenceDecs_decode_amd64_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_amd64_adjust_three
-	JMP  sequenceDecs_decode_amd64_adjust_two
-
-sequenceDecs_decode_amd64_adjust_zero:
-	MOVQ R11, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_one:
-	MOVQ R12, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_two:
-	MOVQ R13, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_three:
-	LEAQ -1(R11), AX
-
-sequenceDecs_decode_amd64_adjust_test_temp_valid:
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_amd64_adjust_temp_valid
-	MOVQ  $0x00000001, AX
-
-sequenceDecs_decode_amd64_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R12, R13
-	MOVQ    R11, R12
-	MOVQ    AX, R11
-	MOVQ    AX, CX
-
-sequenceDecs_decode_amd64_adjust_end:
-	MOVQ CX, 16(R10)
-
-	// Check values
-	MOVQ  8(R10), AX
-	MOVQ  (R10), R14
-	LEAQ  (AX)(R14*1), R15
-	MOVQ  s+0(FP), BP
-	ADDQ  R15, 256(BP)
-	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
-	CMPQ  AX, $0x00020002
-	JA    sequenceDecs_decode_amd64_error_match_len_too_big
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_amd64_match_len_ofs_ok
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_amd64_error_match_len_ofs_mismatch
-
-sequenceDecs_decode_amd64_match_len_ofs_ok:
-	ADDQ $0x18, R10
-	MOVQ ctx+16(FP), AX
-	DECQ 96(AX)
-	JNS  sequenceDecs_decode_amd64_main_loop
-	MOVQ s+0(FP), AX
-	MOVQ R11, 144(AX)
-	MOVQ R12, 152(AX)
-	MOVQ R13, 160(AX)
-	MOVQ br+8(FP), AX
-	MOVQ DX, 32(AX)
-	MOVB BL, 40(AX)
-	MOVQ SI, 24(AX)
-
-	// Return success
-	MOVQ $0x00000000, ret+24(FP)
-	RET
-
-	// Return with match length error
-sequenceDecs_decode_amd64_error_match_len_ofs_mismatch:
-	MOVQ $0x00000001, ret+24(FP)
-	RET
-
-	// Return with match too long error
-sequenceDecs_decode_amd64_error_match_len_too_big:
-	MOVQ $0x00000002, ret+24(FP)
-	RET
-
-// func sequenceDecs_decode_56_amd64(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: CMOV
-TEXT ·sequenceDecs_decode_56_amd64(SB), $8-32
-	MOVQ    br+8(FP), AX
-	MOVQ    32(AX), DX
-	MOVBQZX 40(AX), BX
-	MOVQ    24(AX), SI
-	MOVQ    (AX), AX
-	ADDQ    SI, AX
-	MOVQ    AX, (SP)
-	MOVQ    ctx+16(FP), AX
-	MOVQ    72(AX), DI
-	MOVQ    80(AX), R8
-	MOVQ    88(AX), R9
-	MOVQ    104(AX), R10
-	MOVQ    s+0(FP), AX
-	MOVQ    144(AX), R11
-	MOVQ    152(AX), R12
-	MOVQ    160(AX), R13
-
-sequenceDecs_decode_56_amd64_main_loop:
-	MOVQ (SP), R14
-
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ SI, $0x08
-	JL   sequenceDecs_decode_56_amd64_fill_byte_by_byte
-	MOVQ BX, AX
-	SHRQ $0x03, AX
-	SUBQ AX, R14
-	MOVQ (R14), DX
-	SUBQ AX, SI
-	ANDQ $0x07, BX
-	JMP  sequenceDecs_decode_56_amd64_fill_end
-
-sequenceDecs_decode_56_amd64_fill_byte_by_byte:
-	CMPQ    SI, $0x00
-	JLE     sequenceDecs_decode_56_amd64_fill_end
-	CMPQ    BX, $0x07
-	JLE     sequenceDecs_decode_56_amd64_fill_end
-	SHLQ    $0x08, DX
-	SUBQ    $0x01, R14
-	SUBQ    $0x01, SI
-	SUBQ    $0x08, BX
-	MOVBQZX (R14), AX
-	ORQ     AX, DX
-	JMP     sequenceDecs_decode_56_amd64_fill_byte_by_byte
-
-sequenceDecs_decode_56_amd64_fill_end:
-	// Update offset
-	MOVQ    R9, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, 16(R10)
-
-	// Update match length
-	MOVQ    R8, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, 8(R10)
-
-	// Update literal length
-	MOVQ    DI, AX
-	MOVQ    BX, CX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVB    AH, CL
-	ADDQ    CX, BX
-	NEGL    CX
-	SHRQ    CL, R15
-	SHRQ    $0x20, AX
-	TESTQ   CX, CX
-	CMOVQEQ CX, R15
-	ADDQ    R15, AX
-	MOVQ    AX, (R10)
-
-	// Fill bitreader for state updates
-	MOVQ    R14, (SP)
-	MOVQ    R9, AX
-	SHRQ    $0x08, AX
-	MOVBQZX AL, AX
-	MOVQ    ctx+16(FP), CX
-	CMPQ    96(CX), $0x00
-	JZ      sequenceDecs_decode_56_amd64_skip_update
-
-	// Update Literal Length State
-	MOVBQZX DI, R14
-	SHRQ    $0x10, DI
-	MOVWQZX DI, DI
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_56_amd64_llState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, DI
-
-sequenceDecs_decode_56_amd64_llState_updateState_skip_zero:
-	// Load ctx.llTable
-	MOVQ ctx+16(FP), CX
-	MOVQ (CX), CX
-	MOVQ (CX)(DI*8), DI
-
-	// Update Match Length State
-	MOVBQZX R8, R14
-	SHRQ    $0x10, R8
-	MOVWQZX R8, R8
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R8
-
-sequenceDecs_decode_56_amd64_mlState_updateState_skip_zero:
-	// Load ctx.mlTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 24(CX), CX
-	MOVQ (CX)(R8*8), R8
-
-	// Update Offset State
-	MOVBQZX R9, R14
-	SHRQ    $0x10, R9
-	MOVWQZX R9, R9
-	CMPQ    R14, $0x00
-	JZ      sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero
-	MOVQ    BX, CX
-	ADDQ    R14, BX
-	MOVQ    DX, R15
-	SHLQ    CL, R15
-	MOVQ    R14, CX
-	NEGQ    CX
-	SHRQ    CL, R15
-	ADDQ    R15, R9
-
-sequenceDecs_decode_56_amd64_ofState_updateState_skip_zero:
-	// Load ctx.ofTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 48(CX), CX
-	MOVQ (CX)(R9*8), R9
-
-sequenceDecs_decode_56_amd64_skip_update:
-	// Adjust offset
-	MOVQ 16(R10), CX
-	CMPQ AX, $0x01
-	JBE  sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0
-	MOVQ R12, R13
-	MOVQ R11, R12
-	MOVQ CX, R11
-	JMP  sequenceDecs_decode_56_amd64_adjust_end
-
-sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0:
-	CMPQ (R10), $0x00000000
-	JNE  sequenceDecs_decode_56_amd64_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_amd64_adjust_offset_nonzero
-
-sequenceDecs_decode_56_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_amd64_adjust_offset_nonzero
-	MOVQ  R11, CX
-	JMP   sequenceDecs_decode_56_amd64_adjust_end
-
-sequenceDecs_decode_56_amd64_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_56_amd64_adjust_zero
-	JEQ  sequenceDecs_decode_56_amd64_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_56_amd64_adjust_three
-	JMP  sequenceDecs_decode_56_amd64_adjust_two
-
-sequenceDecs_decode_56_amd64_adjust_zero:
-	MOVQ R11, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_one:
-	MOVQ R12, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_two:
-	MOVQ R13, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_three:
-	LEAQ -1(R11), AX
-
-sequenceDecs_decode_56_amd64_adjust_test_temp_valid:
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_56_amd64_adjust_temp_valid
-	MOVQ  $0x00000001, AX
-
-sequenceDecs_decode_56_amd64_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R12, R13
-	MOVQ    R11, R12
-	MOVQ    AX, R11
-	MOVQ    AX, CX
-
-sequenceDecs_decode_56_amd64_adjust_end:
-	MOVQ CX, 16(R10)
-
-	// Check values
-	MOVQ  8(R10), AX
-	MOVQ  (R10), R14
-	LEAQ  (AX)(R14*1), R15
-	MOVQ  s+0(FP), BP
-	ADDQ  R15, 256(BP)
-	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
-	CMPQ  AX, $0x00020002
-	JA    sequenceDecs_decode_56_amd64_error_match_len_too_big
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_amd64_match_len_ofs_ok
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch
-
-sequenceDecs_decode_56_amd64_match_len_ofs_ok:
-	ADDQ $0x18, R10
-	MOVQ ctx+16(FP), AX
-	DECQ 96(AX)
-	JNS  sequenceDecs_decode_56_amd64_main_loop
-	MOVQ s+0(FP), AX
-	MOVQ R11, 144(AX)
-	MOVQ R12, 152(AX)
-	MOVQ R13, 160(AX)
-	MOVQ br+8(FP), AX
-	MOVQ DX, 32(AX)
-	MOVB BL, 40(AX)
-	MOVQ SI, 24(AX)
-
-	// Return success
-	MOVQ $0x00000000, ret+24(FP)
-	RET
-
-	// Return with match length error
-sequenceDecs_decode_56_amd64_error_match_len_ofs_mismatch:
-	MOVQ $0x00000001, ret+24(FP)
-	RET
-
-	// Return with match too long error
-sequenceDecs_decode_56_amd64_error_match_len_too_big:
-	MOVQ $0x00000002, ret+24(FP)
-	RET
-
-// func sequenceDecs_decode_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: BMI, BMI2, CMOV
-TEXT ·sequenceDecs_decode_bmi2(SB), $8-32
-	MOVQ    br+8(FP), CX
-	MOVQ    32(CX), AX
-	MOVBQZX 40(CX), DX
-	MOVQ    24(CX), BX
-	MOVQ    (CX), CX
-	ADDQ    BX, CX
-	MOVQ    CX, (SP)
-	MOVQ    ctx+16(FP), CX
-	MOVQ    72(CX), SI
-	MOVQ    80(CX), DI
-	MOVQ    88(CX), R8
-	MOVQ    104(CX), R9
-	MOVQ    s+0(FP), CX
-	MOVQ    144(CX), R10
-	MOVQ    152(CX), R11
-	MOVQ    160(CX), R12
-
-sequenceDecs_decode_bmi2_main_loop:
-	MOVQ (SP), R13
-
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ BX, $0x08
-	JL   sequenceDecs_decode_bmi2_fill_byte_by_byte
-	MOVQ DX, CX
-	SHRQ $0x03, CX
-	SUBQ CX, R13
-	MOVQ (R13), AX
-	SUBQ CX, BX
-	ANDQ $0x07, DX
-	JMP  sequenceDecs_decode_bmi2_fill_end
-
-sequenceDecs_decode_bmi2_fill_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decode_bmi2_fill_end
-	CMPQ    DX, $0x07
-	JLE     sequenceDecs_decode_bmi2_fill_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R13
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_byte_by_byte
-
-sequenceDecs_decode_bmi2_fill_end:
-	// Update offset
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
-	MOVQ   CX, DX
-	MOVQ   R8, CX
-	SHRQ   $0x20, CX
-	ADDQ   R15, CX
-	MOVQ   CX, 16(R9)
-
-	// Update match length
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, DI, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
-	MOVQ   CX, DX
-	MOVQ   DI, CX
-	SHRQ   $0x20, CX
-	ADDQ   R15, CX
-	MOVQ   CX, 8(R9)
-
-	// Fill bitreader to have enough for the remaining
-	CMPQ BX, $0x08
-	JL   sequenceDecs_decode_bmi2_fill_2_byte_by_byte
-	MOVQ DX, CX
-	SHRQ $0x03, CX
-	SUBQ CX, R13
-	MOVQ (R13), AX
-	SUBQ CX, BX
-	ANDQ $0x07, DX
-	JMP  sequenceDecs_decode_bmi2_fill_2_end
-
-sequenceDecs_decode_bmi2_fill_2_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decode_bmi2_fill_2_end
-	CMPQ    DX, $0x07
-	JLE     sequenceDecs_decode_bmi2_fill_2_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R13
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_bmi2_fill_2_byte_by_byte
-
-sequenceDecs_decode_bmi2_fill_2_end:
-	// Update literal length
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, SI, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
-	MOVQ   CX, DX
-	MOVQ   SI, CX
-	SHRQ   $0x20, CX
-	ADDQ   R15, CX
-	MOVQ   CX, (R9)
-
-	// Fill bitreader for state updates
-	MOVQ   R13, (SP)
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R13
-	MOVQ   ctx+16(FP), CX
-	CMPQ   96(CX), $0x00
-	JZ     sequenceDecs_decode_bmi2_skip_update
-
-	// Update Literal Length State
-	MOVBQZX SI, R14
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, SI, SI
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
-	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, SI
-
-	// Load ctx.llTable
-	MOVQ ctx+16(FP), CX
-	MOVQ (CX), CX
-	MOVQ (CX)(SI*8), SI
-
-	// Update Match Length State
-	MOVBQZX DI, R14
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, DI, DI
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
-	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, DI
-
-	// Load ctx.mlTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 24(CX), CX
-	MOVQ (CX)(DI*8), DI
-
-	// Update Offset State
-	MOVBQZX R8, R14
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, R8, R8
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
-	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, R8
-
-	// Load ctx.ofTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 48(CX), CX
-	MOVQ (CX)(R8*8), R8
-
-sequenceDecs_decode_bmi2_skip_update:
-	// Adjust offset
-	MOVQ 16(R9), CX
-	CMPQ R13, $0x01
-	JBE  sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0
-	MOVQ R11, R12
-	MOVQ R10, R11
-	MOVQ CX, R10
-	JMP  sequenceDecs_decode_bmi2_adjust_end
-
-sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_bmi2_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decode_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_bmi2_adjust_offset_nonzero
-	MOVQ  R10, CX
-	JMP   sequenceDecs_decode_bmi2_adjust_end
-
-sequenceDecs_decode_bmi2_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_bmi2_adjust_zero
-	JEQ  sequenceDecs_decode_bmi2_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_bmi2_adjust_three
-	JMP  sequenceDecs_decode_bmi2_adjust_two
-
-sequenceDecs_decode_bmi2_adjust_zero:
-	MOVQ R10, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_one:
-	MOVQ R11, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_two:
-	MOVQ R12, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_three:
-	LEAQ -1(R10), R13
-
-sequenceDecs_decode_bmi2_adjust_test_temp_valid:
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_bmi2_adjust_temp_valid
-	MOVQ  $0x00000001, R13
-
-sequenceDecs_decode_bmi2_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R11, R12
-	MOVQ    R10, R11
-	MOVQ    R13, R10
-	MOVQ    R13, CX
-
-sequenceDecs_decode_bmi2_adjust_end:
-	MOVQ CX, 16(R9)
-
-	// Check values
-	MOVQ  8(R9), R13
-	MOVQ  (R9), R14
-	LEAQ  (R13)(R14*1), R15
-	MOVQ  s+0(FP), BP
-	ADDQ  R15, 256(BP)
-	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
-	CMPQ  R13, $0x00020002
-	JA    sequenceDecs_decode_bmi2_error_match_len_too_big
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_bmi2_match_len_ofs_ok
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch
-
-sequenceDecs_decode_bmi2_match_len_ofs_ok:
-	ADDQ $0x18, R9
-	MOVQ ctx+16(FP), CX
-	DECQ 96(CX)
-	JNS  sequenceDecs_decode_bmi2_main_loop
-	MOVQ s+0(FP), CX
-	MOVQ R10, 144(CX)
-	MOVQ R11, 152(CX)
-	MOVQ R12, 160(CX)
-	MOVQ br+8(FP), CX
-	MOVQ AX, 32(CX)
-	MOVB DL, 40(CX)
-	MOVQ BX, 24(CX)
-
-	// Return success
-	MOVQ $0x00000000, ret+24(FP)
-	RET
-
-	// Return with match length error
-sequenceDecs_decode_bmi2_error_match_len_ofs_mismatch:
-	MOVQ $0x00000001, ret+24(FP)
-	RET
-
-	// Return with match too long error
-sequenceDecs_decode_bmi2_error_match_len_too_big:
-	MOVQ $0x00000002, ret+24(FP)
-	RET
-
-// func sequenceDecs_decode_56_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmContext) int
-// Requires: BMI, BMI2, CMOV
-TEXT ·sequenceDecs_decode_56_bmi2(SB), $8-32
-	MOVQ    br+8(FP), CX
-	MOVQ    32(CX), AX
-	MOVBQZX 40(CX), DX
-	MOVQ    24(CX), BX
-	MOVQ    (CX), CX
-	ADDQ    BX, CX
-	MOVQ    CX, (SP)
-	MOVQ    ctx+16(FP), CX
-	MOVQ    72(CX), SI
-	MOVQ    80(CX), DI
-	MOVQ    88(CX), R8
-	MOVQ    104(CX), R9
-	MOVQ    s+0(FP), CX
-	MOVQ    144(CX), R10
-	MOVQ    152(CX), R11
-	MOVQ    160(CX), R12
-
-sequenceDecs_decode_56_bmi2_main_loop:
-	MOVQ (SP), R13
-
-	// Fill bitreader to have enough for the offset and match length.
-	CMPQ BX, $0x08
-	JL   sequenceDecs_decode_56_bmi2_fill_byte_by_byte
-	MOVQ DX, CX
-	SHRQ $0x03, CX
-	SUBQ CX, R13
-	MOVQ (R13), AX
-	SUBQ CX, BX
-	ANDQ $0x07, DX
-	JMP  sequenceDecs_decode_56_bmi2_fill_end
-
-sequenceDecs_decode_56_bmi2_fill_byte_by_byte:
-	CMPQ    BX, $0x00
-	JLE     sequenceDecs_decode_56_bmi2_fill_end
-	CMPQ    DX, $0x07
-	JLE     sequenceDecs_decode_56_bmi2_fill_end
-	SHLQ    $0x08, AX
-	SUBQ    $0x01, R13
-	SUBQ    $0x01, BX
-	SUBQ    $0x08, DX
-	MOVBQZX (R13), CX
-	ORQ     CX, AX
-	JMP     sequenceDecs_decode_56_bmi2_fill_byte_by_byte
-
-sequenceDecs_decode_56_bmi2_fill_end:
-	// Update offset
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
-	MOVQ   CX, DX
-	MOVQ   R8, CX
-	SHRQ   $0x20, CX
-	ADDQ   R15, CX
-	MOVQ   CX, 16(R9)
-
-	// Update match length
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, DI, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
-	MOVQ   CX, DX
-	MOVQ   DI, CX
-	SHRQ   $0x20, CX
-	ADDQ   R15, CX
-	MOVQ   CX, 8(R9)
-
-	// Update literal length
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, SI, R14
-	MOVQ   AX, R15
-	LEAQ   (DX)(R14*1), CX
-	ROLQ   CL, R15
-	BZHIQ  R14, R15, R15
-	MOVQ   CX, DX
-	MOVQ   SI, CX
-	SHRQ   $0x20, CX
-	ADDQ   R15, CX
-	MOVQ   CX, (R9)
-
-	// Fill bitreader for state updates
-	MOVQ   R13, (SP)
-	MOVQ   $0x00000808, CX
-	BEXTRQ CX, R8, R13
-	MOVQ   ctx+16(FP), CX
-	CMPQ   96(CX), $0x00
-	JZ     sequenceDecs_decode_56_bmi2_skip_update
-
-	// Update Literal Length State
-	MOVBQZX SI, R14
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, SI, SI
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
-	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, SI
-
-	// Load ctx.llTable
-	MOVQ ctx+16(FP), CX
-	MOVQ (CX), CX
-	MOVQ (CX)(SI*8), SI
-
-	// Update Match Length State
-	MOVBQZX DI, R14
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, DI, DI
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
-	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, DI
-
-	// Load ctx.mlTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 24(CX), CX
-	MOVQ (CX)(DI*8), DI
-
-	// Update Offset State
-	MOVBQZX R8, R14
-	MOVQ    $0x00001010, CX
-	BEXTRQ  CX, R8, R8
-	LEAQ    (DX)(R14*1), CX
-	MOVQ    AX, R15
-	MOVQ    CX, DX
-	ROLQ    CL, R15
-	BZHIQ   R14, R15, R15
-	ADDQ    R15, R8
-
-	// Load ctx.ofTable
-	MOVQ ctx+16(FP), CX
-	MOVQ 48(CX), CX
-	MOVQ (CX)(R8*8), R8
-
-sequenceDecs_decode_56_bmi2_skip_update:
-	// Adjust offset
-	MOVQ 16(R9), CX
-	CMPQ R13, $0x01
-	JBE  sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0
-	MOVQ R11, R12
-	MOVQ R10, R11
-	MOVQ CX, R10
-	JMP  sequenceDecs_decode_56_bmi2_adjust_end
-
-sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_56_bmi2_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decode_56_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
-	MOVQ  R10, CX
-	JMP   sequenceDecs_decode_56_bmi2_adjust_end
-
-sequenceDecs_decode_56_bmi2_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_56_bmi2_adjust_zero
-	JEQ  sequenceDecs_decode_56_bmi2_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_56_bmi2_adjust_three
-	JMP  sequenceDecs_decode_56_bmi2_adjust_two
-
-sequenceDecs_decode_56_bmi2_adjust_zero:
-	MOVQ R10, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_56_bmi2_adjust_one:
-	MOVQ R11, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_56_bmi2_adjust_two:
-	MOVQ R12, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_56_bmi2_adjust_three:
-	LEAQ -1(R10), R13
-
-sequenceDecs_decode_56_bmi2_adjust_test_temp_valid:
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_56_bmi2_adjust_temp_valid
-	MOVQ  $0x00000001, R13
-
-sequenceDecs_decode_56_bmi2_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R11, R12
-	MOVQ    R10, R11
-	MOVQ    R13, R10
-	MOVQ    R13, CX
-
-sequenceDecs_decode_56_bmi2_adjust_end:
-	MOVQ CX, 16(R9)
-
-	// Check values
-	MOVQ  8(R9), R13
-	MOVQ  (R9), R14
-	LEAQ  (R13)(R14*1), R15
-	MOVQ  s+0(FP), BP
-	ADDQ  R15, 256(BP)
-	MOVQ  ctx+16(FP), R15
-	SUBQ  R14, 128(R15)
-	CMPQ  R13, $0x00020002
-	JA    sequenceDecs_decode_56_bmi2_error_match_len_too_big
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_bmi2_match_len_ofs_ok
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch
-
-sequenceDecs_decode_56_bmi2_match_len_ofs_ok:
-	ADDQ $0x18, R9
-	MOVQ ctx+16(FP), CX
-	DECQ 96(CX)
-	JNS  sequenceDecs_decode_56_bmi2_main_loop
-	MOVQ s+0(FP), CX
-	MOVQ R10, 144(CX)
-	MOVQ R11, 152(CX)
-	MOVQ R12, 160(CX)
-	MOVQ br+8(FP), CX
-	MOVQ AX, 32(CX)
-	MOVB DL, 40(CX)
-	MOVQ BX, 24(CX)
-
-	// Return success
-	MOVQ $0x00000000, ret+24(FP)
-	RET
-
-	// Return with match length error
-sequenceDecs_decode_56_bmi2_error_match_len_ofs_mismatch:
-	MOVQ $0x00000001, ret+24(FP)
-	RET
-
-	// Return with match too long error
-sequenceDecs_decode_56_bmi2_error_match_len_too_big:
-	MOVQ $0x00000002, ret+24(FP)
-	RET
-
-// func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
-// Requires: SSE
-TEXT ·sequenceDecs_executeSimple_amd64(SB), $8-9
-	MOVQ  ctx+0(FP), DI
-	MOVQ  8(DI), CX
-	TESTQ CX, CX
-	JZ    empty_seqs
-	MOVQ  (DI), AX
-	MOVQ  24(DI), DX
-	MOVQ  32(DI), BX
-	MOVQ  40(DI), SI
-	MOVQ  80(DI), SI
-	MOVQ  104(DI), R8
-	MOVQ  120(DI), R9
-	MOVQ  56(DI), R10
-	MOVQ  64(DI), DI
-	ADDQ  DI, R10
-
-	// seqsBase += 24 * seqIndex
-	LEAQ (DX)(DX*2), R11
-	SHLQ $0x03, R11
-	ADDQ R11, AX
+	MOVQ    112(AX), CX
+	MOVQ    CX, 40(SP)
+	MOVQ    144(AX), CX
+	MOVQ    CX, 48(SP)
+	MOVQ    136(AX), CX
+	MOVQ    CX, 56(SP)
+	MOVQ    200(AX), CX
+	MOVQ    CX, 80(SP)
+	MOVQ    176(AX), CX
+	MOVQ    CX, 72(SP)
+	MOVQ    184(AX), CX
+	MOVQ    CX, 64(SP)
+	MOVQ    64(SP), CX
+	ADDQ    CX, 72(SP)
 
 	// outBase += outPosition
-	ADDQ R8, BX
+	MOVQ 56(SP), CX
+	ADDQ CX, 40(SP)
+	MOVQ 128(AX), CX
+	MOVQ CX, 32(SP)
 
-main_loop:
-	MOVQ (AX), R13
-	MOVQ 8(AX), R11
-	MOVQ 16(AX), R12
+	// Check if we're retrying after `out` resize
+	CMPQ 208(AX), $0x01
+	JNE  sequenceDecs_decodeSync_amd64_main_loop
+	MOVQ 216(AX), CX
+	MOVQ CX, 24(SP)
+	MOVQ 232(AX), CX
+	MOVQ CX, 8(SP)
+	MOVQ 224(AX), CX
+	MOVQ CX, 16(SP)
+	JMP  execute_single_triple
+	MOVQ s+0(FP), AX
+	MOVQ 144(AX), R10
+	MOVQ 152(AX), R11
+	MOVQ 160(AX), R12
+
+sequenceDecs_decodeSync_amd64_main_loop:
+	MOVQ (SP), R13
+
+	// Fill bitreader to have enough for the offset and match length.
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decodeSync_amd64_fill_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R13
+	MOVQ (R13), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decodeSync_amd64_fill_end
+
+sequenceDecs_decodeSync_amd64_fill_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decodeSync_amd64_fill_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decodeSync_amd64_fill_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R13), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_byte_by_byte
+
+sequenceDecs_decodeSync_amd64_fill_end:
+	// Update offset
+	MOVQ    R9, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R14
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R14
+	ADDQ    R14, AX
+	MOVQ    AX, 8(SP)
+
+	// Update match length
+	MOVQ    R8, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R14
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R14
+	ADDQ    R14, AX
+	MOVQ    AX, 16(SP)
+
+	// Fill bitreader to have enough for the remaining
+	CMPQ SI, $0x08
+	JL   sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
+	MOVQ BX, AX
+	SHRQ $0x03, AX
+	SUBQ AX, R13
+	MOVQ (R13), DX
+	SUBQ AX, SI
+	ANDQ $0x07, BX
+	JMP  sequenceDecs_decodeSync_amd64_fill_2_end
+
+sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte:
+	CMPQ    SI, $0x00
+	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
+	CMPQ    BX, $0x07
+	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
+	SHLQ    $0x08, DX
+	SUBQ    $0x01, R13
+	SUBQ    $0x01, SI
+	SUBQ    $0x08, BX
+	MOVBQZX (R13), AX
+	ORQ     AX, DX
+	JMP     sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
+
+sequenceDecs_decodeSync_amd64_fill_2_end:
+	// Update literal length
+	MOVQ    DI, AX
+	MOVQ    BX, CX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVB    AH, CL
+	ADDQ    CX, BX
+	NEGL    CX
+	SHRQ    CL, R14
+	SHRQ    $0x20, AX
+	TESTQ   CX, CX
+	CMOVQEQ CX, R14
+	ADDQ    R14, AX
+	MOVQ    AX, 24(SP)
+
+	// Fill bitreader for state updates
+	MOVQ    R13, (SP)
+	MOVQ    R9, AX
+	SHRQ    $0x08, AX
+	MOVBQZX AL, AX
+	MOVQ    ctx+16(FP), CX
+	CMPQ    96(CX), $0x00
+	JZ      sequenceDecs_decodeSync_amd64_skip_update
+
+	// Update Literal Length State
+	MOVBQZX DI, R13
+	SHRQ    $0x10, DI
+	MOVWQZX DI, DI
+	CMPQ    R13, $0x00
+	JZ      sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R13, BX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVQ    R13, CX
+	NEGQ    CX
+	SHRQ    CL, R14
+	ADDQ    R14, DI
+
+sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
+	// Load ctx.llTable
+	MOVQ ctx+16(FP), CX
+	MOVQ (CX), CX
+	MOVQ (CX)(DI*8), DI
+
+	// Update Match Length State
+	MOVBQZX R8, R13
+	SHRQ    $0x10, R8
+	MOVWQZX R8, R8
+	CMPQ    R13, $0x00
+	JZ      sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R13, BX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVQ    R13, CX
+	NEGQ    CX
+	SHRQ    CL, R14
+	ADDQ    R14, R8
+
+sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
+	// Load ctx.mlTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 24(CX), CX
+	MOVQ (CX)(R8*8), R8
+
+	// Update Offset State
+	MOVBQZX R9, R13
+	SHRQ    $0x10, R9
+	MOVWQZX R9, R9
+	CMPQ    R13, $0x00
+	JZ      sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero
+	MOVQ    BX, CX
+	ADDQ    R13, BX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVQ    R13, CX
+	NEGQ    CX
+	SHRQ    CL, R14
+	ADDQ    R14, R9
+
+sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
+	// Load ctx.ofTable
+	MOVQ ctx+16(FP), CX
+	MOVQ 48(CX), CX
+	MOVQ (CX)(R9*8), R9
+
+sequenceDecs_decodeSync_amd64_skip_update:
+	// Adjust offset
+	MOVQ 8(SP), CX
+	CMPQ AX, $0x01
+	JBE  sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
+	MOVQ R11, R12
+	MOVQ R10, R11
+	MOVQ CX, R10
+	JMP  sequenceDecs_decodeSync_amd64_adjust_end
+
+sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
+	CMPQ 24(SP), $0x00000000
+	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
+	INCQ CX
+	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
+
+sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
+	MOVQ  R10, CX
+	JMP   sequenceDecs_decodeSync_amd64_adjust_end
+
+sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
+	CMPQ CX, $0x01
+	JB   sequenceDecs_decodeSync_amd64_adjust_zero
+	JEQ  sequenceDecs_decodeSync_amd64_adjust_one
+	CMPQ CX, $0x02
+	JA   sequenceDecs_decodeSync_amd64_adjust_three
+	JMP  sequenceDecs_decodeSync_amd64_adjust_two
+
+sequenceDecs_decodeSync_amd64_adjust_zero:
+	MOVQ R10, AX
+	JMP  sequenceDecs_decodeSync_amd64_adjust_test_temp_valid
+
+sequenceDecs_decodeSync_amd64_adjust_one:
+	MOVQ R11, AX
+	JMP  sequenceDecs_decodeSync_amd64_adjust_test_temp_valid
+
+sequenceDecs_decodeSync_amd64_adjust_two:
+	MOVQ R12, AX
+	JMP  sequenceDecs_decodeSync_amd64_adjust_test_temp_valid
+
+sequenceDecs_decodeSync_amd64_adjust_three:
+	LEAQ -1(R10), AX
+
+sequenceDecs_decodeSync_amd64_adjust_test_temp_valid:
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decodeSync_amd64_adjust_temp_valid
+	MOVQ  $0x00000001, AX
+
+sequenceDecs_decodeSync_amd64_adjust_temp_valid:
+	CMPQ    CX, $0x01
+	CMOVQNE R11, R12
+	MOVQ    R10, R11
+	MOVQ    AX, R10
+	MOVQ    AX, CX
+
+sequenceDecs_decodeSync_amd64_adjust_end:
+	MOVQ CX, 8(SP)
+
+	// Check values
+	MOVQ  16(SP), AX
+	MOVQ  24(SP), R13
+	LEAQ  (AX)(R13*1), R14
+	MOVQ  s+0(FP), BP
+	ADDQ  R14, 256(BP)
+	MOVQ  ctx+16(FP), R14
+	SUBQ  R13, 104(R14)
+	CMPQ  AX, $0x00020002
+	JA    sequenceDecs_decodeSync_amd64_error_match_len_too_big
+	TESTQ CX, CX
+	JNZ   sequenceDecs_decodeSync_amd64_match_len_ofs_ok
+	TESTQ AX, AX
+	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
+
+sequenceDecs_decodeSync_amd64_match_len_ofs_ok:
+execute_single_triple:
+	// Check if ll + ml < cap(out)
+	MOVQ 32(SP), AX
+	MOVQ 24(SP), CX
+	ADDQ 16(SP), CX
+	CMPQ CX, AX
+	JA   error_out_of_capacity
 
 	// Copy literals
-	TESTQ R13, R13
+	MOVQ  24(SP), AX
+	TESTQ AX, AX
 	JZ    check_offset
+	MOVQ  48(SP), CX
+	MOVQ  40(SP), R13
 	XORQ  R14, R14
-	TESTQ $0x00000001, R13
+	TESTQ $0x00000001, AX
 	JZ    copy_1_word
-	MOVB  (SI)(R14*1), R15
-	MOVB  R15, (BX)(R14*1)
+	MOVB  (CX)(R14*1), R15
+	MOVB  R15, (R13)(R14*1)
 	ADDQ  $0x01, R14
 
 copy_1_word:
-	TESTQ $0x00000002, R13
+	TESTQ $0x00000002, AX
 	JZ    copy_1_dword
-	MOVW  (SI)(R14*1), R15
-	MOVW  R15, (BX)(R14*1)
+	MOVW  (CX)(R14*1), R15
+	MOVW  R15, (R13)(R14*1)
 	ADDQ  $0x02, R14
 
 copy_1_dword:
-	TESTQ $0x00000004, R13
+	TESTQ $0x00000004, AX
 	JZ    copy_1_qword
-	MOVL  (SI)(R14*1), R15
-	MOVL  R15, (BX)(R14*1)
+	MOVL  (CX)(R14*1), R15
+	MOVL  R15, (R13)(R14*1)
 	ADDQ  $0x04, R14
 
 copy_1_qword:
-	TESTQ $0x00000008, R13
+	TESTQ $0x00000008, AX
 	JZ    copy_1_test
-	MOVQ  (SI)(R14*1), R15
-	MOVQ  R15, (BX)(R14*1)
+	MOVQ  (CX)(R14*1), R15
+	MOVQ  R15, (R13)(R14*1)
 	ADDQ  $0x08, R14
 	JMP   copy_1_test
 
 copy_1:
-	MOVUPS (SI)(R14*1), X0
-	MOVUPS X0, (BX)(R14*1)
+	MOVUPS (CX)(R14*1), X0
+	MOVUPS X0, (R13)(R14*1)
 	ADDQ   $0x10, R14
 
 copy_1_test:
-	CMPQ R14, R13
+	CMPQ R14, AX
 	JB   copy_1
-	ADDQ R13, SI
-	ADDQ R13, BX
-	ADDQ R13, R8
+	ADDQ AX, 48(SP)
+	ADDQ AX, 40(SP)
+	ADDQ AX, 56(SP)
+	MOVQ 8(SP), R15
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
 check_offset:
-	LEAQ (R8)(DI*1), R13
-	CMPQ R12, R13
+	MOVQ 56(SP), AX
+	ADDQ 64(SP), AX
+	CMPQ R15, AX
 	JG   error_match_off_too_big
-	CMPQ R12, R9
+	CMPQ R15, 80(SP)
 	JG   error_match_off_too_big
+	MOVQ 16(SP), AX
 
 	// Copy match from history
-	MOVQ  R12, R13
-	SUBQ  R8, R13
+	MOVQ  R15, CX
+	SUBQ  56(SP), CX
 	JLS   copy_match
-	MOVQ  R10, R14
-	SUBQ  R13, R14
-	CMPQ  R11, R13
+	MOVQ  72(SP), R13
+	SUBQ  CX, R13
+	CMPQ  AX, CX
 	JGE   copy_all_from_history
-	XORQ  R12, R12
-	TESTQ $0x00000001, R11
+	MOVQ  40(SP), CX
+	XORQ  R14, R14
+	TESTQ $0x00000001, AX
 	JZ    copy_4_word
-	MOVB  (R14)(R12*1), R13
-	MOVB  R13, (BX)(R12*1)
-	ADDQ  $0x01, R12
+	MOVB  (R13)(R14*1), BP
+	MOVB  BP, (CX)(R14*1)
+	ADDQ  $0x01, R14
 
 copy_4_word:
-	TESTQ $0x00000002, R11
+	TESTQ $0x00000002, AX
 	JZ    copy_4_dword
-	MOVW  (R14)(R12*1), R13
-	MOVW  R13, (BX)(R12*1)
-	ADDQ  $0x02, R12
+	MOVW  (R13)(R14*1), BP
+	MOVW  BP, (CX)(R14*1)
+	ADDQ  $0x02, R14
 
 copy_4_dword:
-	TESTQ $0x00000004, R11
+	TESTQ $0x00000004, AX
 	JZ    copy_4_qword
-	MOVL  (R14)(R12*1), R13
-	MOVL  R13, (BX)(R12*1)
-	ADDQ  $0x04, R12
+	MOVL  (R13)(R14*1), BP
+	MOVL  BP, (CX)(R14*1)
+	ADDQ  $0x04, R14
 
 copy_4_qword:
-	TESTQ $0x00000008, R11
+	TESTQ $0x00000008, AX
 	JZ    copy_4_test
-	MOVQ  (R14)(R12*1), R13
-	MOVQ  R13, (BX)(R12*1)
-	ADDQ  $0x08, R12
+	MOVQ  (R13)(R14*1), BP
+	MOVQ  BP, (CX)(R14*1)
+	ADDQ  $0x08, R14
 	JMP   copy_4_test
 
 copy_4:
-	MOVUPS (R14)(R12*1), X0
-	MOVUPS X0, (BX)(R12*1)
-	ADDQ   $0x10, R12
+	MOVUPS (R13)(R14*1), X0
+	MOVUPS X0, (CX)(R14*1)
+	ADDQ   $0x10, R14
 
 copy_4_test:
-	CMPQ R12, R11
+	CMPQ R14, AX
 	JB   copy_4
-	ADDQ R11, R8
-	ADDQ R11, BX
-	ADDQ $0x18, AX
-	INCQ DX
-	CMPQ DX, CX
-	JB   main_loop
-	JMP  loop_finished
+	ADDQ AX, 56(SP)
+	ADDQ AX, 40(SP)
+	JMP  handle_loop
+	JMP loop_finished
 
 copy_all_from_history:
-	XORQ  R15, R15
-	TESTQ $0x00000001, R13
-	JZ    copy_5_word
-	MOVB  (R14)(R15*1), BP
-	MOVB  BP, (BX)(R15*1)
-	ADDQ  $0x01, R15
-
-copy_5_word:
-	TESTQ $0x00000002, R13
-	JZ    copy_5_dword
-	MOVW  (R14)(R15*1), BP
-	MOVW  BP, (BX)(R15*1)
-	ADDQ  $0x02, R15
-
-copy_5_dword:
-	TESTQ $0x00000004, R13
-	JZ    copy_5_qword
-	MOVL  (R14)(R15*1), BP
-	MOVL  BP, (BX)(R15*1)
-	ADDQ  $0x04, R15
-
-copy_5_qword:
-	TESTQ $0x00000008, R13
-	JZ    copy_5_test
-	MOVQ  (R14)(R15*1), BP
-	MOVQ  BP, (BX)(R15*1)
-	ADDQ  $0x08, R15
-	JMP   copy_5_test
-
-copy_5:
-	MOVUPS (R14)(R15*1), X0
-	MOVUPS X0, (BX)(R15*1)
-	ADDQ   $0x10, R15
-
-copy_5_test:
-	CMPQ R15, R13
-	JB   copy_5
-	ADDQ R13, BX
-	ADDQ R13, R8
-	SUBQ R13, R11
+	MOVQ 40(SP), R13
+	ADDQ CX, 40(SP)
+	ADDQ CX, 56(SP)
+	SUBQ CX, AX
 
 	// Copy match from the current buffer
 copy_match:
-	TESTQ R11, R11
+	TESTQ AX, AX
 	JZ    handle_loop
-	MOVQ  BX, R13
-	SUBQ  R12, R13
+	MOVQ  40(SP), CX
+	SUBQ  R15, CX
 
 	// ml <= mo
-	CMPQ R11, R12
+	CMPQ AX, R15
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R12, R12
+	MOVQ 40(SP), R13
+	XORQ R14, R14
 
 copy_2:
-	MOVUPS (R13)(R12*1), X0
-	MOVUPS X0, (BX)(R12*1)
-	ADDQ   $0x10, R12
-	CMPQ   R12, R11
+	MOVUPS (CX)(R14*1), X0
+	MOVUPS X0, (R13)(R14*1)
+	ADDQ   $0x10, R14
+	CMPQ   R14, AX
 	JB     copy_2
-	ADDQ   R11, BX
-	ADDQ   R11, R8
+	ADDQ   AX, 40(SP)
+	ADDQ   AX, 56(SP)
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ R12, R12
+	MOVQ 40(SP), R13
+	XORQ R14, R14
 
 copy_slow_3:
-	MOVB (R13)(R12*1), R14
-	MOVB R14, (BX)(R12*1)
-	INCQ R12
-	CMPQ R12, R11
+	MOVB (CX)(R14*1), BP
+	MOVB BP, (R13)(R14*1)
+	INCQ R14
+	CMPQ R14, AX
 	JB   copy_slow_3
-	ADDQ R11, BX
-	ADDQ R11, R8
+	ADDQ AX, 40(SP)
+	ADDQ AX, 56(SP)
 
 handle_loop:
-	ADDQ $0x18, AX
-	INCQ DX
-	CMPQ DX, CX
-	JB   main_loop
+	MOVQ ctx+16(FP), AX
+	DECQ 96(AX)
+	JNS  sequenceDecs_decodeSync_amd64_main_loop
 
 loop_finished:
-	// Return value
-	MOVB $0x01, ret+8(FP)
+	MOVQ s+0(FP), AX
+	MOVQ R10, 144(AX)
+	MOVQ R11, 152(AX)
+	MOVQ R12, 160(AX)
+	MOVQ br+8(FP), AX
+	MOVQ DX, 32(AX)
+	MOVB BL, 40(AX)
+	MOVQ SI, 24(AX)
 
-	// Update the context
-	MOVQ ctx+0(FP), AX
-	MOVQ DX, 24(AX)
-	MOVQ R8, 104(AX)
-	MOVQ 80(AX), CX
-	SUBQ CX, SI
-	MOVQ SI, 112(AX)
+	// Return success
+	MOVQ $0x00000000, ret+24(FP)
 	RET
 
+	// Return with match length error
+sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 224(CX)
+	MOVQ $0x00000001, ret+24(FP)
+	RET
+
+	// Return with match too long error
+sequenceDecs_decodeSync_amd64_error_match_len_too_big:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 224(CX)
+	MOVQ $0x00000002, ret+24(FP)
+	RET
+
+	// Return with match offset too long error
 error_match_off_too_big:
-	// Return value
-	MOVB $0x00, ret+8(FP)
-
-	// Update the context
-	MOVQ ctx+0(FP), AX
-	MOVQ DX, 24(AX)
-	MOVQ R8, 104(AX)
-	MOVQ 80(AX), CX
-	SUBQ CX, SI
-	MOVQ SI, 112(AX)
+	MOVQ ctx+16(FP), AX
+	MOVQ 8(SP), CX
+	MOVQ CX, 232(AX)
+	MOVQ 56(SP), CX
+	MOVQ CX, 136(AX)
+	MOVQ $0x00000003, ret+24(FP)
 	RET
 
-empty_seqs:
-	// Return value
-	MOVB $0x01, ret+8(FP)
+	// Return request to resize `out` by at least ll + ml bytes
+error_out_of_capacity:
+	MOVQ ctx+16(FP), AX
+	MOVQ 24(SP), CX
+	MOVQ CX, 216(AX)
+	MOVQ 16(SP), CX
+	MOVQ CX, 224(AX)
+	MOVQ 56(SP), CX
+	MOVQ CX, 136(AX)
+	MOVQ br+8(FP), AX
+	MOVQ DX, 32(AX)
+	MOVB BL, 40(AX)
+	MOVQ SI, 24(AX)
+	MOVQ $0x00000004, ret+24(FP)
 	RET

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -5,7 +5,7 @@
 
 // func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
 // Requires: CMOV, SSE
-TEXT ·sequenceDecs_decodeSync_amd64(SB), $88-32
+TEXT ·sequenceDecs_decodeSync_amd64(SB), $80-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
 	MOVBQZX 40(AX), BX
@@ -17,24 +17,22 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $88-32
 	MOVQ    72(AX), DI
 	MOVQ    80(AX), R8
 	MOVQ    88(AX), R9
-	MOVQ    112(AX), CX
-	MOVQ    CX, 40(SP)
+	MOVQ    112(AX), R10
 	MOVQ    144(AX), CX
-	MOVQ    CX, 48(SP)
+	MOVQ    CX, 40(SP)
 	MOVQ    136(AX), CX
-	MOVQ    CX, 56(SP)
+	MOVQ    CX, 48(SP)
 	MOVQ    200(AX), CX
-	MOVQ    CX, 80(SP)
-	MOVQ    176(AX), CX
 	MOVQ    CX, 72(SP)
-	MOVQ    184(AX), CX
+	MOVQ    176(AX), CX
 	MOVQ    CX, 64(SP)
-	MOVQ    64(SP), CX
-	ADDQ    CX, 72(SP)
+	MOVQ    184(AX), CX
+	MOVQ    CX, 56(SP)
+	MOVQ    56(SP), CX
+	ADDQ    CX, 64(SP)
 
 	// outBase += outPosition
-	MOVQ 56(SP), CX
-	ADDQ CX, 40(SP)
+	ADDQ 48(SP), R10
 	MOVQ 128(AX), CX
 	MOVQ CX, 32(SP)
 
@@ -51,15 +49,15 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $88-32
 	MOVQ s+0(FP), AX
 
 sequenceDecs_decodeSync_amd64_main_loop:
-	MOVQ (SP), R10
+	MOVQ (SP), R11
 
 	// Fill bitreader to have enough for the offset and match length.
 	CMPQ SI, $0x08
 	JL   sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R10
-	MOVQ (R10), DX
+	SUBQ AX, R11
+	MOVQ (R11), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_end
@@ -70,10 +68,10 @@ sequenceDecs_decodeSync_amd64_fill_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R10
+	SUBQ    $0x01, R11
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R10), AX
+	MOVBQZX (R11), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 
@@ -81,31 +79,31 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	// Update offset
 	MOVQ    R9, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R11
-	SHLQ    CL, R11
+	MOVQ    DX, R12
+	SHLQ    CL, R12
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R11
+	SHRQ    CL, R12
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R11
-	ADDQ    R11, AX
+	CMOVQEQ CX, R12
+	ADDQ    R12, AX
 	MOVQ    AX, 8(SP)
 
 	// Update match length
 	MOVQ    R8, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R11
-	SHLQ    CL, R11
+	MOVQ    DX, R12
+	SHLQ    CL, R12
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R11
+	SHRQ    CL, R12
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R11
-	ADDQ    R11, AX
+	CMOVQEQ CX, R12
+	ADDQ    R12, AX
 	MOVQ    AX, 16(SP)
 
 	// Fill bitreader to have enough for the remaining
@@ -113,8 +111,8 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	JL   sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R10
-	MOVQ (R10), DX
+	SUBQ AX, R11
+	MOVQ (R11), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_2_end
@@ -125,10 +123,10 @@ sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R10
+	SUBQ    $0x01, R11
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R10), AX
+	MOVBQZX (R11), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 
@@ -136,20 +134,20 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	// Update literal length
 	MOVQ    DI, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R11
-	SHLQ    CL, R11
+	MOVQ    DX, R12
+	SHLQ    CL, R12
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R11
+	SHRQ    CL, R12
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R11
-	ADDQ    R11, AX
+	CMOVQEQ CX, R12
+	ADDQ    R12, AX
 	MOVQ    AX, 24(SP)
 
 	// Fill bitreader for state updates
-	MOVQ    R10, (SP)
+	MOVQ    R11, (SP)
 	MOVQ    R9, AX
 	SHRQ    $0x08, AX
 	MOVBQZX AL, AX
@@ -158,19 +156,19 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	JZ      sequenceDecs_decodeSync_amd64_skip_update
 
 	// Update Literal Length State
-	MOVBQZX DI, R10
+	MOVBQZX DI, R11
 	SHRQ    $0x10, DI
 	MOVWQZX DI, DI
-	CMPQ    R10, $0x00
+	CMPQ    R11, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R10, BX
-	MOVQ    DX, R11
-	SHLQ    CL, R11
-	MOVQ    R10, CX
+	ADDQ    R11, BX
+	MOVQ    DX, R12
+	SHLQ    CL, R12
+	MOVQ    R11, CX
 	NEGQ    CX
-	SHRQ    CL, R11
-	ADDQ    R11, DI
+	SHRQ    CL, R12
+	ADDQ    R12, DI
 
 sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	// Load ctx.llTable
@@ -179,19 +177,19 @@ sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	MOVQ (CX)(DI*8), DI
 
 	// Update Match Length State
-	MOVBQZX R8, R10
+	MOVBQZX R8, R11
 	SHRQ    $0x10, R8
 	MOVWQZX R8, R8
-	CMPQ    R10, $0x00
+	CMPQ    R11, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R10, BX
-	MOVQ    DX, R11
-	SHLQ    CL, R11
-	MOVQ    R10, CX
+	ADDQ    R11, BX
+	MOVQ    DX, R12
+	SHLQ    CL, R12
+	MOVQ    R11, CX
 	NEGQ    CX
-	SHRQ    CL, R11
-	ADDQ    R11, R8
+	SHRQ    CL, R12
+	ADDQ    R12, R8
 
 sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	// Load ctx.mlTable
@@ -200,19 +198,19 @@ sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	MOVQ (CX)(R8*8), R8
 
 	// Update Offset State
-	MOVBQZX R9, R10
+	MOVBQZX R9, R11
 	SHRQ    $0x10, R9
 	MOVWQZX R9, R9
-	CMPQ    R10, $0x00
+	CMPQ    R11, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R10, BX
-	MOVQ    DX, R11
-	SHLQ    CL, R11
-	MOVQ    R10, CX
+	ADDQ    R11, BX
+	MOVQ    DX, R12
+	SHLQ    CL, R12
+	MOVQ    R11, CX
 	NEGQ    CX
-	SHRQ    CL, R11
-	ADDQ    R11, R9
+	SHRQ    CL, R12
+	ADDQ    R12, R9
 
 sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 	// Load ctx.ofTable
@@ -223,40 +221,40 @@ sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 sequenceDecs_decodeSync_amd64_skip_update:
 	// Adjust offset
 	MOVQ   s+0(FP), CX
-	MOVQ   8(SP), R10
+	MOVQ   8(SP), R11
 	CMPQ   AX, $0x01
 	JBE    sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
 	MOVUPS 144(CX), X0
-	MOVQ   R10, 144(CX)
+	MOVQ   R11, 144(CX)
 	MOVUPS X0, 152(CX)
 	JMP    sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
 	CMPQ 24(SP), $0x00000000
 	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
-	INCQ R10
+	INCQ R11
 	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
 
 sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
-	TESTQ R10, R10
+	TESTQ R11, R11
 	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
-	MOVQ  144(CX), R10
+	MOVQ  144(CX), R11
 	JMP   sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
-	MOVQ    R10, AX
-	XORQ    R11, R11
-	MOVQ    $-1, R13
-	CMPQ    R10, $0x03
-	CMOVQEQ R11, AX
-	CMOVQEQ R13, R11
-	LEAQ    144(CX), R13
-	ADDQ    (R13)(AX*8), R11
+	MOVQ    R11, AX
+	XORQ    R12, R12
+	MOVQ    $-1, R14
+	CMPQ    R11, $0x03
+	CMOVQEQ R12, AX
+	CMOVQEQ R14, R12
+	LEAQ    144(CX), R14
+	ADDQ    (R14)(AX*8), R12
 	JNZ     sequenceDecs_decodeSync_amd64_adjust_temp_valid
-	MOVQ    $0x00000001, R11
+	MOVQ    $0x00000001, R12
 
 sequenceDecs_decodeSync_amd64_adjust_temp_valid:
-	CMPQ R10, $0x01
+	CMPQ R11, $0x01
 	JZ   sequenceDecs_decodeSync_amd64_adjust_skip
 	MOVQ 152(CX), AX
 	MOVQ AX, 160(CX)
@@ -264,23 +262,23 @@ sequenceDecs_decodeSync_amd64_adjust_temp_valid:
 sequenceDecs_decodeSync_amd64_adjust_skip:
 	MOVQ 144(CX), AX
 	MOVQ AX, 152(CX)
-	MOVQ R11, 144(CX)
-	MOVQ R11, R10
+	MOVQ R12, 144(CX)
+	MOVQ R12, R11
 
 sequenceDecs_decodeSync_amd64_adjust_end:
-	MOVQ R10, 8(SP)
+	MOVQ R11, 8(SP)
 
 	// Check values
 	MOVQ  16(SP), AX
 	MOVQ  24(SP), CX
-	LEAQ  (AX)(CX*1), R11
-	MOVQ  s+0(FP), R13
-	ADDQ  R11, 256(R13)
-	MOVQ  ctx+16(FP), R11
-	SUBQ  CX, 104(R11)
+	LEAQ  (AX)(CX*1), R12
+	MOVQ  s+0(FP), R14
+	ADDQ  R12, 256(R14)
+	MOVQ  ctx+16(FP), R12
+	SUBQ  CX, 104(R12)
 	CMPQ  AX, $0x00020002
 	JA    sequenceDecs_decodeSync_amd64_error_match_len_too_big
-	TESTQ R10, R10
+	TESTQ R11, R11
 	JNZ   sequenceDecs_decodeSync_amd64_match_len_ofs_ok
 	TESTQ AX, AX
 	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
@@ -298,8 +296,7 @@ execute_single_triple:
 	MOVQ  24(SP), AX
 	TESTQ AX, AX
 	JZ    check_offset
-	MOVQ  48(SP), CX
-	MOVQ  40(SP), R10
+	MOVQ  40(SP), CX
 	XORQ  R11, R11
 	TESTQ $0x00000001, AX
 	JZ    copy_1_word
@@ -337,128 +334,125 @@ copy_1:
 copy_1_test:
 	CMPQ R11, AX
 	JB   copy_1
-	ADDQ AX, 48(SP)
 	ADDQ AX, 40(SP)
-	ADDQ AX, 56(SP)
-	MOVQ 8(SP), R12
+	ADDQ AX, R10
+	ADDQ AX, 48(SP)
+	MOVQ 8(SP), R13
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
 check_offset:
-	MOVQ 56(SP), AX
-	ADDQ 64(SP), AX
-	CMPQ R12, AX
+	MOVQ 48(SP), AX
+	ADDQ 56(SP), AX
+	CMPQ R13, AX
 	JG   error_match_off_too_big
-	CMPQ R12, 80(SP)
+	CMPQ R13, 72(SP)
 	JG   error_match_off_too_big
 	MOVQ 16(SP), AX
 
 	// Copy match from history
-	MOVQ  R12, CX
-	SUBQ  56(SP), CX
+	MOVQ  R13, CX
+	SUBQ  48(SP), CX
 	JLS   copy_match
-	MOVQ  72(SP), R10
-	SUBQ  CX, R10
+	MOVQ  64(SP), R11
+	SUBQ  CX, R11
 	CMPQ  AX, CX
 	JGE   copy_all_from_history
-	MOVQ  40(SP), CX
-	XORQ  R11, R11
+	XORQ  CX, CX
 	TESTQ $0x00000001, AX
 	JZ    copy_4_word
-	MOVB  (R10)(R11*1), R13
-	MOVB  R13, (CX)(R11*1)
-	ADDQ  $0x01, R11
+	MOVB  (R11)(CX*1), R12
+	MOVB  R12, (R10)(CX*1)
+	ADDQ  $0x01, CX
 
 copy_4_word:
 	TESTQ $0x00000002, AX
 	JZ    copy_4_dword
-	MOVW  (R10)(R11*1), R13
-	MOVW  R13, (CX)(R11*1)
-	ADDQ  $0x02, R11
+	MOVW  (R11)(CX*1), R12
+	MOVW  R12, (R10)(CX*1)
+	ADDQ  $0x02, CX
 
 copy_4_dword:
 	TESTQ $0x00000004, AX
 	JZ    copy_4_qword
-	MOVL  (R10)(R11*1), R13
-	MOVL  R13, (CX)(R11*1)
-	ADDQ  $0x04, R11
+	MOVL  (R11)(CX*1), R12
+	MOVL  R12, (R10)(CX*1)
+	ADDQ  $0x04, CX
 
 copy_4_qword:
 	TESTQ $0x00000008, AX
 	JZ    copy_4_test
-	MOVQ  (R10)(R11*1), R13
-	MOVQ  R13, (CX)(R11*1)
-	ADDQ  $0x08, R11
+	MOVQ  (R11)(CX*1), R12
+	MOVQ  R12, (R10)(CX*1)
+	ADDQ  $0x08, CX
 	JMP   copy_4_test
 
 copy_4:
-	MOVUPS (R10)(R11*1), X0
-	MOVUPS X0, (CX)(R11*1)
-	ADDQ   $0x10, R11
+	MOVUPS (R11)(CX*1), X0
+	MOVUPS X0, (R10)(CX*1)
+	ADDQ   $0x10, CX
 
 copy_4_test:
-	CMPQ R11, AX
+	CMPQ CX, AX
 	JB   copy_4
-	ADDQ AX, 56(SP)
-	ADDQ AX, 40(SP)
+	ADDQ AX, 48(SP)
+	ADDQ AX, R10
 	JMP  handle_loop
 	JMP loop_finished
 
 copy_all_from_history:
-	MOVQ  40(SP), R11
-	XORQ  R13, R13
+	XORQ  R12, R12
 	TESTQ $0x00000001, CX
 	JZ    copy_5_word
-	MOVB  (R10)(R13*1), R14
-	MOVB  R14, (R11)(R13*1)
-	ADDQ  $0x01, R13
+	MOVB  (R11)(R12*1), R14
+	MOVB  R14, (R10)(R12*1)
+	ADDQ  $0x01, R12
 
 copy_5_word:
 	TESTQ $0x00000002, CX
 	JZ    copy_5_dword
-	MOVW  (R10)(R13*1), R14
-	MOVW  R14, (R11)(R13*1)
-	ADDQ  $0x02, R13
+	MOVW  (R11)(R12*1), R14
+	MOVW  R14, (R10)(R12*1)
+	ADDQ  $0x02, R12
 
 copy_5_dword:
 	TESTQ $0x00000004, CX
 	JZ    copy_5_qword
-	MOVL  (R10)(R13*1), R14
-	MOVL  R14, (R11)(R13*1)
-	ADDQ  $0x04, R13
+	MOVL  (R11)(R12*1), R14
+	MOVL  R14, (R10)(R12*1)
+	ADDQ  $0x04, R12
 
 copy_5_qword:
 	TESTQ $0x00000008, CX
 	JZ    copy_5_test
-	MOVQ  (R10)(R13*1), R14
-	MOVQ  R14, (R11)(R13*1)
-	ADDQ  $0x08, R13
+	MOVQ  (R11)(R12*1), R14
+	MOVQ  R14, (R10)(R12*1)
+	ADDQ  $0x08, R12
 	JMP   copy_5_test
 
 copy_5:
-	MOVUPS (R10)(R13*1), X0
-	MOVUPS X0, (R11)(R13*1)
-	ADDQ   $0x10, R13
+	MOVUPS (R11)(R12*1), X0
+	MOVUPS X0, (R10)(R12*1)
+	ADDQ   $0x10, R12
 
 copy_5_test:
-	CMPQ R13, CX
+	CMPQ R12, CX
 	JB   copy_5
-	ADDQ CX, 40(SP)
-	ADDQ CX, 56(SP)
+	ADDQ CX, R10
+	ADDQ CX, 48(SP)
 	SUBQ CX, AX
 
 	// Copy match from the current buffer
 copy_match:
 	TESTQ AX, AX
 	JZ    handle_loop
-	MOVQ  40(SP), CX
-	SUBQ  R12, CX
+	MOVQ  R10, CX
+	SUBQ  R13, CX
 
 	// ml <= mo
-	CMPQ AX, R12
+	CMPQ AX, R13
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	MOVQ 40(SP), R10
 	XORQ R11, R11
 
 copy_2:
@@ -467,23 +461,22 @@ copy_2:
 	ADDQ   $0x10, R11
 	CMPQ   R11, AX
 	JB     copy_2
-	ADDQ   AX, 40(SP)
-	ADDQ   AX, 56(SP)
+	ADDQ   AX, R10
+	ADDQ   AX, 48(SP)
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	MOVQ 40(SP), R10
 	XORQ R11, R11
 
 copy_slow_3:
-	MOVB (CX)(R11*1), R13
-	MOVB R13, (R10)(R11*1)
+	MOVB (CX)(R11*1), R12
+	MOVB R12, (R10)(R11*1)
 	INCQ R11
 	CMPQ R11, AX
 	JB   copy_slow_3
-	ADDQ AX, 40(SP)
-	ADDQ AX, 56(SP)
+	ADDQ AX, R10
+	ADDQ AX, 48(SP)
 
 handle_loop:
 	MOVQ ctx+16(FP), AX
@@ -522,7 +515,7 @@ error_match_off_too_big:
 	MOVQ ctx+16(FP), AX
 	MOVQ 8(SP), CX
 	MOVQ CX, 232(AX)
-	MOVQ 56(SP), CX
+	MOVQ 48(SP), CX
 	MOVQ CX, 136(AX)
 	MOVQ $0x00000003, ret+24(FP)
 	RET
@@ -534,7 +527,7 @@ error_out_of_capacity:
 	MOVQ CX, 216(AX)
 	MOVQ 16(SP), CX
 	MOVQ CX, 224(AX)
-	MOVQ 56(SP), CX
+	MOVQ 48(SP), CX
 	MOVQ CX, 136(AX)
 	MOVQ br+8(FP), AX
 	MOVQ DX, 32(AX)

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -1310,17 +1310,46 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R12, R12
+	XORQ  R12, R12
+	TESTQ $0x00000001, R13
+	JZ    copy_2_word
+	MOVB  (R11)(R12*1), R14
+	MOVB  R14, (BX)(R12*1)
+	ADDQ  $0x01, R12
+
+copy_2_word:
+	TESTQ $0x00000002, R13
+	JZ    copy_2_dword
+	MOVW  (R11)(R12*1), R14
+	MOVW  R14, (BX)(R12*1)
+	ADDQ  $0x02, R12
+
+copy_2_dword:
+	TESTQ $0x00000004, R13
+	JZ    copy_2_qword
+	MOVL  (R11)(R12*1), R14
+	MOVL  R14, (BX)(R12*1)
+	ADDQ  $0x04, R12
+
+copy_2_qword:
+	TESTQ $0x00000008, R13
+	JZ    copy_2_test
+	MOVQ  (R11)(R12*1), R14
+	MOVQ  R14, (BX)(R12*1)
+	ADDQ  $0x08, R12
+	JMP   copy_2_test
 
 copy_2:
 	MOVUPS (R11)(R12*1), X0
 	MOVUPS X0, (BX)(R12*1)
 	ADDQ   $0x10, R12
-	CMPQ   R12, R13
-	JB     copy_2
-	ADDQ   R13, BX
-	ADDQ   R13, DI
-	JMP    handle_loop
+
+copy_2_test:
+	CMPQ R12, R13
+	JB   copy_2
+	ADDQ R13, BX
+	ADDQ R13, DI
+	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
@@ -1821,17 +1850,46 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ CX, CX
+	XORQ  CX, CX
+	TESTQ $0x00000001, R13
+	JZ    copy_2_word
+	MOVB  (AX)(CX*1), R14
+	MOVB  R14, (R10)(CX*1)
+	ADDQ  $0x01, CX
+
+copy_2_word:
+	TESTQ $0x00000002, R13
+	JZ    copy_2_dword
+	MOVW  (AX)(CX*1), R14
+	MOVW  R14, (R10)(CX*1)
+	ADDQ  $0x02, CX
+
+copy_2_dword:
+	TESTQ $0x00000004, R13
+	JZ    copy_2_qword
+	MOVL  (AX)(CX*1), R14
+	MOVL  R14, (R10)(CX*1)
+	ADDQ  $0x04, CX
+
+copy_2_qword:
+	TESTQ $0x00000008, R13
+	JZ    copy_2_test
+	MOVQ  (AX)(CX*1), R14
+	MOVQ  R14, (R10)(CX*1)
+	ADDQ  $0x08, CX
+	JMP   copy_2_test
 
 copy_2:
 	MOVUPS (AX)(CX*1), X0
 	MOVUPS X0, (R10)(CX*1)
 	ADDQ   $0x10, CX
-	CMPQ   CX, R13
-	JB     copy_2
-	ADDQ   R13, R10
-	ADDQ   R13, R12
-	JMP    handle_loop
+
+copy_2_test:
+	CMPQ CX, R13
+	JB   copy_2
+	ADDQ R13, R10
+	ADDQ R13, R12
+	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
@@ -2351,17 +2409,46 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R12, R12
+	XORQ  R12, R12
+	TESTQ $0x00000001, R13
+	JZ    copy_2_word
+	MOVB  (CX)(R12*1), R14
+	MOVB  R14, (R9)(R12*1)
+	ADDQ  $0x01, R12
+
+copy_2_word:
+	TESTQ $0x00000002, R13
+	JZ    copy_2_dword
+	MOVW  (CX)(R12*1), R14
+	MOVW  R14, (R9)(R12*1)
+	ADDQ  $0x02, R12
+
+copy_2_dword:
+	TESTQ $0x00000004, R13
+	JZ    copy_2_qword
+	MOVL  (CX)(R12*1), R14
+	MOVL  R14, (R9)(R12*1)
+	ADDQ  $0x04, R12
+
+copy_2_qword:
+	TESTQ $0x00000008, R13
+	JZ    copy_2_test
+	MOVQ  (CX)(R12*1), R14
+	MOVQ  R14, (R9)(R12*1)
+	ADDQ  $0x08, R12
+	JMP   copy_2_test
 
 copy_2:
 	MOVUPS (CX)(R12*1), X0
 	MOVUPS X0, (R9)(R12*1)
 	ADDQ   $0x10, R12
-	CMPQ   R12, R13
-	JB     copy_2
-	ADDQ   R13, R9
-	ADDQ   R13, R11
-	JMP    handle_loop
+
+copy_2_test:
+	CMPQ R12, R13
+	JB   copy_2
+	ADDQ R13, R9
+	ADDQ R13, R11
+	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -1881,9 +1881,10 @@ sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch:
 
 	// Return with match too long error
 sequenceDecs_decodeSync_amd64_error_match_len_too_big:
-	MOVQ 16(SP), AX
-	MOVQ ctx+16(FP), CX
-	MOVQ AX, 224(CX)
+	MOVQ ctx+16(FP), AX
+	MOVQ 16(SP), CX
+	MOVQ CX, 224(AX)
+	MOVQ R12, 136(AX)
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
@@ -2407,9 +2408,10 @@ sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch:
 
 	// Return with match too long error
 sequenceDecs_decodeSync_bmi2_error_match_len_too_big:
-	MOVQ 16(SP), AX
-	MOVQ ctx+16(FP), CX
-	MOVQ AX, 224(CX)
+	MOVQ ctx+16(FP), AX
+	MOVQ 16(SP), CX
+	MOVQ CX, 224(AX)
+	MOVQ R11, 136(AX)
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -5,7 +5,7 @@
 
 // func sequenceDecs_decodeSync_amd64(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
 // Requires: CMOV, SSE
-TEXT ·sequenceDecs_decodeSync_amd64(SB), $72-32
+TEXT ·sequenceDecs_decodeSync_amd64(SB), $64-32
 	MOVQ    br+8(FP), AX
 	MOVQ    32(AX), DX
 	MOVBQZX 40(AX), BX
@@ -18,20 +18,19 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $72-32
 	MOVQ    80(AX), R8
 	MOVQ    88(AX), R9
 	MOVQ    112(AX), R10
-	MOVQ    144(AX), CX
-	MOVQ    CX, 40(SP)
-	MOVQ    136(AX), R11
+	MOVQ    144(AX), R11
+	MOVQ    136(AX), R12
 	MOVQ    200(AX), CX
-	MOVQ    CX, 64(SP)
-	MOVQ    176(AX), CX
 	MOVQ    CX, 56(SP)
-	MOVQ    184(AX), CX
+	MOVQ    176(AX), CX
 	MOVQ    CX, 48(SP)
-	MOVQ    48(SP), CX
-	ADDQ    CX, 56(SP)
+	MOVQ    184(AX), CX
+	MOVQ    CX, 40(SP)
+	MOVQ    40(SP), CX
+	ADDQ    CX, 48(SP)
 
 	// outBase += outPosition
-	ADDQ R11, R10
+	ADDQ R12, R10
 	MOVQ 128(AX), CX
 	MOVQ CX, 32(SP)
 
@@ -48,15 +47,15 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $72-32
 	MOVQ s+0(FP), AX
 
 sequenceDecs_decodeSync_amd64_main_loop:
-	MOVQ (SP), R12
+	MOVQ (SP), R13
 
 	// Fill bitreader to have enough for the offset and match length.
 	CMPQ SI, $0x08
 	JL   sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R12
-	MOVQ (R12), DX
+	SUBQ AX, R13
+	MOVQ (R13), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_end
@@ -67,10 +66,10 @@ sequenceDecs_decodeSync_amd64_fill_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R12
+	SUBQ    $0x01, R13
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R12), AX
+	MOVBQZX (R13), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_byte_by_byte
 
@@ -78,31 +77,31 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	// Update offset
 	MOVQ    R9, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R13
-	SHLQ    CL, R13
+	MOVQ    DX, R14
+	SHLQ    CL, R14
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R13
+	SHRQ    CL, R14
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R13
-	ADDQ    R13, AX
+	CMOVQEQ CX, R14
+	ADDQ    R14, AX
 	MOVQ    AX, 8(SP)
 
 	// Update match length
 	MOVQ    R8, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R13
-	SHLQ    CL, R13
+	MOVQ    DX, R14
+	SHLQ    CL, R14
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R13
+	SHRQ    CL, R14
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R13
-	ADDQ    R13, AX
+	CMOVQEQ CX, R14
+	ADDQ    R14, AX
 	MOVQ    AX, 16(SP)
 
 	// Fill bitreader to have enough for the remaining
@@ -110,8 +109,8 @@ sequenceDecs_decodeSync_amd64_fill_end:
 	JL   sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 	MOVQ BX, AX
 	SHRQ $0x03, AX
-	SUBQ AX, R12
-	MOVQ (R12), DX
+	SUBQ AX, R13
+	MOVQ (R13), DX
 	SUBQ AX, SI
 	ANDQ $0x07, BX
 	JMP  sequenceDecs_decodeSync_amd64_fill_2_end
@@ -122,10 +121,10 @@ sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte:
 	CMPQ    BX, $0x07
 	JLE     sequenceDecs_decodeSync_amd64_fill_2_end
 	SHLQ    $0x08, DX
-	SUBQ    $0x01, R12
+	SUBQ    $0x01, R13
 	SUBQ    $0x01, SI
 	SUBQ    $0x08, BX
-	MOVBQZX (R12), AX
+	MOVBQZX (R13), AX
 	ORQ     AX, DX
 	JMP     sequenceDecs_decodeSync_amd64_fill_2_byte_by_byte
 
@@ -133,20 +132,20 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	// Update literal length
 	MOVQ    DI, AX
 	MOVQ    BX, CX
-	MOVQ    DX, R13
-	SHLQ    CL, R13
+	MOVQ    DX, R14
+	SHLQ    CL, R14
 	MOVB    AH, CL
 	ADDQ    CX, BX
 	NEGL    CX
-	SHRQ    CL, R13
+	SHRQ    CL, R14
 	SHRQ    $0x20, AX
 	TESTQ   CX, CX
-	CMOVQEQ CX, R13
-	ADDQ    R13, AX
+	CMOVQEQ CX, R14
+	ADDQ    R14, AX
 	MOVQ    AX, 24(SP)
 
 	// Fill bitreader for state updates
-	MOVQ    R12, (SP)
+	MOVQ    R13, (SP)
 	MOVQ    R9, AX
 	SHRQ    $0x08, AX
 	MOVBQZX AL, AX
@@ -155,19 +154,19 @@ sequenceDecs_decodeSync_amd64_fill_2_end:
 	JZ      sequenceDecs_decodeSync_amd64_skip_update
 
 	// Update Literal Length State
-	MOVBQZX DI, R12
+	MOVBQZX DI, R13
 	SHRQ    $0x10, DI
 	MOVWQZX DI, DI
-	CMPQ    R12, $0x00
+	CMPQ    R13, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R12, BX
-	MOVQ    DX, R13
-	SHLQ    CL, R13
-	MOVQ    R12, CX
+	ADDQ    R13, BX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVQ    R13, CX
 	NEGQ    CX
-	SHRQ    CL, R13
-	ADDQ    R13, DI
+	SHRQ    CL, R14
+	ADDQ    R14, DI
 
 sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	// Load ctx.llTable
@@ -176,19 +175,19 @@ sequenceDecs_decodeSync_amd64_llState_updateState_skip_zero:
 	MOVQ (CX)(DI*8), DI
 
 	// Update Match Length State
-	MOVBQZX R8, R12
+	MOVBQZX R8, R13
 	SHRQ    $0x10, R8
 	MOVWQZX R8, R8
-	CMPQ    R12, $0x00
+	CMPQ    R13, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R12, BX
-	MOVQ    DX, R13
-	SHLQ    CL, R13
-	MOVQ    R12, CX
+	ADDQ    R13, BX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVQ    R13, CX
 	NEGQ    CX
-	SHRQ    CL, R13
-	ADDQ    R13, R8
+	SHRQ    CL, R14
+	ADDQ    R14, R8
 
 sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	// Load ctx.mlTable
@@ -197,19 +196,19 @@ sequenceDecs_decodeSync_amd64_mlState_updateState_skip_zero:
 	MOVQ (CX)(R8*8), R8
 
 	// Update Offset State
-	MOVBQZX R9, R12
+	MOVBQZX R9, R13
 	SHRQ    $0x10, R9
 	MOVWQZX R9, R9
-	CMPQ    R12, $0x00
+	CMPQ    R13, $0x00
 	JZ      sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero
 	MOVQ    BX, CX
-	ADDQ    R12, BX
-	MOVQ    DX, R13
-	SHLQ    CL, R13
-	MOVQ    R12, CX
+	ADDQ    R13, BX
+	MOVQ    DX, R14
+	SHLQ    CL, R14
+	MOVQ    R13, CX
 	NEGQ    CX
-	SHRQ    CL, R13
-	ADDQ    R13, R9
+	SHRQ    CL, R14
+	ADDQ    R14, R9
 
 sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 	// Load ctx.ofTable
@@ -220,40 +219,40 @@ sequenceDecs_decodeSync_amd64_ofState_updateState_skip_zero:
 sequenceDecs_decodeSync_amd64_skip_update:
 	// Adjust offset
 	MOVQ   s+0(FP), CX
-	MOVQ   8(SP), R12
+	MOVQ   8(SP), R13
 	CMPQ   AX, $0x01
 	JBE    sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0
 	MOVUPS 144(CX), X0
-	MOVQ   R12, 144(CX)
+	MOVQ   R13, 144(CX)
 	MOVUPS X0, 152(CX)
 	JMP    sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
 	CMPQ 24(SP), $0x00000000
 	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
-	INCQ R12
+	INCQ R13
 	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
 
 sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
-	TESTQ R12, R12
+	TESTQ R13, R13
 	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
-	MOVQ  144(CX), R12
+	MOVQ  144(CX), R13
 	JMP   sequenceDecs_decodeSync_amd64_adjust_end
 
 sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
-	MOVQ    R12, AX
-	XORQ    R13, R13
-	MOVQ    $-1, R15
-	CMPQ    R12, $0x03
-	CMOVQEQ R13, AX
-	CMOVQEQ R15, R13
-	LEAQ    144(CX), R15
-	ADDQ    (R15)(AX*8), R13
+	MOVQ    R13, AX
+	XORQ    R14, R14
+	MOVQ    $-1, BP
+	CMPQ    R13, $0x03
+	CMOVQEQ R14, AX
+	CMOVQEQ BP, R14
+	LEAQ    144(CX), BP
+	ADDQ    (BP)(AX*8), R14
 	JNZ     sequenceDecs_decodeSync_amd64_adjust_temp_valid
-	MOVQ    $0x00000001, R13
+	MOVQ    $0x00000001, R14
 
 sequenceDecs_decodeSync_amd64_adjust_temp_valid:
-	CMPQ R12, $0x01
+	CMPQ R13, $0x01
 	JZ   sequenceDecs_decodeSync_amd64_adjust_skip
 	MOVQ 152(CX), AX
 	MOVQ AX, 160(CX)
@@ -261,23 +260,23 @@ sequenceDecs_decodeSync_amd64_adjust_temp_valid:
 sequenceDecs_decodeSync_amd64_adjust_skip:
 	MOVQ 144(CX), AX
 	MOVQ AX, 152(CX)
-	MOVQ R13, 144(CX)
-	MOVQ R13, R12
+	MOVQ R14, 144(CX)
+	MOVQ R14, R13
 
 sequenceDecs_decodeSync_amd64_adjust_end:
-	MOVQ R12, 8(SP)
+	MOVQ R13, 8(SP)
 
 	// Check values
 	MOVQ  16(SP), AX
 	MOVQ  24(SP), CX
-	LEAQ  (AX)(CX*1), R13
-	MOVQ  s+0(FP), R15
-	ADDQ  R13, 256(R15)
-	MOVQ  ctx+16(FP), R13
-	SUBQ  CX, 104(R13)
+	LEAQ  (AX)(CX*1), R14
+	MOVQ  s+0(FP), BP
+	ADDQ  R14, 256(BP)
+	MOVQ  ctx+16(FP), R14
+	SUBQ  CX, 104(R14)
 	CMPQ  AX, $0x00020002
 	JA    sequenceDecs_decodeSync_amd64_error_match_len_too_big
-	TESTQ R12, R12
+	TESTQ R13, R13
 	JNZ   sequenceDecs_decodeSync_amd64_match_len_ofs_ok
 	TESTQ AX, AX
 	JNZ   sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch
@@ -295,149 +294,148 @@ execute_single_triple:
 	MOVQ  24(SP), AX
 	TESTQ AX, AX
 	JZ    check_offset
-	MOVQ  40(SP), CX
-	XORQ  R12, R12
+	XORQ  CX, CX
 	TESTQ $0x00000001, AX
 	JZ    copy_1_word
-	MOVB  (CX)(R12*1), R13
-	MOVB  R13, (R10)(R12*1)
-	ADDQ  $0x01, R12
+	MOVB  (R11)(CX*1), R13
+	MOVB  R13, (R10)(CX*1)
+	ADDQ  $0x01, CX
 
 copy_1_word:
 	TESTQ $0x00000002, AX
 	JZ    copy_1_dword
-	MOVW  (CX)(R12*1), R13
-	MOVW  R13, (R10)(R12*1)
-	ADDQ  $0x02, R12
+	MOVW  (R11)(CX*1), R13
+	MOVW  R13, (R10)(CX*1)
+	ADDQ  $0x02, CX
 
 copy_1_dword:
 	TESTQ $0x00000004, AX
 	JZ    copy_1_qword
-	MOVL  (CX)(R12*1), R13
-	MOVL  R13, (R10)(R12*1)
-	ADDQ  $0x04, R12
+	MOVL  (R11)(CX*1), R13
+	MOVL  R13, (R10)(CX*1)
+	ADDQ  $0x04, CX
 
 copy_1_qword:
 	TESTQ $0x00000008, AX
 	JZ    copy_1_test
-	MOVQ  (CX)(R12*1), R13
-	MOVQ  R13, (R10)(R12*1)
-	ADDQ  $0x08, R12
+	MOVQ  (R11)(CX*1), R13
+	MOVQ  R13, (R10)(CX*1)
+	ADDQ  $0x08, CX
 	JMP   copy_1_test
 
 copy_1:
-	MOVUPS (CX)(R12*1), X0
-	MOVUPS X0, (R10)(R12*1)
-	ADDQ   $0x10, R12
+	MOVUPS (R11)(CX*1), X0
+	MOVUPS X0, (R10)(CX*1)
+	ADDQ   $0x10, CX
 
 copy_1_test:
-	CMPQ R12, AX
+	CMPQ CX, AX
 	JB   copy_1
-	ADDQ AX, 40(SP)
-	ADDQ AX, R10
 	ADDQ AX, R11
-	MOVQ 8(SP), R14
+	ADDQ AX, R10
+	ADDQ AX, R12
+	MOVQ 8(SP), R15
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
 check_offset:
-	MOVQ R11, AX
-	ADDQ 48(SP), AX
-	CMPQ R14, AX
+	MOVQ R12, AX
+	ADDQ 40(SP), AX
+	CMPQ R15, AX
 	JG   error_match_off_too_big
-	CMPQ R14, 64(SP)
+	CMPQ R15, 56(SP)
 	JG   error_match_off_too_big
 	MOVQ 16(SP), AX
 
 	// Copy match from history
-	MOVQ  R14, CX
-	SUBQ  R11, CX
+	MOVQ  R15, CX
+	SUBQ  R12, CX
 	JLS   copy_match
-	MOVQ  56(SP), R12
-	SUBQ  CX, R12
+	MOVQ  48(SP), R13
+	SUBQ  CX, R13
 	CMPQ  AX, CX
 	JGE   copy_all_from_history
 	XORQ  CX, CX
 	TESTQ $0x00000001, AX
 	JZ    copy_4_word
-	MOVB  (R12)(CX*1), R13
-	MOVB  R13, (R10)(CX*1)
+	MOVB  (R13)(CX*1), R14
+	MOVB  R14, (R10)(CX*1)
 	ADDQ  $0x01, CX
 
 copy_4_word:
 	TESTQ $0x00000002, AX
 	JZ    copy_4_dword
-	MOVW  (R12)(CX*1), R13
-	MOVW  R13, (R10)(CX*1)
+	MOVW  (R13)(CX*1), R14
+	MOVW  R14, (R10)(CX*1)
 	ADDQ  $0x02, CX
 
 copy_4_dword:
 	TESTQ $0x00000004, AX
 	JZ    copy_4_qword
-	MOVL  (R12)(CX*1), R13
-	MOVL  R13, (R10)(CX*1)
+	MOVL  (R13)(CX*1), R14
+	MOVL  R14, (R10)(CX*1)
 	ADDQ  $0x04, CX
 
 copy_4_qword:
 	TESTQ $0x00000008, AX
 	JZ    copy_4_test
-	MOVQ  (R12)(CX*1), R13
-	MOVQ  R13, (R10)(CX*1)
+	MOVQ  (R13)(CX*1), R14
+	MOVQ  R14, (R10)(CX*1)
 	ADDQ  $0x08, CX
 	JMP   copy_4_test
 
 copy_4:
-	MOVUPS (R12)(CX*1), X0
+	MOVUPS (R13)(CX*1), X0
 	MOVUPS X0, (R10)(CX*1)
 	ADDQ   $0x10, CX
 
 copy_4_test:
 	CMPQ CX, AX
 	JB   copy_4
-	ADDQ AX, R11
+	ADDQ AX, R12
 	ADDQ AX, R10
 	JMP  handle_loop
 	JMP loop_finished
 
 copy_all_from_history:
-	XORQ  R13, R13
+	XORQ  R14, R14
 	TESTQ $0x00000001, CX
 	JZ    copy_5_word
-	MOVB  (R12)(R13*1), R15
-	MOVB  R15, (R10)(R13*1)
-	ADDQ  $0x01, R13
+	MOVB  (R13)(R14*1), BP
+	MOVB  BP, (R10)(R14*1)
+	ADDQ  $0x01, R14
 
 copy_5_word:
 	TESTQ $0x00000002, CX
 	JZ    copy_5_dword
-	MOVW  (R12)(R13*1), R15
-	MOVW  R15, (R10)(R13*1)
-	ADDQ  $0x02, R13
+	MOVW  (R13)(R14*1), BP
+	MOVW  BP, (R10)(R14*1)
+	ADDQ  $0x02, R14
 
 copy_5_dword:
 	TESTQ $0x00000004, CX
 	JZ    copy_5_qword
-	MOVL  (R12)(R13*1), R15
-	MOVL  R15, (R10)(R13*1)
-	ADDQ  $0x04, R13
+	MOVL  (R13)(R14*1), BP
+	MOVL  BP, (R10)(R14*1)
+	ADDQ  $0x04, R14
 
 copy_5_qword:
 	TESTQ $0x00000008, CX
 	JZ    copy_5_test
-	MOVQ  (R12)(R13*1), R15
-	MOVQ  R15, (R10)(R13*1)
-	ADDQ  $0x08, R13
+	MOVQ  (R13)(R14*1), BP
+	MOVQ  BP, (R10)(R14*1)
+	ADDQ  $0x08, R14
 	JMP   copy_5_test
 
 copy_5:
-	MOVUPS (R12)(R13*1), X0
-	MOVUPS X0, (R10)(R13*1)
-	ADDQ   $0x10, R13
+	MOVUPS (R13)(R14*1), X0
+	MOVUPS X0, (R10)(R14*1)
+	ADDQ   $0x10, R14
 
 copy_5_test:
-	CMPQ R13, CX
+	CMPQ R14, CX
 	JB   copy_5
 	ADDQ CX, R10
-	ADDQ CX, R11
+	ADDQ CX, R12
 	SUBQ CX, AX
 
 	// Copy match from the current buffer
@@ -445,37 +443,37 @@ copy_match:
 	TESTQ AX, AX
 	JZ    handle_loop
 	MOVQ  R10, CX
-	SUBQ  R14, CX
+	SUBQ  R15, CX
 
 	// ml <= mo
-	CMPQ AX, R14
+	CMPQ AX, R15
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R12, R12
+	XORQ R13, R13
 
 copy_2:
-	MOVUPS (CX)(R12*1), X0
-	MOVUPS X0, (R10)(R12*1)
-	ADDQ   $0x10, R12
-	CMPQ   R12, AX
+	MOVUPS (CX)(R13*1), X0
+	MOVUPS X0, (R10)(R13*1)
+	ADDQ   $0x10, R13
+	CMPQ   R13, AX
 	JB     copy_2
 	ADDQ   AX, R10
-	ADDQ   AX, R11
+	ADDQ   AX, R12
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ R12, R12
+	XORQ R13, R13
 
 copy_slow_3:
-	MOVB (CX)(R12*1), R13
-	MOVB R13, (R10)(R12*1)
-	INCQ R12
-	CMPQ R12, AX
+	MOVB (CX)(R13*1), R14
+	MOVB R14, (R10)(R13*1)
+	INCQ R13
+	CMPQ R13, AX
 	JB   copy_slow_3
 	ADDQ AX, R10
-	ADDQ AX, R11
+	ADDQ AX, R12
 
 handle_loop:
 	MOVQ ctx+16(FP), AX
@@ -514,7 +512,7 @@ error_match_off_too_big:
 	MOVQ ctx+16(FP), AX
 	MOVQ 8(SP), CX
 	MOVQ CX, 232(AX)
-	MOVQ R11, 136(AX)
+	MOVQ R12, 136(AX)
 	MOVQ $0x00000003, ret+24(FP)
 	RET
 
@@ -525,7 +523,7 @@ error_out_of_capacity:
 	MOVQ CX, 216(AX)
 	MOVQ 16(SP), CX
 	MOVQ CX, 224(AX)
-	MOVQ R11, 136(AX)
+	MOVQ R12, 136(AX)
 	MOVQ br+8(FP), AX
 	MOVQ DX, 32(AX)
 	MOVB BL, 40(AX)

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -721,10 +721,9 @@ TEXT ·sequenceDecs_decodeSync_amd64(SB), $32-32
 	MOVQ    80(AX), R8
 	MOVQ    88(AX), R9
 	MOVQ    112(AX), R11
-	MOVQ    120(AX), CX
-	MOVQ    136(AX), R12
-	MOVQ    160(AX), R13
-	MOVQ    168(AX), AX
+	MOVQ    144(AX), R12
+	MOVQ    136(AX), R13
+	MOVQ    176(AX), AX
 
 	// outBase += outPosition
 	ADDQ R13, R11
@@ -1058,24 +1057,39 @@ handle_loop:
 	MOVB BL, 40(AX)
 	MOVQ SI, 24(AX)
 
+	// Update the context
+	MOVQ ctx+16(FP), AX
+	MOVQ R13, 136(AX)
+	MOVQ 144(AX), CX
+	SUBQ CX, R12
+	MOVQ R12, 168(AX)
+
 	// Return success
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
 	// Return with match length error
 sequenceDecs_decodeSync_amd64_error_match_len_ofs_mismatch:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 184(CX)
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
 	// Return with match length too long error
 sequenceDecs_decodeSync_amd64_error_match_len_too_big:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 184(CX)
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
 	// Return with match offset too long error
 error_match_off_too_big:
+	MOVQ 8(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 192(CX)
 	MOVQ $0x00000003, ret+24(FP)
-	RET
 	RET
 
 // func sequenceDecs_decodeSync_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeSyncAsmContext) int
@@ -1093,10 +1107,9 @@ TEXT ·sequenceDecs_decodeSync_bmi2(SB), $32-32
 	MOVQ    80(CX), DI
 	MOVQ    88(CX), R8
 	MOVQ    112(CX), R10
-	MOVQ    120(CX), R11
-	MOVQ    136(CX), R11
-	MOVQ    160(CX), R12
-	MOVQ    168(CX), CX
+	MOVQ    144(CX), R11
+	MOVQ    136(CX), R12
+	MOVQ    176(CX), CX
 
 	// outBase += outPosition
 	ADDQ R12, R10
@@ -1408,22 +1421,37 @@ handle_loop:
 	MOVB DL, 40(CX)
 	MOVQ BX, 24(CX)
 
+	// Update the context
+	MOVQ ctx+16(FP), AX
+	MOVQ R12, 136(AX)
+	MOVQ 144(AX), CX
+	SUBQ CX, R11
+	MOVQ R11, 168(AX)
+
 	// Return success
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
 	// Return with match length error
 sequenceDecs_decodeSync_bmi2_error_match_len_ofs_mismatch:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 184(CX)
 	MOVQ $0x00000001, ret+24(FP)
 	RET
 
 	// Return with match length too long error
 sequenceDecs_decodeSync_bmi2_error_match_len_too_big:
+	MOVQ 16(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 184(CX)
 	MOVQ $0x00000002, ret+24(FP)
 	RET
 
 	// Return with match offset too long error
 error_match_off_too_big:
+	MOVQ 8(SP), AX
+	MOVQ ctx+16(FP), CX
+	MOVQ AX, 192(CX)
 	MOVQ $0x00000003, ret+24(FP)
-	RET
 	RET

--- a/zstd/seqdec_generic.go
+++ b/zstd/seqdec_generic.go
@@ -8,6 +8,11 @@ import (
 	"io"
 )
 
+// decode sequences from the stream with the provided history but without dictionary.
+func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
+	return false, nil
+}
+
 // decode sequences from the stream without the provided history.
 func (s *sequenceDecs) decode(seqs []seqVals) error {
 	br := s.br


### PR DESCRIPTION
A little hacking in the current generator allowed us to reuse almost all code. That's nice!

Part of #515.

For now `go test -run TestDecoder` pass, I'm working on fixing the remaining tests. Another thing is that PR does not incorporate yet the history support (waiting for #542)

Benchmark results from an Ice Lake machine. Some quite good speed ups are there!

```
benchmark                                                                 old ns/op     new ns/op     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-16                            4948849       3115659       -37.04%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-16                        884190        525662        -40.55%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-16                         16820567      13477758      -19.87%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-16                           12468563      9806714       -21.35%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-16                         3829515       1815824       -52.58%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-16                          5235045       2684060       -48.73%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-16                             1494667       1004488       -32.80%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-16                       226176        180516        -20.19%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-16                       126631        125630        -0.79%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-16                             14001037      12040286      -14.00%
BenchmarkDecoder_DecoderSmall/html.zst-16                                 1013496       580645        -42.71%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-16                        78160         62866         -19.57%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-16                               592552        291325        -50.84%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-16                           106829        62462         -41.53%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-16                            1901163       902247        -52.54%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-16                              1417726       673019        -52.53%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-16                            475107        223363        -52.99%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-16                             634311        277013        -56.33%
BenchmarkDecoder_DecodeAll/html_x_4.zst-16                                299068        201638        -32.58%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-16                          24184         18814         -22.20%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-16                          11298         11294         -0.04%
BenchmarkDecoder_DecodeAll/urls.10K.zst-16                                1568542       949901        -39.44%
BenchmarkDecoder_DecodeAll/html.zst-16                                    124118        70389         -43.29%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-16                           9838          7870          -20.00%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-16      1452726       760812        -47.63%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-16      1495242       710737        -52.47%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-16       1407918       696247        -50.55%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-16         1459001       698224        -52.14%
BenchmarkDecoder_DecodeAllFiles/e.txt/fastest-16                          9190          9184          -0.07%
BenchmarkDecoder_DecodeAllFiles/e.txt/default-16                          346024        169963        -50.88%
BenchmarkDecoder_DecodeAllFiles/e.txt/better-16                           249534        148022        -40.68%
BenchmarkDecoder_DecodeAllFiles/e.txt/best-16                             148253        132778        -10.44%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/fastest-16              3584          3385          -5.55%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/default-16              3293          2842          -13.70%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/better-16               3897          3796          -2.59%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/best-16                 9021          11001         +21.95%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/fastest-16                 4922          4361          -11.40%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/default-16                 7764          6750          -13.06%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/better-16                  7758          6751          -12.98%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/best-16                    7987          6581          -17.60%
BenchmarkDecoder_DecodeAllFiles/html.txt/fastest-16                       86160         46936         -45.52%
BenchmarkDecoder_DecodeAllFiles/html.txt/default-16                       92630         47010         -49.25%
BenchmarkDecoder_DecodeAllFiles/html.txt/better-16                        85408         44996         -47.32%
BenchmarkDecoder_DecodeAllFiles/html.txt/best-16                          102427        46479         -54.62%
BenchmarkDecoder_DecodeAllFiles/pi.txt/fastest-16                         9195          9192          -0.03%
BenchmarkDecoder_DecodeAllFiles/pi.txt/default-16                         351130        170379        -51.48%
BenchmarkDecoder_DecodeAllFiles/pi.txt/better-16                          245196        147856        -39.70%
BenchmarkDecoder_DecodeAllFiles/pi.txt/best-16                            146306        132574        -9.39%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/fastest-16                    31964         25333         -20.75%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/default-16                    33961         31073         -8.50%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/better-16                     26667         24121         -9.55%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/best-16                       34375         31844         -7.36%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/fastest-16                     9212          9188          -0.26%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/default-16                     9176          9176          +0.00%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/better-16                      9179          9182          +0.03%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/best-16                        9190          9193          +0.03%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/fastest-16     182557        85521         -53.15%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/default-16     160984        83577         -48.08%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/better-16      147865        78830         -46.69%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/best-16        157513        81901         -48.00%
BenchmarkDecoder_DecodeAllFilesP/e.txt/fastest-16                         1034          1029          -0.48%
BenchmarkDecoder_DecodeAllFilesP/e.txt/default-16                         45459         22683         -50.10%
BenchmarkDecoder_DecodeAllFilesP/e.txt/better-16                          29775         18967         -36.30%
BenchmarkDecoder_DecodeAllFilesP/e.txt/best-16                            18079         15816         -12.52%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/fastest-16             539           502           -6.97%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/default-16             546           524           -4.19%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/better-16              522           527           +0.88%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/best-16                883           854           -3.27%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/fastest-16                730           631           -13.46%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/default-16                846           680           -19.67%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/better-16                 874           681           -22.07%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/best-16                   970           707           -27.08%
BenchmarkDecoder_DecodeAllFilesP/html.txt/fastest-16                      12545         6806          -45.75%
BenchmarkDecoder_DecodeAllFilesP/html.txt/default-16                      13652         6875          -49.64%
BenchmarkDecoder_DecodeAllFilesP/html.txt/better-16                       11274         6569          -41.73%
BenchmarkDecoder_DecodeAllFilesP/html.txt/best-16                         12746         6791          -46.72%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/fastest-16                        1044          1063          +1.82%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/default-16                        40948         22787         -44.35%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/better-16                         28497         18869         -33.79%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/best-16                           17973         15798         -12.10%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/fastest-16                   4327          2945          -31.94%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/default-16                   4279          3075          -28.14%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/better-16                    3562          2528          -29.03%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/best-16                      4120          3120          -24.27%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/fastest-16                    1045          1049          +0.38%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/default-16                    1047          1039          -0.76%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/better-16                     1046          1034          -1.15%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/best-16                       1047          1044          -0.29%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-16                       70555         35143         -50.19%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-16                   14388         8518          -40.80%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-16                    235269        108394        -53.93%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-16                      176150        81790         -53.57%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-16                    57606         27782         -51.77%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-16                     77776         35865         -53.89%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-16                        36842         22593         -38.68%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-16                  3396          2428          -28.50%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-16                  1260          1245          -1.19%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-16                        173875        101967        -41.36%
BenchmarkDecoder_DecodeAllParallel/html.zst-16                            16539         9267          -43.97%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-16                   1347          1081          -19.75%

benchmark                                                                 old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-16                            297.96       473.27       1.59x
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-16                        1072.96      1804.78      1.68x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-16                         229.18       286.02       1.25x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-16                           273.81       348.13       1.27x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-16                         261.50       551.50       2.11x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-16                          232.42       453.31       1.95x
BenchmarkDecoder_DecoderSmall/html_x_4.zst-16                             2192.33      3262.16      1.49x
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-16                       3621.95      4538.10      1.25x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-16                       7776.50      7838.44      1.01x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-16                             401.16       466.49       1.16x
BenchmarkDecoder_DecoderSmall/html.zst-16                                 808.29       1410.85      1.75x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-16                        417.20       518.69       1.24x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-16                               311.06       632.70       2.03x
BenchmarkDecoder_DecodeAll/geo.protodata.zst-16                           1110.07      1898.57      1.71x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-16                            253.46       534.07       2.11x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-16                              301.01       634.09       2.11x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-16                            263.48       560.43       2.13x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-16                             239.77       549.03       2.29x
BenchmarkDecoder_DecodeAll/html_x_4.zst-16                                1369.59      2031.36      1.48x
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-16                          4234.23      5442.83      1.29x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-16                          10894.85     10899.45     1.00x
BenchmarkDecoder_DecodeAll/urls.10K.zst-16                                447.60       739.12       1.65x
BenchmarkDecoder_DecodeAll/html.zst-16                                    825.02       1454.76      1.76x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-16                           414.31       517.91       1.25x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-16      267.06       509.93       1.91x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-16      259.47       545.86       2.10x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-16       275.56       557.22       2.02x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-16         265.91       555.64       2.09x
BenchmarkDecoder_DecodeAllFiles/e.txt/fastest-16                          10881.20     10888.55     1.00x
BenchmarkDecoder_DecodeAllFiles/e.txt/default-16                          289.01       588.38       2.04x
BenchmarkDecoder_DecodeAllFiles/e.txt/better-16                           400.76       675.60       1.69x
BenchmarkDecoder_DecodeAllFiles/e.txt/best-16                             674.54       753.16       1.12x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/fastest-16              1148.38      1215.84      1.06x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/default-16              1249.77      1448.41      1.16x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/better-16               1056.17      1084.20      1.03x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/best-16                 456.25       374.13       0.82x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/fastest-16                 314.49       354.95       1.13x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/default-16                 199.38       229.32       1.15x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/better-16                  199.54       229.31       1.15x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/best-16                    193.81       235.24       1.21x
BenchmarkDecoder_DecodeAllFiles/html.txt/fastest-16                       516.22       947.62       1.84x
BenchmarkDecoder_DecodeAllFiles/html.txt/default-16                       480.16       946.12       1.97x
BenchmarkDecoder_DecodeAllFiles/html.txt/better-16                        520.76       988.46       1.90x
BenchmarkDecoder_DecodeAllFiles/html.txt/best-16                          434.23       956.93       2.20x
BenchmarkDecoder_DecodeAllFiles/pi.txt/fastest-16                         10876.10     10879.70     1.00x
BenchmarkDecoder_DecodeAllFiles/pi.txt/default-16                         284.80       586.94       2.06x
BenchmarkDecoder_DecodeAllFiles/pi.txt/better-16                          407.85       676.35       1.66x
BenchmarkDecoder_DecodeAllFiles/pi.txt/best-16                            683.52       754.32       1.10x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/fastest-16                    1601.81      2021.07      1.26x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/default-16                    1507.63      1647.72      1.09x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/better-16                     1919.97      2122.61      1.11x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/best-16                       1489.44      1607.82      1.08x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/fastest-16                     10856.04     10884.37     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/default-16                     10898.82     10898.93     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/better-16                      10895.15     10891.77     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/best-16                        10882.01     10878.53     1.00x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/fastest-16     2125.17      4536.47      2.13x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/default-16     2409.95      4642.02      1.93x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/better-16      2623.78      4921.51      1.88x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/best-16        2463.05      4737.00      1.92x
BenchmarkDecoder_DecodeAllFilesP/e.txt/fastest-16                         96723.30     97181.69     1.00x
BenchmarkDecoder_DecodeAllFilesP/e.txt/default-16                         2199.84      4408.78      2.00x
BenchmarkDecoder_DecodeAllFilesP/e.txt/better-16                          3358.67      5272.34      1.57x
BenchmarkDecoder_DecodeAllFilesP/e.txt/best-16                            5531.33      6322.87      1.14x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/fastest-16             7633.80      8205.11      1.07x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/default-16             7531.33      7861.34      1.04x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/better-16              7878.01      7808.28      0.99x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/best-16                4663.70      4821.59      1.03x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/fastest-16                2121.74      2451.88      1.16x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/default-16                1828.81      2276.38      1.24x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/better-16                 1770.70      2272.06      1.28x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/best-16                   1595.73      2188.35      1.37x
BenchmarkDecoder_DecodeAllFilesP/html.txt/fastest-16                      3545.30      6534.77      1.84x
BenchmarkDecoder_DecodeAllFilesP/html.txt/default-16                      3257.99      6469.33      1.99x
BenchmarkDecoder_DecodeAllFilesP/html.txt/better-16                       3945.06      6770.89      1.72x
BenchmarkDecoder_DecodeAllFilesP/html.txt/best-16                         3489.38      6549.74      1.88x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/fastest-16                        95753.69     94059.51     0.98x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/default-16                        2442.18      4388.66      1.80x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/better-16                         3509.25      5299.73      1.51x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/best-16                           5564.01      6330.20      1.14x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/fastest-16                   11832.49     17385.80     1.47x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/default-16                   11965.02     16651.74     1.39x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/better-16                    14375.72     20255.73     1.41x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/best-16                      12425.77     16411.38     1.32x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/fastest-16                    95659.72     95287.85     1.00x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/default-16                    95492.90     96289.36     1.01x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/better-16                     95576.73     96741.03     1.01x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/best-16                       95552.41     95804.44     1.00x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-16                       2612.42      5244.90      2.01x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-16                   8242.15      13921.55     1.69x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-16                    2048.12      4445.45      2.17x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-16                      2422.67      5217.70      2.15x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-16                    2173.02      4505.70      2.07x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-16                     1955.48      4240.60      2.17x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-16                        11117.71     18129.71     1.63x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-16                  30154.29     42167.57     1.40x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-16                  97717.39     98890.90     1.01x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-16                        4037.89      6885.44      1.71x
BenchmarkDecoder_DecodeAllParallel/html.zst-16                            6191.33      11050.07     1.78x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-16                   3025.76      3768.91      1.25x
```