### PR TITLE
zstd: Fix non-effective noescape tag

### DIFF
--- a/zstd/fse_decoder_amd64.go
+++ b/zstd/fse_decoder_amd64.go
@@ -21,7 +21,8 @@ type buildDtableAsmContext struct {
 
 // buildDtable_asm is an x86 assembly implementation of fseDecoder.buildDtable.
 // Function returns non-zero exit code on error.
-// go:noescape
+//
+//go:noescape
 func buildDtable_asm(s *fseDecoder, ctx *buildDtableAsmContext) int
 
 // please keep in sync with _generate/gen_fse.go


### PR DESCRIPTION
Regression from #598 causing excessive heap allocations.