### PR TITLE
tests: Pin garble version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -85,7 +85,7 @@ jobs:
       run: go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d&&./s2c -verify s2c &&./s2d s2c.s2&&rm ./s2c&&rm s2d&&rm s2c.s2
 
     - name: install garble
-      run: go install mvdan.cc/garble@latest
+      run: go install mvdan.cc/garble@v0.7.0
 
     - name: goreleaser deprecation
       run: curl -sfL https://git.io/goreleaser | VERSION=v1.9.2 sh -s -- check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       -
         name: install garble
-        run: go install mvdan.cc/garble@latest
+        run: go install mvdan.cc/garble@v0.7.0
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
v0.7.0 requires Go 1.18. Upgrade & pin the dependency for now.