### PR TITLE
zstd: Faster decoding memcopy in asm

### DIFF
--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -1317,7 +1317,7 @@ func BenchmarkDecoder_DecodeAllFilesP(b *testing.B) {
 					if err != nil {
 						b.Error(err)
 					}
-					_, err = dec.DecodeAll(encoded, nil)
+					raw, err := dec.DecodeAll(encoded, nil)
 					if err != nil {
 						b.Error(err)
 					}
@@ -1326,7 +1326,7 @@ func BenchmarkDecoder_DecodeAllFilesP(b *testing.B) {
 					b.ReportAllocs()
 					b.ResetTimer()
 					b.RunParallel(func(pb *testing.PB) {
-						buf := make([]byte, len(raw))
+						buf := make([]byte, cap(raw))
 						var err error
 						for pb.Next() {
 							buf, err = dec.DecodeAll(encoded, buf[:0])
@@ -1373,7 +1373,7 @@ func BenchmarkDecoder_DecodeAllParallel(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
-				got := make([]byte, len(got))
+				got := make([]byte, cap(got))
 				for pb.Next() {
 					_, err = dec.DecodeAll(in, got[:0])
 					if err != nil {

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -1326,30 +1326,30 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R12, R12
+	ADDQ R13, DI
+	MOVQ BX, R12
+	ADDQ R13, BX
 
 copy_2:
-	MOVUPS (R11)(R12*1), X0
-	MOVUPS X0, (BX)(R12*1)
+	MOVUPS (R11), X0
+	MOVUPS X0, (R12)
+	ADDQ   $0x10, R11
 	ADDQ   $0x10, R12
-	CMPQ   R12, R13
-	JB     copy_2
-	ADDQ   R13, BX
-	ADDQ   R13, DI
+	SUBQ   $0x10, R13
+	JHI    copy_2
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ R12, R12
+	ADDQ R13, DI
 
 copy_slow_3:
-	MOVB (R11)(R12*1), R14
-	MOVB R14, (BX)(R12*1)
-	INCQ R12
-	CMPQ R12, R13
-	JB   copy_slow_3
-	ADDQ R13, BX
-	ADDQ R13, DI
+	MOVB (R11), R12
+	MOVB R12, (BX)
+	INCQ R11
+	INCQ BX
+	DECQ R13
+	JNZ  copy_slow_3
 
 handle_loop:
 	ADDQ $0x18, AX
@@ -1826,30 +1826,30 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ CX, CX
+	ADDQ R13, R12
+	MOVQ R10, CX
+	ADDQ R13, R10
 
 copy_2:
-	MOVUPS (AX)(CX*1), X0
-	MOVUPS X0, (R10)(CX*1)
+	MOVUPS (AX), X0
+	MOVUPS X0, (CX)
+	ADDQ   $0x10, AX
 	ADDQ   $0x10, CX
-	CMPQ   CX, R13
-	JB     copy_2
-	ADDQ   R13, R10
-	ADDQ   R13, R12
+	SUBQ   $0x10, R13
+	JHI    copy_2
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ CX, CX
+	ADDQ R13, R12
 
 copy_slow_3:
-	MOVB (AX)(CX*1), R14
-	MOVB R14, (R10)(CX*1)
-	INCQ CX
-	CMPQ CX, R13
-	JB   copy_slow_3
-	ADDQ R13, R10
-	ADDQ R13, R12
+	MOVB (AX), CL
+	MOVB CL, (R10)
+	INCQ AX
+	INCQ R10
+	DECQ R13
+	JNZ  copy_slow_3
 
 handle_loop:
 	MOVQ ctx+16(FP), AX
@@ -2333,30 +2333,30 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
-	XORQ R12, R12
+	ADDQ R13, R11
+	MOVQ R9, R12
+	ADDQ R13, R9
 
 copy_2:
-	MOVUPS (CX)(R12*1), X0
-	MOVUPS X0, (R9)(R12*1)
+	MOVUPS (CX), X0
+	MOVUPS X0, (R12)
+	ADDQ   $0x10, CX
 	ADDQ   $0x10, R12
-	CMPQ   R12, R13
-	JB     copy_2
-	ADDQ   R13, R9
-	ADDQ   R13, R11
+	SUBQ   $0x10, R13
+	JHI    copy_2
 	JMP    handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ R12, R12
+	ADDQ R13, R11
 
 copy_slow_3:
-	MOVB (CX)(R12*1), R14
-	MOVB R14, (R9)(R12*1)
-	INCQ R12
-	CMPQ R12, R13
-	JB   copy_slow_3
-	ADDQ R13, R9
-	ADDQ R13, R11
+	MOVB (CX), R12
+	MOVB R12, (R9)
+	INCQ CX
+	INCQ R9
+	DECQ R13
+	JNZ  copy_slow_3
 
 handle_loop:
 	MOVQ ctx+16(FP), CX
@@ -2862,6 +2862,7 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
+	ADDQ  R13, R12
 	XORQ  CX, CX
 	TESTQ $0x00000001, R13
 	JZ    copy_2_word
@@ -2900,21 +2901,19 @@ copy_2_test:
 	CMPQ CX, R13
 	JB   copy_2
 	ADDQ R13, R10
-	ADDQ R13, R12
 	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ CX, CX
+	ADDQ R13, R12
 
 copy_slow_3:
-	MOVB (AX)(CX*1), R14
-	MOVB R14, (R10)(CX*1)
-	INCQ CX
-	CMPQ CX, R13
-	JB   copy_slow_3
-	ADDQ R13, R10
-	ADDQ R13, R12
+	MOVB (AX), CL
+	MOVB CL, (R10)
+	INCQ AX
+	INCQ R10
+	DECQ R13
+	JNZ  copy_slow_3
 
 handle_loop:
 	MOVQ ctx+16(FP), AX
@@ -3398,6 +3397,7 @@ copy_match:
 	JA   copy_overlapping_match
 
 	// Copy non-overlapping match
+	ADDQ  R13, R11
 	XORQ  R12, R12
 	TESTQ $0x00000001, R13
 	JZ    copy_2_word
@@ -3436,21 +3436,19 @@ copy_2_test:
 	CMPQ R12, R13
 	JB   copy_2
 	ADDQ R13, R9
-	ADDQ R13, R11
 	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
-	XORQ R12, R12
+	ADDQ R13, R11
 
 copy_slow_3:
-	MOVB (CX)(R12*1), R14
-	MOVB R14, (R9)(R12*1)
-	INCQ R12
-	CMPQ R12, R13
-	JB   copy_slow_3
-	ADDQ R13, R9
-	ADDQ R13, R11
+	MOVB (CX), R12
+	MOVB R12, (R9)
+	INCQ CX
+	INCQ R9
+	DECQ R13
+	JNZ  copy_slow_3
 
 handle_loop:
 	MOVQ ctx+16(FP), CX


### PR DESCRIPTION
Use faster method for `copyMemory` and `copyOverlappedMemory`.

```
λ benchcmp before.txt after.txt
benchmark                                                    old ns/op     new ns/op     delta
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-32          17933         14089         -21.44%
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-32      4489          3847          -14.30%
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-32       56959         44537         -21.81%
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-32         44430         33115         -25.47%
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-32       15040         12049         -19.89%
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-32        18360         14098         -23.21%
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-32           11643         12058         +3.56%
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-32     1105          1063          -3.80%
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-32     1865          1841          -1.29%
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-32           52351         43161         -17.55%
BenchmarkDecoder_DecodeAllParallel/html.zst-32               5230          4134          -20.96%
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-32      1276          1279          +0.24%

benchmark                                                    old MB/s     new MB/s     speedup
BenchmarkDecoder_DecodeAllParallel/kppkn.gtb.zst-32          10278.54     13082.74     1.27x
BenchmarkDecoder_DecodeAllParallel/geo.protodata.zst-32      26415.30     30828.11     1.17x
BenchmarkDecoder_DecodeAllParallel/plrabn12.txt.zst-32       8459.72      10819.37     1.28x
BenchmarkDecoder_DecodeAllParallel/lcet10.txt.zst-32         9605.02      12887.11     1.34x
BenchmarkDecoder_DecodeAllParallel/asyoulik.txt.zst-32       8323.26      10388.96     1.25x
BenchmarkDecoder_DecodeAllParallel/alice29.txt.zst-32        8283.62      10787.77     1.30x
BenchmarkDecoder_DecodeAllParallel/html_x_4.zst-32           35179.58     33968.10     0.97x
BenchmarkDecoder_DecodeAllParallel/paper-100k.pdf.zst-32     92685.55     96354.41     1.04x
BenchmarkDecoder_DecodeAllParallel/fireworks.jpeg.zst-32     65985.69     66854.61     1.01x
BenchmarkDecoder_DecodeAllParallel/urls.10K.zst-32           13411.18     16266.62     1.21x
BenchmarkDecoder_DecodeAllParallel/html.zst-32               19578.29     24768.39     1.27x
BenchmarkDecoder_DecodeAllParallel/comp-data.bin.zst-32      3194.49      3188.05      1.00x
```

```
λ go test -short -bench=seqdec_execute >after.txt&&benchcmp before.txt after.txt
benchmark                                                                                       old ns/op     new ns/op     delta
Benchmark_seqdec_execute/n-12286-lits-13914-prev-9869-1990358-3296656-win-4194304.blk-32        129910        130620        +0.55%
Benchmark_seqdec_execute/n-12485-lits-6960-prev-976039-2250252-2463561-win-4194304.blk-32       139487        134032        -3.91%
Benchmark_seqdec_execute/n-14746-lits-14461-prev-209-8-1379909-win-4194304.blk-32               37155         38636         +3.99%
Benchmark_seqdec_execute/n-1525-lits-1498-prev-2009476-797934-2994405-win-4194304.blk-32        16318         15788         -3.25%
Benchmark_seqdec_execute/n-3478-lits-3628-prev-895243-2104056-2119329-win-4194304.blk-32        44386         43959         -0.96%
Benchmark_seqdec_execute/n-8422-lits-5840-prev-168095-2298675-433830-win-4194304.blk-32         100065        96156         -3.91%
Benchmark_seqdec_execute/n-1000-lits-1057-prev-21887-92-217-win-8388608.blk-32                  8119          7373          -9.19%
Benchmark_seqdec_execute/n-15134-lits-20798-prev-4882976-4884216-4474622-win-8388608.blk-32     84669         83034         -1.93%
Benchmark_seqdec_execute/n-2-lits-0-prev-620601-689171-848-win-8388608.blk-32                   2914          2773          -4.84%
Benchmark_seqdec_execute/n-90-lits-67-prev-19498-23-19710-win-8388608.blk-32                    4318          3824          -11.44%
Benchmark_seqdec_execute/n-931-lits-1179-prev-36502-1526-1518-win-8388608.blk-32                7851          7203          -8.25%
Benchmark_seqdec_execute/n-2898-lits-4062-prev-335-386-751-win-8388608.blk-32                   15161         14315         -5.58%
Benchmark_seqdec_execute/n-4056-lits-12419-prev-10792-66-309849-win-8388608.blk-32              23920         20065         -16.12%
Benchmark_seqdec_execute/n-8028-lits-4568-prev-917-65-920-win-8388608.blk-32                    53268         52768         -0.94%
```