### PR TITLE
zstd: Fix offset check when ll == 0

### DIFF
--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -632,7 +632,7 @@ func TestDecoderRegression(t *testing.T) {
 	}
 	defer dec.Close()
 	for i, tt := range zr.File {
-		if !strings.HasSuffix(tt.Name, "artifact (5)") || (testing.Short() && i > 10) {
+		if testing.Short() && i > 10 {
 			continue
 		}
 		t.Run("Reader-"+tt.Name, func(t *testing.T) {

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -322,13 +322,13 @@ func (s *sequenceDecs) decodeSync(hist []byte) error {
 
 		if mo > len(out)+len(hist) || mo > s.windowSize {
 			if len(s.dict) == 0 {
-				return fmt.Errorf("match offset (%d) bigger than current history (%d)", mo, len(out)+len(hist))
+				return fmt.Errorf("match offset (%d) bigger than current history (%d)", mo, len(out)+len(hist)-startSize)
 			}
 
 			// we may be in dictionary.
 			dictO := len(s.dict) - (mo - (len(out) + len(hist)))
 			if dictO < 0 || dictO >= len(s.dict) {
-				return fmt.Errorf("match offset (%d) bigger than current history (%d)", mo, len(out)+len(hist))
+				return fmt.Errorf("match offset (%d) bigger than current history (%d)", mo, len(out)+len(hist)-startSize)
 			}
 			end := dictO + ml
 			if end > len(s.dict) {

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -1114,7 +1114,7 @@ main_loop:
 
 	// Copy literals
 	TESTQ R13, R13
-	JZ    copy_history
+	JZ    check_offset
 	XORQ  R14, R14
 
 copy_1:
@@ -1128,6 +1128,7 @@ copy_1:
 	ADDQ   R13, R8
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
+check_offset:
 	LEAQ (R8)(DI*1), R13
 	CMPQ R12, R13
 	JG   error_match_off_too_big
@@ -1135,11 +1136,9 @@ copy_1:
 	JG   error_match_off_too_big
 
 	// Copy match from history
-copy_history:
 	MOVQ  R12, R13
 	SUBQ  R8, R13
-	CMPQ  R13, $0x00
-	JLE   copy_match
+	JLS   copy_match
 	MOVQ  R10, R14
 	SUBQ  R13, R14
 	CMPQ  R11, R13


### PR DESCRIPTION
Remove redundant `CMPQ`. Fix error reporting on decodeSync.

Fixes #549