### PR TITLE
zstd: Optimize copyMemoryPrecise further

### DIFF
--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -1217,21 +1217,19 @@ check_offset:
 	SUBQ R11, R14
 	CMPQ R13, R11
 	JG   copy_all_from_history
-	MOVQ R13, R11
-	SUBQ $0x10, R11
+	CMPQ R13, $0x10
 	JB   copy_4_small
+	XORQ R11, R11
 
 copy_4_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (BX)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, BX
-	SUBQ   $0x10, R11
-	JAE    copy_4_loop
-	LEAQ   16(R14)(R11*1), R14
-	LEAQ   16(BX)(R11*1), BX
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(BX)
+	MOVUPS (R14)(R11*1), X0
+	MOVUPS X0, (BX)(R11*1)
+	ADDQ   $0x10, R11
+	CMPQ   R11, R13
+	JB     copy_4_loop
+	JE     copy_4_end
+	MOVUPS -16(R14)(R13*1), X0
+	MOVUPS X0, -16(BX)(R13*1)
 	JMP    copy_4_end
 
 copy_4_small:
@@ -1246,8 +1244,6 @@ copy_4_move_3:
 	MOVB 2(R14), R12
 	MOVW R11, (BX)
 	MOVB R12, 2(BX)
-	ADDQ R13, R14
-	ADDQ R13, BX
 	JMP  copy_4_end
 
 copy_4_move_4through7:
@@ -1255,8 +1251,6 @@ copy_4_move_4through7:
 	MOVL -4(R14)(R13*1), R12
 	MOVL R11, (BX)
 	MOVL R12, -4(BX)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, BX
 	JMP  copy_4_end
 
 copy_4_move_8through16:
@@ -1264,10 +1258,10 @@ copy_4_move_8through16:
 	MOVQ -8(R14)(R13*1), R12
 	MOVQ R11, (BX)
 	MOVQ R12, -8(BX)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, BX
 
 copy_4_end:
+	ADDQ R13, R14
+	ADDQ R13, BX
 	ADDQ R13, DI
 	ADDQ $0x18, AX
 	INCQ DX
@@ -1276,21 +1270,19 @@ copy_4_end:
 	JMP  loop_finished
 
 copy_all_from_history:
-	MOVQ R11, R15
-	SUBQ $0x10, R15
+	CMPQ R11, $0x10
 	JB   copy_5_small
+	XORQ R15, R15
 
 copy_5_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (BX)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, BX
-	SUBQ   $0x10, R15
-	JAE    copy_5_loop
-	LEAQ   16(R14)(R15*1), R14
-	LEAQ   16(BX)(R15*1), BX
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(BX)
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (BX)(R15*1)
+	ADDQ   $0x10, R15
+	CMPQ   R15, R11
+	JB     copy_5_loop
+	JE     copy_5_end
+	MOVUPS -16(R14)(R11*1), X0
+	MOVUPS X0, -16(BX)(R11*1)
 	JMP    copy_5_end
 
 copy_5_small:
@@ -1306,8 +1298,6 @@ copy_5_move_1or2:
 	MOVB -1(R14)(R11*1), BP
 	MOVB R15, (BX)
 	MOVB BP, -1(BX)(R11*1)
-	ADDQ R11, R14
-	ADDQ R11, BX
 	JMP  copy_5_end
 
 copy_5_move_3:
@@ -1315,8 +1305,6 @@ copy_5_move_3:
 	MOVB 2(R14), BP
 	MOVW R15, (BX)
 	MOVB BP, 2(BX)
-	ADDQ R11, R14
-	ADDQ R11, BX
 	JMP  copy_5_end
 
 copy_5_move_4through7:
@@ -1324,8 +1312,6 @@ copy_5_move_4through7:
 	MOVL -4(R14)(R11*1), BP
 	MOVL R15, (BX)
 	MOVL BP, -4(BX)(R11*1)
-	ADDQ R11, R14
-	ADDQ R11, BX
 	JMP  copy_5_end
 
 copy_5_move_8through16:
@@ -1333,10 +1319,10 @@ copy_5_move_8through16:
 	MOVQ -8(R14)(R11*1), BP
 	MOVQ R15, (BX)
 	MOVQ BP, -8(BX)(R11*1)
-	ADDQ R11, R14
-	ADDQ R11, BX
 
 copy_5_end:
+	ADDQ R11, R14
+	ADDQ R11, BX
 	ADDQ R11, DI
 	SUBQ R11, R13
 
@@ -1445,21 +1431,19 @@ main_loop:
 	// Copy literals
 	TESTQ R11, R11
 	JZ    check_offset
-	MOVQ  R11, R14
-	SUBQ  $0x10, R14
+	CMPQ  R11, $0x10
 	JB    copy_1_small
+	XORQ  R14, R14
 
 copy_1_loop:
-	MOVUPS (SI), X0
-	MOVUPS X0, (BX)
-	ADDQ   $0x10, SI
-	ADDQ   $0x10, BX
-	SUBQ   $0x10, R14
-	JAE    copy_1_loop
-	LEAQ   16(SI)(R14*1), SI
-	LEAQ   16(BX)(R14*1), BX
-	MOVUPS -16(SI), X0
-	MOVUPS X0, -16(BX)
+	MOVUPS (SI)(R14*1), X0
+	MOVUPS X0, (BX)(R14*1)
+	ADDQ   $0x10, R14
+	CMPQ   R14, R11
+	JB     copy_1_loop
+	JE     copy_1_end
+	MOVUPS -16(SI)(R11*1), X0
+	MOVUPS X0, -16(BX)(R11*1)
 	JMP    copy_1_end
 
 copy_1_small:
@@ -1475,8 +1459,6 @@ copy_1_move_1or2:
 	MOVB -1(SI)(R11*1), R15
 	MOVB R14, (BX)
 	MOVB R15, -1(BX)(R11*1)
