### PR TITLE
zstd: Add DecodeAllCapLimit

### DIFF
--- a/zstd/decoder.go
+++ b/zstd/decoder.go
@@ -502,22 +502,6 @@ func (d *Decoder) nextBlockSync() (ok bool) {
 				d.current.err = ErrDecoderSizeExceeded
 				return false
 			}
-			if d.frame.FrameContentSize != fcsUnknown {
-				if !d.o.limitToCap && d.frame.FrameContentSize > d.o.maxDecodedSize {
-					if debugDecoder {
-						println("decoder size exceeded, fcs:", d.frame.FrameContentSize, "> mds", d.o.maxDecodedSize)
-					}
-					d.current.err = ErrDecoderSizeExceeded
-					return false
-				}
-				if d.o.limitToCap && d.frame.FrameContentSize > uint64(cap(d.frame.history.b)-len(d.frame.history.b)) {
-					if debugDecoder {
-						println("decoder size exceeded, fcs:", d.frame.FrameContentSize, "> cap", cap(d.frame.history.b)-len(d.frame.history.b))
-					}
-					d.current.err = ErrDecoderSizeExceeded
-					return false
-				}
-			}
 
 			d.syncStream.decodedFrame = 0
 			d.syncStream.inFrame = true

--- a/zstd/decoder.go
+++ b/zstd/decoder.go
@@ -312,6 +312,7 @@ func (d *Decoder) DecodeAll(input, dst []byte) ([]byte, error) {
 	// Grab a block decoder and frame decoder.
 	block := <-d.decoders
 	frame := block.localFrame
+	initialSize := len(dst)
 	defer func() {
 		if debugDecoder {
 			printf("re-adding decoder: %p", block)
@@ -354,15 +355,15 @@ func (d *Decoder) DecodeAll(input, dst []byte) ([]byte, error) {
 			return dst, ErrWindowSizeExceeded
 		}
 		if frame.FrameContentSize != fcsUnknown {
-			if frame.FrameContentSize > d.o.maxDecodedSize-uint64(len(dst)) {
+			if frame.FrameContentSize > d.o.maxDecodedSize-uint64(len(dst)-initialSize) {
 				if debugDecoder {
-					println("decoder size exceeded:", frame.FrameContentSize, ">", d.o.maxDecodedSize-uint64(len(dst)))
+					println("decoder size exceeded; fcs:", frame.FrameContentSize, "> mcs:", d.o.maxDecodedSize-uint64(len(dst)-initialSize), "len:", len(dst))
 				}
 				return dst, ErrDecoderSizeExceeded
 			}
 			if d.o.limitToCap && frame.FrameContentSize > uint64(cap(dst)-len(dst)) {
 				if debugDecoder {
-					println("decoder size exceeded:", frame.FrameContentSize, ">", cap(dst)-len(dst))
+					println("decoder size exceeded; fcs:", frame.FrameContentSize, "> (cap-len)", cap(dst)-len(dst))
 				}
 				return dst, ErrDecoderSizeExceeded
 			}
@@ -390,6 +391,9 @@ func (d *Decoder) DecodeAll(input, dst []byte) ([]byte, error) {
 		dst, err = frame.runDecoder(dst, block)
 		if err != nil {
 			return dst, err
+		}
+		if uint64(len(dst)-initialSize) > d.o.maxDecodedSize {
+			return dst, ErrDecoderSizeExceeded
 		}
 		if len(frame.bBuf) == 0 {
 			if debugDecoder {

--- a/zstd/decoder_options.go
+++ b/zstd/decoder_options.go
@@ -20,6 +20,7 @@ type decoderOptions struct {
 	maxWindowSize  uint64
 	dicts          []dict
 	ignoreChecksum bool
+	limitToCap     bool
 }
 
 func (o *decoderOptions) setDefault() {
@@ -110,6 +111,17 @@ func WithDecoderMaxWindow(size uint64) DOption {
 			return errors.New("WithMaxWindowSize must be less than (1<<41) + 7*(1<<38) ~ 3.75TB")
 		}
 		o.maxWindowSize = size
+		return nil
+	}
+}
+
+// WithDecodeAllCapLimit will limit DecodeAll to decoding cap(dst)-len(dst) bytes,
+// or any size set in WithDecoderMaxMemory.
+// This can be used to limit decoding to a specific maximum output size.
+// Disabled by default.
+func WithDecodeAllCapLimit(b bool) DOption {
+	return func(o *decoderOptions) error {
+		o.limitToCap = b
 		return nil
 	}
 }

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -1903,30 +1903,52 @@ func timeout(after time.Duration) (cancel func()) {
 }
 
 func TestWithDecodeAllCapLimit(t *testing.T) {
-	enc, _ := NewWriter(nil, WithZeroFrames(true), WithWindowSize(4<<10))
-	dec, _ := NewReader(nil, WithDecodeAllCapLimit(true))
+	var encs []*Encoder
+	var decs []*Decoder
+	addEnc := func(e *Encoder, _ error) {
+		encs = append(encs, e)
+	}
+	addDec := func(d *Decoder, _ error) {
+		decs = append(decs, d)
+	}
+	addEnc(NewWriter(nil, WithZeroFrames(true), WithWindowSize(4<<10)))
+	addEnc(NewWriter(nil, WithEncoderConcurrency(1), WithWindowSize(4<<10)))
+	addEnc(NewWriter(nil, WithZeroFrames(false), WithWindowSize(4<<10)))
+	addEnc(NewWriter(nil, WithWindowSize(128<<10)))
+	addDec(NewReader(nil, WithDecodeAllCapLimit(true)))
+	addDec(NewReader(nil, WithDecodeAllCapLimit(true), WithDecoderConcurrency(1)))
+	addDec(NewReader(nil, WithDecodeAllCapLimit(true), WithDecoderLowmem(true)))
+	addDec(NewReader(nil, WithDecodeAllCapLimit(true), WithDecoderMaxWindow(128<<10)))
+	addDec(NewReader(nil, WithDecodeAllCapLimit(true), WithDecoderMaxMemory(1<<20)))
 	for sz := 0; sz < 1<<20; sz = (sz + 1) * 2 {
 		sz := sz
 		t.Run(strconv.Itoa(sz), func(t *testing.T) {
-			encoded := enc.EncodeAll(make([]byte, sz), nil)
-			for i := sz - 1; i < sz+1; i++ {
-				if i < 0 {
-					continue
-				}
-				const existinglen = 5
-				got, err := dec.DecodeAll(encoded, make([]byte, existinglen, i+existinglen))
-				if i < sz {
-					if err != ErrDecoderSizeExceeded {
-						t.Errorf("cap: %d, want %v, got %v", i, ErrDecoderSizeExceeded, err)
-					}
-				} else {
-					if err != nil {
-						t.Errorf("cap: %d, want %v, got %v", i, nil, err)
-						continue
-					}
-					if len(got) != existinglen+i {
-						t.Errorf("cap: %d, want output size %d, got %d", i, existinglen+i, len(got))
-					}
+			t.Parallel()
+			for ei, enc := range encs {
+				for di, dec := range decs {
+					t.Run(fmt.Sprintf("e%d:d%d", ei, di), func(t *testing.T) {
+						encoded := enc.EncodeAll(make([]byte, sz), nil)
+						for i := sz - 1; i < sz+1; i++ {
+							if i < 0 {
+								continue
+							}
+							const existinglen = 5
+							got, err := dec.DecodeAll(encoded, make([]byte, existinglen, i+existinglen))
+							if i < sz {
+								if err != ErrDecoderSizeExceeded {
+									t.Errorf("cap: %d, want %v, got %v", i, ErrDecoderSizeExceeded, err)
+								}
+							} else {
+								if err != nil {
+									t.Errorf("cap: %d, want %v, got %v", i, nil, err)
+									continue
+								}
+								if len(got) != existinglen+i {
+									t.Errorf("cap: %d, want output size %d, got %d", i, existinglen+i, len(got))
+								}
+							}
+						}
+					})
 				}
 			}
 		})

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -389,11 +389,13 @@ func (d *frameDec) runDecoder(dst []byte, dec *blockDec) ([]byte, error) {
 		if err != nil {
 			break
 		}
-		if uint64(len(d.history.b)) > d.o.maxDecodedSize {
+		if uint64(len(d.history.b)-crcStart) > d.o.maxDecodedSize {
+			println("runDecoder: maxDecodedSize exceeded", uint64(len(d.history.b)-crcStart), ">", d.o.maxDecodedSize)
 			err = ErrDecoderSizeExceeded
 			break
 		}
 		if d.o.limitToCap && len(d.history.b) > cap(dst) {
+			println("runDecoder: cap exceeded", uint64(len(d.history.b)), ">", cap(dst))
 			err = ErrDecoderSizeExceeded
 			break
 		}

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -353,12 +353,23 @@ func (d *frameDec) runDecoder(dst []byte, dec *blockDec) ([]byte, error) {
 	// Store input length, so we only check new data.
 	crcStart := len(dst)
 	d.history.decoders.maxSyncLen = 0
+	if d.o.limitToCap {
+		d.history.decoders.maxSyncLen = uint64(cap(dst) - len(dst))
+	}
 	if d.FrameContentSize != fcsUnknown {
-		d.history.decoders.maxSyncLen = d.FrameContentSize + uint64(len(dst))
+		if !d.o.limitToCap || d.FrameContentSize+uint64(len(dst)) < d.history.decoders.maxSyncLen {
+			d.history.decoders.maxSyncLen = d.FrameContentSize + uint64(len(dst))
+		}
 		if d.history.decoders.maxSyncLen > d.o.maxDecodedSize {
+			if debugDecoder {
+				println("maxSyncLen:", d.history.decoders.maxSyncLen, "> maxDecodedSize:", d.o.maxDecodedSize)
+			}
 			return dst, ErrDecoderSizeExceeded
 		}
-		if uint64(cap(dst)) < d.history.decoders.maxSyncLen {
+		if debugDecoder {
+			println("maxSyncLen:", d.history.decoders.maxSyncLen)
+		}
+		if !d.o.limitToCap && uint64(cap(dst)-len(dst)) < d.history.decoders.maxSyncLen {
 			// Alloc for output
 			dst2 := make([]byte, len(dst), d.history.decoders.maxSyncLen+compressedBlockOverAlloc)
 			copy(dst2, dst)
@@ -379,6 +390,10 @@ func (d *frameDec) runDecoder(dst []byte, dec *blockDec) ([]byte, error) {
 			break
 		}
 		if uint64(len(d.history.b)) > d.o.maxDecodedSize {
+			err = ErrDecoderSizeExceeded
+			break
+		}
+		if d.o.limitToCap && len(d.history.b) > cap(dst) {
 			err = ErrDecoderSizeExceeded
 			break
 		}


### PR DESCRIPTION
WithDecodeAllCapLimit will limit DecodeAll to decoding cap(dst)-len(dst) bytes, or any size set in WithDecoderMaxMemory.

This can be used to limit decoding to a specific maximum output size.

Disabled by default.

Fixes #647