### PR TITLE
s2: Slightly faster non-assembly decompression

### DIFF
--- a/s2/decode_other.go
+++ b/s2/decode_other.go
@@ -38,14 +38,19 @@ func s2Decode(dst, src []byte) int {
 				s += 2
 				x = uint32(src[s-1])
 			case x == 61:
+				in := src[s : s+3]
+				x = uint32(in[1]) | uint32(in[2])<<8
 				s += 3
-				x = uint32(src[s-2]) | uint32(src[s-1])<<8
 			case x == 62:
+				in := src[s : s+4]
+				// Load as 32 bit and shift down.
+				x = uint32(in[0]) | uint32(in[1])<<8 | uint32(in[2])<<16 | uint32(in[3])<<24
+				x >>= 8
 				s += 4
-				x = uint32(src[s-3]) | uint32(src[s-2])<<8 | uint32(src[s-1])<<16
 			case x == 63:
+				in := src[s : s+5]
+				x = uint32(in[1]) | uint32(in[2])<<8 | uint32(in[3])<<16 | uint32(in[4])<<24
 				s += 5
-				x = uint32(src[s-4]) | uint32(src[s-3])<<8 | uint32(src[s-2])<<16 | uint32(src[s-1])<<24
 			}
 			length = int(x) + 1
 			if length > len(dst)-d || length > len(src)-s || (strconv.IntSize == 32 && length <= 0) {
@@ -71,14 +76,16 @@ func s2Decode(dst, src []byte) int {
 				// keep last offset
 				switch length {
 				case 5:
+					length = int(uint32(src[s])) + 4
 					s += 1
-					length = int(uint32(src[s-1])) + 4
 				case 6:
+					in := src[s : s+2]
+					length = int(uint32(in[0])|(uint32(in[1])<<8)) + (1 << 8)
 					s += 2
-					length = int(uint32(src[s-2])|(uint32(src[s-1])<<8)) + (1 << 8)
 				case 7:
+					in := src[s : s+3]
+					length = int((uint32(in[2])<<16)|(uint32(in[1])<<8)|uint32(in[0])) + (1 << 16)
 					s += 3
-					length = int(uint32(src[s-3])|(uint32(src[s-2])<<8)|(uint32(src[s-1])<<16)) + (1 << 16)
 				default: // 0-> 4
 				}
 			} else {
@@ -86,14 +93,16 @@ func s2Decode(dst, src []byte) int {
 			}
 			length += 4
 		case tagCopy2:
+			in := src[s : s+3]
+			length = 1 + int(in[0])>>2
+			offset = int(uint32(in[1]) | uint32(in[2])<<8)
 			s += 3
-			length = 1 + int(src[s-3])>>2
-			offset = int(uint32(src[s-2]) | uint32(src[s-1])<<8)
 
 		case tagCopy4:
+			in := src[s : s+5]
+			length = 1 + int(in[0])>>2
+			offset = int(uint32(in[1]) | uint32(in[2])<<8 | uint32(in[3])<<16 | uint32(in[4])<<24)
 			s += 5
-			length = 1 + int(src[s-5])>>2
-			offset = int(uint32(src[s-4]) | uint32(src[s-3])<<8 | uint32(src[s-2])<<16 | uint32(src[s-1])<<24)
 		}
 
 		if offset <= 0 || d < offset || length > len(dst)-d {


### PR DESCRIPTION
Only seems to help very small encodes really:
```
benchmark                                                                 old ns/op     new ns/op     delta
BenchmarkTwainDecode1e1/default-32                                        24.5          12.6          -48.61%
BenchmarkTwainDecode1e1/better-32                                         25.2          12.6          -49.90%
BenchmarkTwainDecode1e1/best-32                                           25.8          12.6          -51.14%
BenchmarkTwainDecode1e1/snappy-input-32                                   25.1          12.6          -49.66%
BenchmarkTwainDecode1e2/default-32                                        51.9          42.3          -18.41%
BenchmarkTwainDecode1e2/better-32                                         75.1          59.2          -21.17%
BenchmarkTwainDecode1e2/best-32                                           74.3          55.9          -24.67%
BenchmarkTwainDecode1e2/snappy-input-32                                   74.1          57.4          -22.58%
BenchmarkTwainDecode1e3/default-32                                        189           163           -13.62%
BenchmarkTwainDecode1e3/better-32                                         607           577           -4.96%
BenchmarkTwainDecode1e3/best-32                                           634           616           -2.79%
BenchmarkTwainDecode1e3/snappy-input-32                                   519           480           -7.48%
BenchmarkTwainDecode1e4/default-32                                        4646          4690          +0.95%
BenchmarkTwainDecode1e4/better-32                                         11077         11151         +0.67%
BenchmarkTwainDecode1e4/best-32                                           11000         11364         +3.31%
BenchmarkTwainDecode1e4/snappy-input-32                                   11354         11460         +0.93%
BenchmarkTwainDecode1e5/default-32                                        139163        140259        +0.79%
BenchmarkTwainDecode1e5/better-32                                         236537        240051        +1.49%
BenchmarkTwainDecode1e5/best-32                                           233781        235656        +0.80%
BenchmarkTwainDecode1e5/snappy-input-32                                   268110        270810        +1.01%
BenchmarkTwainDecode1e6/default-32                                        1582443       1584509       +0.13%
BenchmarkTwainDecode1e6/better-32                                         2273135       2308712       +1.57%
BenchmarkTwainDecode1e6/best-32                                           2092574       2108555       +0.76%
BenchmarkTwainDecode1e6/snappy-input-32                                   2711775       2727778       +0.59%
BenchmarkTwainDecode1e7/default-32                                        15834966      15962745      +0.81%
BenchmarkTwainDecode1e7/better-32                                         22696148      22958016      +1.15%
BenchmarkTwainDecode1e7/best-32                                           20738425      20910498      +0.83%
BenchmarkTwainDecode1e7/snappy-input-32                                   27306220      27518433      +0.78%
```