-	ADDQ R11, SI
-	ADDQ R11, BX
 	JMP  copy_1_end
 
 copy_1_move_3:
@@ -1484,8 +1466,6 @@ copy_1_move_3:
 	MOVB 2(SI), R15
 	MOVW R14, (BX)
 	MOVB R15, 2(BX)
-	ADDQ R11, SI
-	ADDQ R11, BX
 	JMP  copy_1_end
 
 copy_1_move_4through7:
@@ -1493,8 +1473,6 @@ copy_1_move_4through7:
 	MOVL -4(SI)(R11*1), R15
 	MOVL R14, (BX)
 	MOVL R15, -4(BX)(R11*1)
-	ADDQ R11, SI
-	ADDQ R11, BX
 	JMP  copy_1_end
 
 copy_1_move_8through16:
@@ -1502,10 +1480,10 @@ copy_1_move_8through16:
 	MOVQ -8(SI)(R11*1), R15
 	MOVQ R14, (BX)
 	MOVQ R15, -8(BX)(R11*1)
-	ADDQ R11, SI
-	ADDQ R11, BX
 
 copy_1_end:
+	ADDQ R11, SI
+	ADDQ R11, BX
 	ADDQ R11, DI
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
@@ -1524,21 +1502,19 @@ check_offset:
 	SUBQ R11, R14
 	CMPQ R13, R11
 	JG   copy_all_from_history
-	MOVQ R13, R11
-	SUBQ $0x10, R11
+	CMPQ R13, $0x10
 	JB   copy_4_small
+	XORQ R11, R11
 
 copy_4_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (BX)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, BX
-	SUBQ   $0x10, R11
-	JAE    copy_4_loop
-	LEAQ   16(R14)(R11*1), R14
-	LEAQ   16(BX)(R11*1), BX
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(BX)
+	MOVUPS (R14)(R11*1), X0
+	MOVUPS X0, (BX)(R11*1)
+	ADDQ   $0x10, R11
+	CMPQ   R11, R13
+	JB     copy_4_loop
+	JE     copy_4_end
+	MOVUPS -16(R14)(R13*1), X0
+	MOVUPS X0, -16(BX)(R13*1)
 	JMP    copy_4_end
 
 copy_4_small:
@@ -1553,8 +1529,6 @@ copy_4_move_3:
 	MOVB 2(R14), R12
 	MOVW R11, (BX)
 	MOVB R12, 2(BX)
-	ADDQ R13, R14
-	ADDQ R13, BX
 	JMP  copy_4_end
 
 copy_4_move_4through7:
@@ -1562,8 +1536,6 @@ copy_4_move_4through7:
 	MOVL -4(R14)(R13*1), R12
 	MOVL R11, (BX)
 	MOVL R12, -4(BX)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, BX
 	JMP  copy_4_end
 
 copy_4_move_8through16:
@@ -1571,10 +1543,10 @@ copy_4_move_8through16:
 	MOVQ -8(R14)(R13*1), R12
 	MOVQ R11, (BX)
 	MOVQ R12, -8(BX)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, BX
 
 copy_4_end:
+	ADDQ R13, R14
+	ADDQ R13, BX
 	ADDQ R13, DI
 	ADDQ $0x18, AX
 	INCQ DX
@@ -1583,21 +1555,19 @@ copy_4_end:
 	JMP  loop_finished
 
 copy_all_from_history:
-	MOVQ R11, R15
-	SUBQ $0x10, R15
+	CMPQ R11, $0x10
 	JB   copy_5_small
+	XORQ R15, R15
 
 copy_5_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (BX)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, BX
-	SUBQ   $0x10, R15
-	JAE    copy_5_loop
-	LEAQ   16(R14)(R15*1), R14
-	LEAQ   16(BX)(R15*1), BX
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(BX)
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (BX)(R15*1)
+	ADDQ   $0x10, R15
+	CMPQ   R15, R11
+	JB     copy_5_loop
+	JE     copy_5_end
+	MOVUPS -16(R14)(R11*1), X0
+	MOVUPS X0, -16(BX)(R11*1)
 	JMP    copy_5_end
 
 copy_5_small:
@@ -1613,8 +1583,6 @@ copy_5_move_1or2:
 	MOVB -1(R14)(R11*1), BP
 	MOVB R15, (BX)
 	MOVB BP, -1(BX)(R11*1)
-	ADDQ R11, R14
-	ADDQ R11, BX
 	JMP  copy_5_end
 
 copy_5_move_3:
@@ -1622,8 +1590,6 @@ copy_5_move_3:
 	MOVB 2(R14), BP
 	MOVW R15, (BX)
 	MOVB BP, 2(BX)
-	ADDQ R11, R14
-	ADDQ R11, BX
 	JMP  copy_5_end
 
 copy_5_move_4through7:
@@ -1631,8 +1597,6 @@ copy_5_move_4through7:
 	MOVL -4(R14)(R11*1), BP
 	MOVL R15, (BX)
 	MOVL BP, -4(BX)(R11*1)
-	ADDQ R11, R14
-	ADDQ R11, BX
 	JMP  copy_5_end
 
 copy_5_move_8through16:
@@ -1640,10 +1604,10 @@ copy_5_move_8through16:
 	MOVQ -8(R14)(R11*1), BP
 	MOVQ R15, (BX)
 	MOVQ BP, -8(BX)(R11*1)
-	ADDQ R11, R14
-	ADDQ R11, BX
 
 copy_5_end:
+	ADDQ R11, R14
+	ADDQ R11, BX
 	ADDQ R11, DI
 	SUBQ R11, R13
 
@@ -1658,21 +1622,19 @@ copy_match:
 
 	// Copy non-overlapping match
 	ADDQ R13, DI
-	MOVQ R13, R12
-	SUBQ $0x10, R12
+	CMPQ R13, $0x10
 	JB   copy_2_small
