### PR TITLE
zstd: Use configured block size

### DIFF
--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -551,7 +551,7 @@ func (e *Encoder) EncodeAll(src, dst []byte) []byte {
 	}
 
 	// If we can do everything in one block, prefer that.
-	if len(src) <= maxCompressedBlockSize {
+	if len(src) <= e.o.blockSize {
 		enc.Reset(e.o.dict, true)
 		// Slightly faster with no history and everything in one block.
 		if e.o.crc {


### PR DESCRIPTION
Single blocks up to max block size would be created with EncodeAll, if src was smaller. This uses the configured max block size.

Block size is max for settings >= default, so no change for these.