### PR TITLE
tests: Bump goreleaser version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,10 +88,10 @@ jobs:
       run: go install mvdan.cc/garble@latest
 
     - name: goreleaser deprecation
-      run: curl -sfL https://git.io/goreleaser | VERSION=v1.5.0 sh -s -- check
+      run: curl -sfL https://git.io/goreleaser | VERSION=v1.9.2 sh -s -- check
       
     - name: goreleaser snapshot
-      run: curl -sL https://git.io/goreleaser | VERSION=v1.5.0 sh -s -- --snapshot --skip-publish --rm-dist
+      run: curl -sL https://git.io/goreleaser | VERSION=v1.9.2 sh -s -- --snapshot --skip-publish --rm-dist
 
     - name: Test S2 GOAMD64 v3
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: 1.5.0
+          version: 1.9.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trying to eliminate

```
   • checking config:
   • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
   • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
   • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
   • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
   • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
   • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
```