+	XORQ R12, R12
 
 copy_2_loop:
-	MOVUPS (R11), X0
-	MOVUPS X0, (BX)
-	ADDQ   $0x10, R11
-	ADDQ   $0x10, BX
-	SUBQ   $0x10, R12
-	JAE    copy_2_loop
-	LEAQ   16(R11)(R12*1), R11
-	LEAQ   16(BX)(R12*1), BX
-	MOVUPS -16(R11), X0
-	MOVUPS X0, -16(BX)
+	MOVUPS (R11)(R12*1), X0
+	MOVUPS X0, (BX)(R12*1)
+	ADDQ   $0x10, R12
+	CMPQ   R12, R13
+	JB     copy_2_loop
+	JE     copy_2_end
+	MOVUPS -16(R11)(R13*1), X0
+	MOVUPS X0, -16(BX)(R13*1)
 	JMP    copy_2_end
 
 copy_2_small:
@@ -1688,8 +1650,6 @@ copy_2_move_1or2:
 	MOVB -1(R11)(R13*1), R14
 	MOVB R12, (BX)
 	MOVB R14, -1(BX)(R13*1)
-	ADDQ R13, R11
-	ADDQ R13, BX
 	JMP  copy_2_end
 
 copy_2_move_3:
@@ -1697,8 +1657,6 @@ copy_2_move_3:
 	MOVB 2(R11), R14
 	MOVW R12, (BX)
 	MOVB R14, 2(BX)
-	ADDQ R13, R11
-	ADDQ R13, BX
 	JMP  copy_2_end
 
 copy_2_move_4through7:
@@ -1706,8 +1664,6 @@ copy_2_move_4through7:
 	MOVL -4(R11)(R13*1), R14
 	MOVL R12, (BX)
 	MOVL R14, -4(BX)(R13*1)
-	ADDQ R13, R11
-	ADDQ R13, BX
 	JMP  copy_2_end
 
 copy_2_move_8through16:
@@ -1715,11 +1671,11 @@ copy_2_move_8through16:
 	MOVQ -8(R11)(R13*1), R14
 	MOVQ R12, (BX)
 	MOVQ R14, -8(BX)(R13*1)
-	ADDQ R13, R11
-	ADDQ R13, BX
 
 copy_2_end:
-	JMP handle_loop
+	ADDQ R13, R11
+	ADDQ R13, BX
+	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
@@ -2101,21 +2057,19 @@ check_offset:
 	SUBQ AX, R14
 	CMPQ R13, AX
 	JG   copy_all_from_history
-	MOVQ R13, AX
-	SUBQ $0x10, AX
+	CMPQ R13, $0x10
 	JB   copy_4_small
+	XORQ AX, AX
 
 copy_4_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R10)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R10
-	SUBQ   $0x10, AX
-	JAE    copy_4_loop
-	LEAQ   16(R14)(AX*1), R14
-	LEAQ   16(R10)(AX*1), R10
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R10)
+	MOVUPS (R14)(AX*1), X0
+	MOVUPS X0, (R10)(AX*1)
+	ADDQ   $0x10, AX
+	CMPQ   AX, R13
+	JB     copy_4_loop
+	JE     copy_4_end
+	MOVUPS -16(R14)(R13*1), X0
+	MOVUPS X0, -16(R10)(R13*1)
 	JMP    copy_4_end
 
 copy_4_small:
@@ -2130,8 +2084,6 @@ copy_4_move_3:
 	MOVB 2(R14), CL
 	MOVW AX, (R10)
 	MOVB CL, 2(R10)
-	ADDQ R13, R14
-	ADDQ R13, R10
 	JMP  copy_4_end
 
 copy_4_move_4through7:
@@ -2139,8 +2091,6 @@ copy_4_move_4through7:
 	MOVL -4(R14)(R13*1), CX
 	MOVL AX, (R10)
 	MOVL CX, -4(R10)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R10
 	JMP  copy_4_end
 
 copy_4_move_8through16:
@@ -2148,30 +2098,28 @@ copy_4_move_8through16:
 	MOVQ -8(R14)(R13*1), CX
 	MOVQ AX, (R10)
 	MOVQ CX, -8(R10)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R10
 
 copy_4_end:
+	ADDQ R13, R14
+	ADDQ R13, R10
 	ADDQ R13, R12
 	JMP  handle_loop
 	JMP loop_finished
 
 copy_all_from_history:
-	MOVQ AX, R15
-	SUBQ $0x10, R15
+	CMPQ AX, $0x10
 	JB   copy_5_small
+	XORQ R15, R15
 
 copy_5_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R10)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R10
-	SUBQ   $0x10, R15
-	JAE    copy_5_loop
-	LEAQ   16(R14)(R15*1), R14
-	LEAQ   16(R10)(R15*1), R10
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R10)
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (R10)(R15*1)
+	ADDQ   $0x10, R15
+	CMPQ   R15, AX
+	JB     copy_5_loop
+	JE     copy_5_end
+	MOVUPS -16(R14)(AX*1), X0
+	MOVUPS X0, -16(R10)(AX*1)
 	JMP    copy_5_end
 
 copy_5_small:
@@ -2187,8 +2135,6 @@ copy_5_move_1or2:
 	MOVB -1(R14)(AX*1), BP
 	MOVB R15, (R10)
 	MOVB BP, -1(R10)(AX*1)
-	ADDQ AX, R14
-	ADDQ AX, R10
 	JMP  copy_5_end
 
 copy_5_move_3:
@@ -2196,8 +2142,6 @@ copy_5_move_3:
 	MOVB 2(R14), BP
 	MOVW R15, (R10)
 	MOVB BP, 2(R10)
-	ADDQ AX, R14
-	ADDQ AX, R10
 	JMP  copy_5_end
 
 copy_5_move_4through7:
