### PR TITLE
zstd: Over-alloc destination by 16 bytes

### DIFF
--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -116,13 +116,11 @@ type executeAsmContext struct {
 //go:noescape
 func sequenceDecs_executeSimple_amd64(ctx *executeAsmContext) bool
 
-const overwriteSize = 16
-
 // executeSimple handles cases when dictionary is not used.
 func (s *sequenceDecs) executeSimple(seqs []seqVals, hist []byte) error {
 	// Ensure we have enough output size...
-	if len(s.out)+s.seqSize+overwriteSize > cap(s.out) {
-		addBytes := s.seqSize + len(s.out) + overwriteSize
+	if len(s.out)+s.seqSize+compressedBlockOverAlloc > cap(s.out) {
+		addBytes := s.seqSize + len(s.out) + compressedBlockOverAlloc
 		s.out = append(s.out, make([]byte, addBytes)...)
 		s.out = s.out[:len(s.out)-addBytes]
 	}


### PR DESCRIPTION
Before/after:

```
BenchmarkDecoderSilesia-32    	       4	 281834900 ns/op	 752.03 MB/s	 1623058 B/op	      44 allocs/op
BenchmarkDecoderSilesia-32    	       4	 251419725 ns/op	 843.00 MB/s	   50090 B/op	      43 allocs/op

BenchmarkDecoderEnwik9-32    	       1	1460882800 ns/op	 684.52 MB/s	   71856 B/op	      50 allocs/op
BenchmarkDecoderEnwik9-32    	       1	1439168800 ns/op	 694.85 MB/s	   71440 B/op	      49 allocs/op
```