### PR TITLE
zstd: Fast copy from literals in asm routine

### DIFF
--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -203,12 +203,13 @@ func (s *sequenceDecs) execute(seqs []seqVals, hist []byte) error {
 
 // decode sequences from the stream with the provided history.
 func (s *sequenceDecs) decodeSync(hist []byte) error {
-	if true {
+	{
 		supported, err := s.decodeSyncSimple(hist)
 		if supported {
 			return err
 		}
 	}
+
 	br := s.br
 	seqs := s.nSeqs
 	startSize := len(s.out)


### PR DESCRIPTION
If we know that the `literals` slice has got at least 16 extra capacity after
its length, we can safely use faster copy procedure.

For `go test` invocation it's true for the 16% of calls to decode.

Unfortunately, this approach didn't give any speedup, instead, there are several significant slowdowns. Publishing just to create a record that this approach was already tested.

Results from IceLake

```
benchmark                                                                 old ns/op     new ns/op     delta
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-16                            3557279       3543533       -0.39%
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-16                        775045        782371        +0.95%
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-16                         12166996      12198941      +0.26%
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-16                           9431687       9432074       +0.00%
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-16                         2962194       2953507       -0.29%
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-16                          3639226       3623773       -0.42%
BenchmarkDecoder_DecoderSmall/html_x_4.zst-16                             1368932       1414906       +3.36%
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-16                       196324        195738        -0.30%
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-16                       134630        131176        -2.57%
BenchmarkDecoder_DecoderSmall/urls.10K.zst-16                             11555373      11481798      -0.64%
BenchmarkDecoder_DecoderSmall/html.zst-16                                 935807        936479        +0.07%
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-16                        64055         63970         -0.13%
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-16                               283452        284531        +0.38%
BenchmarkDecoder_DecodeAll/geo.protodata.zst-16                           69243         66418         -4.08%
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-16                            944295        931157        -1.39%
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-16                              691287        682933        -1.21%
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-16                            256668        252614        -1.58%
BenchmarkDecoder_DecodeAll/alice29.txt.zst-16                             277410        281511        +1.48%
BenchmarkDecoder_DecodeAll/html_x_4.zst-16                                205282        255881        +24.65%
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-16                          20197         19474         -3.58%
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-16                          11313         11306         -0.06%
BenchmarkDecoder_DecodeAll/urls.10K.zst-16                                1028054       1027834       -0.02%
BenchmarkDecoder_DecodeAll/html.zst-16                                    73334         80962         +10.40%
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-16                           8017          7975          -0.52%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-16      907994        881967        -2.87%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-16      767101        755825        -1.47%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-16       790752        776570        -1.79%
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-16         741132        732451        -1.17%
BenchmarkDecoder_DecodeAllFiles/e.txt/fastest-16                          9202          9223          +0.23%
BenchmarkDecoder_DecodeAllFiles/e.txt/default-16                          246098        237996        -3.29%
BenchmarkDecoder_DecodeAllFiles/e.txt/better-16                           211593        207971        -1.71%
BenchmarkDecoder_DecodeAllFiles/e.txt/best-16                             142821        143877        +0.74%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/fastest-16              3444          3650          +5.98%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/default-16              2905          3112          +7.13%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/better-16               3863          4060          +5.10%
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/best-16                 11055         11131         +0.69%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/fastest-16                 4345          4318          -0.62%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/default-16                 6906          6876          -0.43%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/better-16                  6914          6896          -0.26%
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/best-16                    6774          6708          -0.97%
BenchmarkDecoder_DecodeAllFiles/html.txt/fastest-16                       49596         57218         +15.37%
BenchmarkDecoder_DecodeAllFiles/html.txt/default-16                       49971         55852         +11.77%
BenchmarkDecoder_DecodeAllFiles/html.txt/better-16                        47812         53812         +12.55%
BenchmarkDecoder_DecodeAllFiles/html.txt/best-16                          49844         56772         +13.90%
BenchmarkDecoder_DecodeAllFiles/pi.txt/fastest-16                         9214          9204          -0.11%
BenchmarkDecoder_DecodeAllFiles/pi.txt/default-16                         250711        240994        -3.88%
BenchmarkDecoder_DecodeAllFiles/pi.txt/better-16                          209383        207280        -1.00%
BenchmarkDecoder_DecodeAllFiles/pi.txt/best-16                            142336        143366        +0.72%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/fastest-16                    25416         27872         +9.66%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/default-16                    31251         33407         +6.90%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/better-16                     24357         25237         +3.61%
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/best-16                       31871         34864         +9.39%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/fastest-16                     9217          9200          -0.18%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/default-16                     9182          9192          +0.11%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/better-16                      9190          9190          +0.00%
BenchmarkDecoder_DecodeAllFiles/sharnd.out/best-16                        9203          9192          -0.12%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/fastest-16     115785        115806        +0.02%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/default-16     116331        116685        +0.30%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/better-16      113160        113138        -0.02%
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/best-16        117959        117968        +0.01%
BenchmarkDecoder_DecodeAllFilesP/e.txt/fastest-16                         1054          1034          -1.90%
BenchmarkDecoder_DecodeAllFilesP/e.txt/default-16                         29016         29017         +0.00%
BenchmarkDecoder_DecodeAllFilesP/e.txt/better-16                          23925         23909         -0.07%
BenchmarkDecoder_DecodeAllFilesP/e.txt/best-16                            17151         17156         +0.03%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/fastest-16             592           590           -0.39%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/default-16             612           570           -6.88%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/better-16              431           519           +20.39%
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/best-16                860           863           +0.35%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/fastest-16                581           584           +0.46%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/default-16                719           714           -0.76%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/better-16                 716           712           -0.50%
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/best-16                   746           744           -0.19%
BenchmarkDecoder_DecodeAllFilesP/html.txt/fastest-16                      8227          8224          -0.04%
BenchmarkDecoder_DecodeAllFilesP/html.txt/default-16                      8522          8551          +0.34%
BenchmarkDecoder_DecodeAllFilesP/html.txt/better-16                       8082          8088          +0.07%
BenchmarkDecoder_DecodeAllFilesP/html.txt/best-16                         8770          8823          +0.60%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/fastest-16                        1030          1049          +1.84%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/default-16                        29256         29206         -0.17%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/better-16                         23781         23767         -0.06%
BenchmarkDecoder_DecodeAllFilesP/pi.txt/best-16                           17147         17152         +0.03%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/fastest-16                   3014          3017          +0.10%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/default-16                   3150          3146          -0.13%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/better-16                    2587          2584          -0.12%
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/best-16                      3144          3157          +0.41%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/fastest-16                    1093          1037          -5.12%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/default-16                    1033          1042          +0.87%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/better-16                     1036          1036          +0.00%
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/best-16                       1041          1047          +0.58%
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-16                       45849         45908         +0.13%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-16                   9552          9508          -0.46%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-16                    147818        147526        -0.20%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-16                      114420        114604        +0.16%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-16                    38381         38363         -0.05%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-16                     48172         48074         -0.20%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-16                        25450         25364         -0.34%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-16                  2708          2716          +0.30%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-16                  1254          1256          +0.16%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-16                        133389        134870        +1.11%
BenchmarkDecoder_DecodeAllParallel/html.zst-16                            12109         12148         +0.32%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-16                   1112          1113          +0.09%

benchmark                                                                 old MB/s     new MB/s     speedup
BenchmarkDecoder_DecoderSmall/kppkn.gtb.zst-16                            414.52       416.13       1.00x
BenchmarkDecoder_DecoderSmall/geo.protodata.zst-16                        1224.06      1212.60      0.99x
BenchmarkDecoder_DecoderSmall/plrabn12.txt.zst-16                         316.83       316.00       1.00x
BenchmarkDecoder_DecoderSmall/lcet10.txt.zst-16                           361.97       361.96       1.00x
BenchmarkDecoder_DecoderSmall/asyoulik.txt.zst-16                         338.07       339.07       1.00x
BenchmarkDecoder_DecoderSmall/alice29.txt.zst-16                          334.33       335.76       1.00x
BenchmarkDecoder_DecoderSmall/html_x_4.zst-16                             2393.69      2315.91      0.97x
BenchmarkDecoder_DecoderSmall/paper-100k.pdf.zst-16                       4172.69      4185.19      1.00x
BenchmarkDecoder_DecoderSmall/fireworks.jpeg.zst-16                       7314.46      7507.05      1.03x
BenchmarkDecoder_DecoderSmall/urls.10K.zst-16                             486.07       489.18       1.01x
BenchmarkDecoder_DecoderSmall/html.zst-16                                 875.39       874.77       1.00x
BenchmarkDecoder_DecoderSmall/comp-data.bin.zst-16                        509.06       509.74       1.00x
BenchmarkDecoder_DecodeAll/kppkn.gtb.zst-16                               650.27       647.80       1.00x
BenchmarkDecoder_DecodeAll/geo.protodata.zst-16                           1712.62      1785.49      1.04x
BenchmarkDecoder_DecodeAll/plrabn12.txt.zst-16                            510.29       517.49       1.01x
BenchmarkDecoder_DecodeAll/lcet10.txt.zst-16                              617.33       624.88       1.01x
BenchmarkDecoder_DecodeAll/asyoulik.txt.zst-16                            487.71       495.53       1.02x
BenchmarkDecoder_DecodeAll/alice29.txt.zst-16                             548.25       540.26       0.99x
BenchmarkDecoder_DecodeAll/html_x_4.zst-16                                1995.31      1600.74      0.80x
BenchmarkDecoder_DecodeAll/paper-100k.pdf.zst-16                          5070.01      5258.21      1.04x
BenchmarkDecoder_DecodeAll/fireworks.jpeg.zst-16                          10880.75     10887.82     1.00x
BenchmarkDecoder_DecodeAll/urls.10K.zst-16                                682.93       683.07       1.00x
BenchmarkDecoder_DecodeAll/html.zst-16                                    1396.34      1264.79      0.91x
BenchmarkDecoder_DecodeAll/comp-data.bin.zst-16                           508.40       511.12       1.01x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-16      427.28       439.88       1.03x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-16      505.75       513.30       1.01x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-16       490.63       499.59       1.02x
BenchmarkDecoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-16         523.47       529.68       1.01x
BenchmarkDecoder_DecodeAllFiles/e.txt/fastest-16                          10867.87     10842.27     1.00x
BenchmarkDecoder_DecodeAllFiles/e.txt/default-16                          406.35       420.19       1.03x
BenchmarkDecoder_DecodeAllFiles/e.txt/better-16                           472.62       480.85       1.02x
BenchmarkDecoder_DecodeAllFiles/e.txt/best-16                             700.20       695.06       0.99x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/fastest-16              1195.08      1127.67      0.94x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/default-16              1416.99      1322.67      0.93x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/better-16               1065.63      1013.87      0.95x
BenchmarkDecoder_DecodeAllFiles/fse-artifact3.bin/best-16                 372.32       369.79       0.99x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/fastest-16                 356.29       358.48       1.01x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/default-16                 224.17       225.12       1.00x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/better-16                  223.91       224.49       1.00x
BenchmarkDecoder_DecodeAllFiles/gettysburg.txt/best-16                    228.52       230.78       1.01x
BenchmarkDecoder_DecodeAllFiles/html.txt/fastest-16                       896.79       777.33       0.87x
BenchmarkDecoder_DecodeAllFiles/html.txt/default-16                       890.06       796.34       0.89x
BenchmarkDecoder_DecodeAllFiles/html.txt/better-16                        930.24       826.53       0.89x
BenchmarkDecoder_DecodeAllFiles/html.txt/best-16                          892.32       783.43       0.88x
BenchmarkDecoder_DecodeAllFiles/pi.txt/fastest-16                         10853.79     10864.63     1.00x
BenchmarkDecoder_DecodeAllFiles/pi.txt/default-16                         398.88       414.96       1.04x
BenchmarkDecoder_DecodeAllFiles/pi.txt/better-16                          477.61       482.45       1.01x
BenchmarkDecoder_DecodeAllFiles/pi.txt/best-16                            702.58       697.54       0.99x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/fastest-16                    2014.49      1837.00      0.91x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/default-16                    1638.36      1532.63      0.94x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/better-16                     2102.09      2028.75      0.97x
BenchmarkDecoder_DecodeAllFiles/pngdata.bin/best-16                       1606.50      1468.56      0.91x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/fastest-16                     10850.19     10869.84     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/default-16                     10891.03     10879.31     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/better-16                      10881.95     10881.99     1.00x
BenchmarkDecoder_DecodeAllFiles/sharnd.out/best-16                        10866.04     10878.99     1.00x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/fastest-16     3350.73      3350.11      1.00x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/default-16     3335.01      3324.87      1.00x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/better-16      3428.46      3429.13      1.00x
BenchmarkDecoder_DecodeAllFilesP/Mark.Twain-Tom.Sawyer.txt/best-16        3288.98      3288.71      1.00x
BenchmarkDecoder_DecodeAllFilesP/e.txt/fastest-16                         94917.74     96713.10     1.02x
BenchmarkDecoder_DecodeAllFilesP/e.txt/default-16                         3446.53      3446.37      1.00x
BenchmarkDecoder_DecodeAllFilesP/e.txt/better-16                          4179.79      4182.68      1.00x
BenchmarkDecoder_DecodeAllFilesP/e.txt/best-16                            5830.57      5829.14      1.00x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/fastest-16             6954.93      6981.96      1.00x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/default-16             6728.27      7226.65      1.07x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/better-16              9548.94      7931.70      0.83x
BenchmarkDecoder_DecodeAllFilesP/fse-artifact3.bin/best-16                4787.94      4771.03      1.00x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/fastest-16                2663.89      2651.76      1.00x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/default-16                2152.76      2169.22      1.01x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/better-16                 2161.89      2172.94      1.01x
BenchmarkDecoder_DecodeAllFilesP/gettysburg.txt/best-16                   2075.38      2079.38      1.00x
BenchmarkDecoder_DecodeAllFilesP/html.txt/fastest-16                      5405.92      5408.29      1.00x
BenchmarkDecoder_DecodeAllFilesP/html.txt/default-16                      5219.24      5201.28      1.00x
BenchmarkDecoder_DecodeAllFilesP/html.txt/better-16                       5503.32      5498.85      1.00x
BenchmarkDecoder_DecodeAllFilesP/html.txt/best-16                         5071.74      5041.28      0.99x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/fastest-16                        97101.55     95376.18     0.98x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/default-16                        3418.25      3424.04      1.00x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/better-16                         4205.23      4207.62      1.00x
BenchmarkDecoder_DecodeAllFilesP/pi.txt/best-16                           5832.05      5830.27      1.00x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/fastest-16                   16989.10     16971.59     1.00x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/default-16                   16252.36     16273.32     1.00x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/better-16                    19791.73     19816.53     1.00x
BenchmarkDecoder_DecodeAllFilesP/pngdata.bin/best-16                      16283.66     16220.06     1.00x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/fastest-16                    91519.41     96427.94     1.05x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/default-16                    96792.75     95984.31     0.99x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/better-16                     96573.04     96537.59     1.00x
BenchmarkDecoder_DecodeAllFilesP/sharnd.out/best-16                       96020.92     95522.84     0.99x
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-16                       4020.13      4014.97      1.00x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-16                   12415.10     12472.69     1.00x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-16                    3259.82      3266.28      1.00x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-16                      3729.71      3723.73      1.00x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-16                    3261.52      3263.00      1.00x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-16                     3157.18      3163.65      1.00x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-16                        16094.14     16148.99     1.00x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-16                  37807.91     37702.43     1.00x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-16                  98162.19     97969.60     1.00x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-16                        5263.45      5205.67      0.99x
BenchmarkDecoder_DecodeAllParallel/html.zst-16                            8456.73      8429.52      1.00x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-16                   3665.41      3661.90      1.00x
```