@@ -2205,8 +2149,6 @@ copy_5_move_4through7:
 	MOVL -4(R14)(AX*1), BP
 	MOVL R15, (R10)
 	MOVL BP, -4(R10)(AX*1)
-	ADDQ AX, R14
-	ADDQ AX, R10
 	JMP  copy_5_end
 
 copy_5_move_8through16:
@@ -2214,10 +2156,10 @@ copy_5_move_8through16:
 	MOVQ -8(R14)(AX*1), BP
 	MOVQ R15, (R10)
 	MOVQ BP, -8(R10)(AX*1)
-	ADDQ AX, R14
-	ADDQ AX, R10
 
 copy_5_end:
+	ADDQ AX, R14
+	ADDQ AX, R10
 	ADDQ AX, R12
 	SUBQ AX, R13
 
@@ -2611,21 +2553,19 @@ check_offset:
 	SUBQ CX, R14
 	CMPQ R13, CX
 	JG   copy_all_from_history
-	MOVQ R13, CX
-	SUBQ $0x10, CX
+	CMPQ R13, $0x10
 	JB   copy_4_small
+	XORQ CX, CX
 
 copy_4_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R9)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R9
-	SUBQ   $0x10, CX
-	JAE    copy_4_loop
-	LEAQ   16(R14)(CX*1), R14
-	LEAQ   16(R9)(CX*1), R9
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R9)
+	MOVUPS (R14)(CX*1), X0
+	MOVUPS X0, (R9)(CX*1)
+	ADDQ   $0x10, CX
+	CMPQ   CX, R13
+	JB     copy_4_loop
+	JE     copy_4_end
+	MOVUPS -16(R14)(R13*1), X0
+	MOVUPS X0, -16(R9)(R13*1)
 	JMP    copy_4_end
 
 copy_4_small:
@@ -2640,8 +2580,6 @@ copy_4_move_3:
 	MOVB 2(R14), R12
 	MOVW CX, (R9)
 	MOVB R12, 2(R9)
-	ADDQ R13, R14
-	ADDQ R13, R9
 	JMP  copy_4_end
 
 copy_4_move_4through7:
@@ -2649,8 +2587,6 @@ copy_4_move_4through7:
 	MOVL -4(R14)(R13*1), R12
 	MOVL CX, (R9)
 	MOVL R12, -4(R9)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R9
 	JMP  copy_4_end
 
 copy_4_move_8through16:
@@ -2658,30 +2594,28 @@ copy_4_move_8through16:
 	MOVQ -8(R14)(R13*1), R12
 	MOVQ CX, (R9)
 	MOVQ R12, -8(R9)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R9
 
 copy_4_end:
+	ADDQ R13, R14
+	ADDQ R13, R9
 	ADDQ R13, R11
 	JMP  handle_loop
 	JMP loop_finished
 
 copy_all_from_history:
-	MOVQ CX, R15
-	SUBQ $0x10, R15
+	CMPQ CX, $0x10
 	JB   copy_5_small
+	XORQ R15, R15
 
 copy_5_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R9)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R9
-	SUBQ   $0x10, R15
-	JAE    copy_5_loop
-	LEAQ   16(R14)(R15*1), R14
-	LEAQ   16(R9)(R15*1), R9
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R9)
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (R9)(R15*1)
+	ADDQ   $0x10, R15
+	CMPQ   R15, CX
+	JB     copy_5_loop
+	JE     copy_5_end
+	MOVUPS -16(R14)(CX*1), X0
+	MOVUPS X0, -16(R9)(CX*1)
 	JMP    copy_5_end
 
 copy_5_small:
@@ -2697,8 +2631,6 @@ copy_5_move_1or2:
 	MOVB -1(R14)(CX*1), BP
 	MOVB R15, (R9)
 	MOVB BP, -1(R9)(CX*1)
-	ADDQ CX, R14
-	ADDQ CX, R9
 	JMP  copy_5_end
 
 copy_5_move_3:
@@ -2706,8 +2638,6 @@ copy_5_move_3:
 	MOVB 2(R14), BP
 	MOVW R15, (R9)
 	MOVB BP, 2(R9)
-	ADDQ CX, R14
-	ADDQ CX, R9
 	JMP  copy_5_end
 
 copy_5_move_4through7:
@@ -2715,8 +2645,6 @@ copy_5_move_4through7:
 	MOVL -4(R14)(CX*1), BP
 	MOVL R15, (R9)
 	MOVL BP, -4(R9)(CX*1)
-	ADDQ CX, R14
-	ADDQ CX, R9
 	JMP  copy_5_end
 
 copy_5_move_8through16:
@@ -2724,10 +2652,10 @@ copy_5_move_8through16:
 	MOVQ -8(R14)(CX*1), BP
 	MOVQ R15, (R9)
 	MOVQ BP, -8(R9)(CX*1)
-	ADDQ CX, R14
-	ADDQ CX, R9
 
 copy_5_end:
+	ADDQ CX, R14
+	ADDQ CX, R9
 	ADDQ CX, R11
 	SUBQ CX, R13
 
@@ -3134,21 +3062,19 @@ sequenceDecs_decodeSync_safe_amd64_match_len_ofs_ok:
 	// Copy literals
 	TESTQ AX, AX
 	JZ    check_offset
-	MOVQ  AX, R14
-	SUBQ  $0x10, R14
+	CMPQ  AX, $0x10
 	JB    copy_1_small
+	XORQ  R14, R14
 
 copy_1_loop:
-	MOVUPS (R11), X0
-	MOVUPS X0, (R10)
-	ADDQ   $0x10, R11
-	ADDQ   $0x10, R10
-	SUBQ   $0x10, R14
-	JAE    copy_1_loop
-	LEAQ   16(R11)(R14*1), R11
-	LEAQ   16(R10)(R14*1), R10
-	MOVUPS -16(R11), X0
-	MOVUPS X0, -16(R10)
+	MOVUPS (R11)(R14*1), X0
+	MOVUPS X0, (R10)(R14*1)
+	ADDQ   $0x10, R14
+	CMPQ   R14, AX
+	JB     copy_1_loop
+	JE     copy_1_end
+	MOVUPS -16(R11)(AX*1), X0
+	MOVUPS X0, -16(R10)(AX*1)
 	JMP    copy_1_end
 
 copy_1_small:
