### PR TITLE
huff0: Fix noescape pragma

### DIFF
--- a/huff0/decompress_amd64.go
+++ b/huff0/decompress_amd64.go
@@ -12,14 +12,14 @@ import (
 
 // decompress4x_main_loop_x86 is an x86 assembler implementation
 // of Decompress4X when tablelog > 8.
-// go:noescape
+//go:noescape
 func decompress4x_main_loop_x86(pbr0, pbr1, pbr2, pbr3 *bitReaderShifted,
 	peekBits uint8, buf *byte, tbl *dEntrySingle) uint8
 
 // decompress4x_8b_loop_x86 is an x86 assembler implementation
 // of Decompress4X when tablelog <= 8 which decodes 4 entries
 // per loop.
-// go:noescape
+//go:noescape
 func decompress4x_8b_loop_x86(pbr0, pbr1, pbr2, pbr3 *bitReaderShifted,
 	peekBits uint8, buf *byte, tbl *dEntrySingle) uint8
 


### PR DESCRIPTION
Before/After:
```
BenchmarkDecoderEnwik9-32    	       1	1439142300 ns/op	 694.86 MB/s	 1536592 B/op	    7681 allocs/op
BenchmarkDecoderEnwik9-32    	       1	1382877200 ns/op	 723.13 MB/s	   71856 B/op	      50 allocs/op
```