@@ -3164,8 +3090,6 @@ copy_1_move_1or2:
 	MOVB -1(R11)(AX*1), R15
 	MOVB R14, (R10)
 	MOVB R15, -1(R10)(AX*1)
-	ADDQ AX, R11
-	ADDQ AX, R10
 	JMP  copy_1_end
 
 copy_1_move_3:
@@ -3173,8 +3097,6 @@ copy_1_move_3:
 	MOVB 2(R11), R15
 	MOVW R14, (R10)
 	MOVB R15, 2(R10)
-	ADDQ AX, R11
-	ADDQ AX, R10
 	JMP  copy_1_end
 
 copy_1_move_4through7:
@@ -3182,8 +3104,6 @@ copy_1_move_4through7:
 	MOVL -4(R11)(AX*1), R15
 	MOVL R14, (R10)
 	MOVL R15, -4(R10)(AX*1)
-	ADDQ AX, R11
-	ADDQ AX, R10
 	JMP  copy_1_end
 
 copy_1_move_8through16:
@@ -3191,10 +3111,10 @@ copy_1_move_8through16:
 	MOVQ -8(R11)(AX*1), R15
 	MOVQ R14, (R10)
 	MOVQ R15, -8(R10)(AX*1)
-	ADDQ AX, R11
-	ADDQ AX, R10
 
 copy_1_end:
+	ADDQ AX, R11
+	ADDQ AX, R10
 	ADDQ AX, R12
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
@@ -3214,21 +3134,19 @@ check_offset:
 	SUBQ AX, R14
 	CMPQ R13, AX
 	JG   copy_all_from_history
-	MOVQ R13, AX
-	SUBQ $0x10, AX
+	CMPQ R13, $0x10
 	JB   copy_4_small
+	XORQ AX, AX
 
 copy_4_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R10)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R10
-	SUBQ   $0x10, AX
-	JAE    copy_4_loop
-	LEAQ   16(R14)(AX*1), R14
-	LEAQ   16(R10)(AX*1), R10
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R10)
+	MOVUPS (R14)(AX*1), X0
+	MOVUPS X0, (R10)(AX*1)
+	ADDQ   $0x10, AX
+	CMPQ   AX, R13
+	JB     copy_4_loop
+	JE     copy_4_end
+	MOVUPS -16(R14)(R13*1), X0
+	MOVUPS X0, -16(R10)(R13*1)
 	JMP    copy_4_end
 
 copy_4_small:
@@ -3243,8 +3161,6 @@ copy_4_move_3:
 	MOVB 2(R14), CL
 	MOVW AX, (R10)
 	MOVB CL, 2(R10)
-	ADDQ R13, R14
-	ADDQ R13, R10
 	JMP  copy_4_end
 
 copy_4_move_4through7:
@@ -3252,8 +3168,6 @@ copy_4_move_4through7:
 	MOVL -4(R14)(R13*1), CX
 	MOVL AX, (R10)
 	MOVL CX, -4(R10)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R10
 	JMP  copy_4_end
 
 copy_4_move_8through16:
@@ -3261,30 +3175,28 @@ copy_4_move_8through16:
 	MOVQ -8(R14)(R13*1), CX
 	MOVQ AX, (R10)
 	MOVQ CX, -8(R10)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R10
 
 copy_4_end:
+	ADDQ R13, R14
+	ADDQ R13, R10
 	ADDQ R13, R12
 	JMP  handle_loop
 	JMP loop_finished
 
 copy_all_from_history:
-	MOVQ AX, R15
-	SUBQ $0x10, R15
+	CMPQ AX, $0x10
 	JB   copy_5_small
+	XORQ R15, R15
 
 copy_5_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R10)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R10
-	SUBQ   $0x10, R15
-	JAE    copy_5_loop
-	LEAQ   16(R14)(R15*1), R14
-	LEAQ   16(R10)(R15*1), R10
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R10)
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (R10)(R15*1)
+	ADDQ   $0x10, R15
+	CMPQ   R15, AX
+	JB     copy_5_loop
+	JE     copy_5_end
+	MOVUPS -16(R14)(AX*1), X0
+	MOVUPS X0, -16(R10)(AX*1)
 	JMP    copy_5_end
 
 copy_5_small:
@@ -3300,8 +3212,6 @@ copy_5_move_1or2:
 	MOVB -1(R14)(AX*1), BP
 	MOVB R15, (R10)
 	MOVB BP, -1(R10)(AX*1)
-	ADDQ AX, R14
-	ADDQ AX, R10
 	JMP  copy_5_end
 
 copy_5_move_3:
@@ -3309,8 +3219,6 @@ copy_5_move_3:
 	MOVB 2(R14), BP
 	MOVW R15, (R10)
 	MOVB BP, 2(R10)
-	ADDQ AX, R14
-	ADDQ AX, R10
 	JMP  copy_5_end
 
 copy_5_move_4through7:
@@ -3318,8 +3226,6 @@ copy_5_move_4through7:
 	MOVL -4(R14)(AX*1), BP
 	MOVL R15, (R10)
 	MOVL BP, -4(R10)(AX*1)
-	ADDQ AX, R14
-	ADDQ AX, R10
 	JMP  copy_5_end
 
 copy_5_move_8through16:
@@ -3327,10 +3233,10 @@ copy_5_move_8through16:
 	MOVQ -8(R14)(AX*1), BP
 	MOVQ R15, (R10)
 	MOVQ BP, -8(R10)(AX*1)
-	ADDQ AX, R14
-	ADDQ AX, R10
 
 copy_5_end:
+	ADDQ AX, R14
+	ADDQ AX, R10
 	ADDQ AX, R12
 	SUBQ AX, R13
 
@@ -3345,21 +3251,19 @@ copy_match:
 
 	// Copy non-overlapping match
 	ADDQ R13, R12
-	MOVQ R13, CX
-	SUBQ $0x10, CX
+	CMPQ R13, $0x10
 	JB   copy_2_small
+	XORQ CX, CX
 
 copy_2_loop:
-	MOVUPS (AX), X0
-	MOVUPS X0, (R10)
-	ADDQ   $0x10, AX
-	ADDQ   $0x10, R10
-	SUBQ   $0x10, CX
-	JAE    copy_2_loop
-	LEAQ   16(AX)(CX*1), AX
-	LEAQ   16(R10)(CX*1), R10
-	MOVUPS -16(AX), X0
-	MOVUPS X0, -16(R10)
+	MOVUPS (AX)(CX*1), X0
+	MOVUPS X0, (R10)(CX*1)
+	ADDQ   $0x10, CX
+	CMPQ   CX, R13
+	JB     copy_2_loop
+	JE     copy_2_end
+	MOVUPS -16(AX)(R13*1), X0
+	MOVUPS X0, -16(R10)(R13*1)
 	JMP    copy_2_end
 
 copy_2_small:
@@ -3375,8 +3279,6 @@ copy_2_move_1or2:
 	MOVB -1(AX)(R13*1), R14
 	MOVB CL, (R10)
 	MOVB R14, -1(R10)(R13*1)
-	ADDQ R13, AX
-	ADDQ R13, R10
 	JMP  copy_2_end
 
 copy_2_move_3:
@@ -3384,8 +3286,6 @@ copy_2_move_3:
 	MOVB 2(AX), R14
 	MOVW CX, (R10)
 	MOVB R14, 2(R10)
-	ADDQ R13, AX
-	ADDQ R13, R10
 	JMP  copy_2_end
 
 copy_2_move_4through7:
@@ -3393,8 +3293,6 @@ copy_2_move_4through7:
 	MOVL -4(AX)(R13*1), R14
 	MOVL CX, (R10)
 	MOVL R14, -4(R10)(R13*1)
-	ADDQ R13, AX
-	ADDQ R13, R10
 	JMP  copy_2_end
 
 copy_2_move_8through16:
@@ -3402,11 +3300,11 @@ copy_2_move_8through16:
 	MOVQ -8(AX)(R13*1), R14
 	MOVQ CX, (R10)
 	MOVQ R14, -8(R10)(R13*1)
-	ADDQ R13, AX
-	ADDQ R13, R10
 
 copy_2_end:
-	JMP handle_loop
+	ADDQ R13, AX
+	ADDQ R13, R10
+	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:
@@ -3746,21 +3644,19 @@ sequenceDecs_decodeSync_safe_bmi2_match_len_ofs_ok:
 	// Copy literals
 	TESTQ CX, CX
 	JZ    check_offset
-	MOVQ  CX, R14
-	SUBQ  $0x10, R14
+	CMPQ  CX, $0x10
 	JB    copy_1_small
+	XORQ  R14, R14
 
 copy_1_loop:
-	MOVUPS (R10), X0
-	MOVUPS X0, (R9)
-	ADDQ   $0x10, R10
-	ADDQ   $0x10, R9
-	SUBQ   $0x10, R14
-	JAE    copy_1_loop
-	LEAQ   16(R10)(R14*1), R10
-	LEAQ   16(R9)(R14*1), R9
-	MOVUPS -16(R10), X0
-	MOVUPS X0, -16(R9)
+	MOVUPS (R10)(R14*1), X0
+	MOVUPS X0, (R9)(R14*1)
+	ADDQ   $0x10, R14
+	CMPQ   R14, CX
+	JB     copy_1_loop
+	JE     copy_1_end
+	MOVUPS -16(R10)(CX*1), X0
+	MOVUPS X0, -16(R9)(CX*1)
 	JMP    copy_1_end
 
 copy_1_small:
@@ -3776,8 +3672,6 @@ copy_1_move_1or2:
 	MOVB -1(R10)(CX*1), R15
 	MOVB R14, (R9)
 	MOVB R15, -1(R9)(CX*1)
-	ADDQ CX, R10
-	ADDQ CX, R9
 	JMP  copy_1_end
 
 copy_1_move_3:
@@ -3785,8 +3679,6 @@ copy_1_move_3:
 	MOVB 2(R10), R15
 	MOVW R14, (R9)
 	MOVB R15, 2(R9)
-	ADDQ CX, R10
-	ADDQ CX, R9
 	JMP  copy_1_end
 
 copy_1_move_4through7:
@@ -3794,8 +3686,6 @@ copy_1_move_4through7:
 	MOVL -4(R10)(CX*1), R15
 	MOVL R14, (R9)
 	MOVL R15, -4(R9)(CX*1)
-	ADDQ CX, R10
-	ADDQ CX, R9
 	JMP  copy_1_end
 
 copy_1_move_8through16:
@@ -3803,10 +3693,10 @@ copy_1_move_8through16:
 	MOVQ -8(R10)(CX*1), R15
 	MOVQ R14, (R9)
 	MOVQ R15, -8(R9)(CX*1)
-	ADDQ CX, R10
-	ADDQ CX, R9
 
 copy_1_end:
+	ADDQ CX, R10
+	ADDQ CX, R9
 	ADDQ CX, R11
 
 	// Malformed input if seq.mo > t+len(hist) || seq.mo > s.windowSize)
@@ -3826,21 +3716,19 @@ check_offset:
 	SUBQ CX, R14
 	CMPQ R13, CX
 	JG   copy_all_from_history
-	MOVQ R13, CX
-	SUBQ $0x10, CX
+	CMPQ R13, $0x10
 	JB   copy_4_small
+	XORQ CX, CX
 
 copy_4_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R9)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R9
-	SUBQ   $0x10, CX
-	JAE    copy_4_loop
-	LEAQ   16(R14)(CX*1), R14
-	LEAQ   16(R9)(CX*1), R9
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R9)
+	MOVUPS (R14)(CX*1), X0
+	MOVUPS X0, (R9)(CX*1)
+	ADDQ   $0x10, CX
+	CMPQ   CX, R13
+	JB     copy_4_loop
+	JE     copy_4_end
+	MOVUPS -16(R14)(R13*1), X0
+	MOVUPS X0, -16(R9)(R13*1)
 	JMP    copy_4_end
 
 copy_4_small:
@@ -3855,8 +3743,6 @@ copy_4_move_3:
 	MOVB 2(R14), R12
 	MOVW CX, (R9)
 	MOVB R12, 2(R9)
-	ADDQ R13, R14
-	ADDQ R13, R9
 	JMP  copy_4_end
 
 copy_4_move_4through7:
@@ -3864,8 +3750,6 @@ copy_4_move_4through7:
 	MOVL -4(R14)(R13*1), R12
 	MOVL CX, (R9)
 	MOVL R12, -4(R9)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R9
 	JMP  copy_4_end
 
 copy_4_move_8through16:
@@ -3873,30 +3757,28 @@ copy_4_move_8through16:
 	MOVQ -8(R14)(R13*1), R12
 	MOVQ CX, (R9)
 	MOVQ R12, -8(R9)(R13*1)
-	ADDQ R13, R14
-	ADDQ R13, R9
 
 copy_4_end:
+	ADDQ R13, R14
+	ADDQ R13, R9
 	ADDQ R13, R11
 	JMP  handle_loop
 	JMP loop_finished
 
 copy_all_from_history:
-	MOVQ CX, R15
-	SUBQ $0x10, R15
+	CMPQ CX, $0x10
 	JB   copy_5_small
+	XORQ R15, R15
 
 copy_5_loop:
-	MOVUPS (R14), X0
-	MOVUPS X0, (R9)
-	ADDQ   $0x10, R14
-	ADDQ   $0x10, R9
-	SUBQ   $0x10, R15
-	JAE    copy_5_loop
-	LEAQ   16(R14)(R15*1), R14
-	LEAQ   16(R9)(R15*1), R9
-	MOVUPS -16(R14), X0
-	MOVUPS X0, -16(R9)
+	MOVUPS (R14)(R15*1), X0
+	MOVUPS X0, (R9)(R15*1)
+	ADDQ   $0x10, R15
+	CMPQ   R15, CX
+	JB     copy_5_loop
+	JE     copy_5_end
+	MOVUPS -16(R14)(CX*1), X0
+	MOVUPS X0, -16(R9)(CX*1)
 	JMP    copy_5_end
 
 copy_5_small:
@@ -3912,8 +3794,6 @@ copy_5_move_1or2:
 	MOVB -1(R14)(CX*1), BP
 	MOVB R15, (R9)
 	MOVB BP, -1(R9)(CX*1)
-	ADDQ CX, R14
-	ADDQ CX, R9
 	JMP  copy_5_end
 
 copy_5_move_3:
@@ -3921,8 +3801,6 @@ copy_5_move_3:
 	MOVB 2(R14), BP
 	MOVW R15, (R9)
 	MOVB BP, 2(R9)
-	ADDQ CX, R14
-	ADDQ CX, R9
 	JMP  copy_5_end
 
 copy_5_move_4through7:
@@ -3930,8 +3808,6 @@ copy_5_move_4through7:
 	MOVL -4(R14)(CX*1), BP
 	MOVL R15, (R9)
 	MOVL BP, -4(R9)(CX*1)
-	ADDQ CX, R14
-	ADDQ CX, R9
 	JMP  copy_5_end
 
 copy_5_move_8through16:
@@ -3939,10 +3815,10 @@ copy_5_move_8through16:
 	MOVQ -8(R14)(CX*1), BP
 	MOVQ R15, (R9)
 	MOVQ BP, -8(R9)(CX*1)
-	ADDQ CX, R14
-	ADDQ CX, R9
 
 copy_5_end:
+	ADDQ CX, R14
+	ADDQ CX, R9
 	ADDQ CX, R11
 	SUBQ CX, R13
 
@@ -3957,21 +3833,19 @@ copy_match:
 
 	// Copy non-overlapping match
 	ADDQ R13, R11
-	MOVQ R13, R12
-	SUBQ $0x10, R12
+	CMPQ R13, $0x10
 	JB   copy_2_small
+	XORQ R12, R12
 
 copy_2_loop:
-	MOVUPS (CX), X0
-	MOVUPS X0, (R9)
-	ADDQ   $0x10, CX
-	ADDQ   $0x10, R9
-	SUBQ   $0x10, R12
-	JAE    copy_2_loop
-	LEAQ   16(CX)(R12*1), CX
-	LEAQ   16(R9)(R12*1), R9
-	MOVUPS -16(CX), X0
-	MOVUPS X0, -16(R9)
+	MOVUPS (CX)(R12*1), X0
+	MOVUPS X0, (R9)(R12*1)
+	ADDQ   $0x10, R12
+	CMPQ   R12, R13
+	JB     copy_2_loop
+	JE     copy_2_end
+	MOVUPS -16(CX)(R13*1), X0
+	MOVUPS X0, -16(R9)(R13*1)
 	JMP    copy_2_end
 
 copy_2_small:
@@ -3987,8 +3861,6 @@ copy_2_move_1or2:
 	MOVB -1(CX)(R13*1), R14
 	MOVB R12, (R9)
 	MOVB R14, -1(R9)(R13*1)
-	ADDQ R13, CX
-	ADDQ R13, R9
 	JMP  copy_2_end
 
 copy_2_move_3:
@@ -3996,8 +3868,6 @@ copy_2_move_3:
 	MOVB 2(CX), R14
 	MOVW R12, (R9)
 	MOVB R14, 2(R9)
-	ADDQ R13, CX
-	ADDQ R13, R9
 	JMP  copy_2_end
 
 copy_2_move_4through7:
@@ -4005,8 +3875,6 @@ copy_2_move_4through7:
 	MOVL -4(CX)(R13*1), R14
 	MOVL R12, (R9)
 	MOVL R14, -4(R9)(R13*1)
-	ADDQ R13, CX
-	ADDQ R13, R9
 	JMP  copy_2_end
 
 copy_2_move_8through16:
@@ -4014,11 +3882,11 @@ copy_2_move_8through16:
 	MOVQ -8(CX)(R13*1), R14
 	MOVQ R12, (R9)
 	MOVQ R14, -8(R9)(R13*1)
-	ADDQ R13, CX
-	ADDQ R13, R9
 
 copy_2_end:
-	JMP handle_loop
+	ADDQ R13, CX
+	ADDQ R13, R9
+	JMP  handle_loop
 
 	// Copy overlapping match
 copy_overlapping_match:


### PR DESCRIPTION
The 16-byte block copy loop is one instruction shorter and all the pointer updating is done at the end to decrease the code size.

This gives a small speedup on some benchmarks, with smaller regressions on some of the others:

```
name                                                   old speed      new speed      delta
Decoder_DecoderSmall/kppkn.gtb.zst/buffered-16          714MB/s ± 1%   719MB/s ± 3%    ~     (p=1.000 n=9+10)
Decoder_DecoderSmall/kppkn.gtb.zst/unbuffered-16       1.16GB/s ± 8%  1.19GB/s ± 4%    ~     (p=0.247 n=10+10)
Decoder_DecoderSmall/geo.protodata.zst/buffered-16     2.25GB/s ± 3%  2.33GB/s ± 4%  +3.30%  (p=0.007 n=9+10)
Decoder_DecoderSmall/geo.protodata.zst/unbuffered-16   2.39GB/s ± 0%  2.51GB/s ± 2%  +5.28%  (p=0.000 n=10+10)
Decoder_DecoderSmall/plrabn12.txt.zst/buffered-16       512MB/s ± 2%   519MB/s ± 3%  +1.45%  (p=0.019 n=10+10)
Decoder_DecoderSmall/plrabn12.txt.zst/unbuffered-16    1.18GB/s ± 5%  1.16GB/s ± 6%    ~     (p=0.393 n=10+10)
Decoder_DecoderSmall/lcet10.txt.zst/buffered-16         612MB/s ± 2%   614MB/s ± 3%    ~     (p=0.796 n=10+10)
Decoder_DecoderSmall/lcet10.txt.zst/unbuffered-16      1.21GB/s ± 8%  1.22GB/s ± 4%    ~     (p=0.912 n=10+10)
Decoder_DecoderSmall/asyoulik.txt.zst/buffered-16       553MB/s ± 2%   553MB/s ± 3%    ~     (p=0.631 n=10+10)
Decoder_DecoderSmall/asyoulik.txt.zst/unbuffered-16    1.16GB/s ± 5%  1.19GB/s ± 4%  +3.12%  (p=0.035 n=10+10)
Decoder_DecoderSmall/alice29.txt.zst/buffered-16        553MB/s ± 2%   555MB/s ± 1%    ~     (p=0.182 n=10+9)
Decoder_DecoderSmall/alice29.txt.zst/unbuffered-16      941MB/s ± 2%   927MB/s ± 4%    ~     (p=0.143 n=10+10)
Decoder_DecoderSmall/html_x_4.zst/buffered-16          4.06GB/s ± 2%  4.10GB/s ± 3%    ~     (p=0.105 n=10+10)
Decoder_DecoderSmall/html_x_4.zst/unbuffered-16        4.71GB/s ± 1%  4.72GB/s ± 2%    ~     (p=0.247 n=10+10)
Decoder_DecoderSmall/paper-100k.pdf.zst/buffered-16    5.96GB/s ± 4%  5.77GB/s ± 4%  -3.21%  (p=0.006 n=10+9)
Decoder_DecoderSmall/paper-100k.pdf.zst/unbuffered-16  5.70GB/s ± 1%  5.80GB/s ± 1%  +1.69%  (p=0.000 n=10+10)
Decoder_DecoderSmall/fireworks.jpeg.zst/buffered-16    11.4GB/s ± 3%  11.6GB/s ± 2%    ~     (p=0.123 n=10+10)
Decoder_DecoderSmall/fireworks.jpeg.zst/unbuffered-16  9.76GB/s ± 1%  9.81GB/s ± 2%    ~     (p=0.400 n=9+10)
Decoder_DecoderSmall/urls.10K.zst/buffered-16           829MB/s ± 2%   815MB/s ± 2%  -1.68%  (p=0.007 n=10+10)
Decoder_DecoderSmall/urls.10K.zst/unbuffered-16        1.48GB/s ± 1%  1.45GB/s ± 3%  -1.88%  (p=0.007 n=10+10)
Decoder_DecoderSmall/html.zst/buffered-16              1.72GB/s ± 1%  1.77GB/s ± 2%  +3.09%  (p=0.000 n=9+10)
Decoder_DecoderSmall/html.zst/unbuffered-16            2.10GB/s ± 2%  2.16GB/s ± 1%  +2.67%  (p=0.000 n=9+10)
Decoder_DecoderSmall/comp-data.bin.zst/buffered-16      684MB/s ± 2%   683MB/s ± 2%    ~     (p=0.905 n=9+10)
Decoder_DecoderSmall/comp-data.bin.zst/unbuffered-16    617MB/s ± 1%   614MB/s ± 1%    ~     (p=0.123 n=10+10)
```