### PR TITLE
zstd: Replace bytes.Equal with smaller comparisons

### DIFF
--- a/zstd/decodeheader.go
+++ b/zstd/decodeheader.go
@@ -4,7 +4,6 @@
 package zstd
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -102,8 +101,8 @@ func (h *Header) Decode(in []byte) error {
 	}
 	h.HeaderSize += 4
 	b, in := in[:4], in[4:]
-	if !bytes.Equal(b, frameMagic) {
-		if !bytes.Equal(b[1:4], skippableFrameMagic) || b[0]&0xf0 != 0x50 {
+	if string(b) != frameMagic {
+		if string(b[1:4]) != skippableFrameMagic || b[0]&0xf0 != 0x50 {
 			return ErrMagicMismatch
 		}
 		if len(in) < 4 {

--- a/zstd/dict.go
+++ b/zstd/dict.go
@@ -1,7 +1,6 @@
 package zstd
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -20,7 +19,7 @@ type dict struct {
 	content []byte
 }
 
-var dictMagic = [4]byte{0x37, 0xa4, 0x30, 0xec}
+const dictMagic = "\x37\xa4\x30\xec"
 
 // ID returns the dictionary id or 0 if d is nil.
 func (d *dict) ID() uint32 {
@@ -50,7 +49,7 @@ func loadDict(b []byte) (*dict, error) {
 		ofDec: sequenceDec{fse: &fseDecoder{}},
 		mlDec: sequenceDec{fse: &fseDecoder{}},
 	}
-	if !bytes.Equal(b[:4], dictMagic[:]) {
+	if string(b[:4]) != dictMagic {
 		return nil, ErrMagicMismatch
 	}
 	d.id = binary.LittleEndian.Uint32(b[4:8])

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -5,7 +5,7 @@
 package zstd
 
 import (
-	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -43,9 +43,9 @@ const (
 	MaxWindowSize = 1 << 29
 )
 
-var (
-	frameMagic          = []byte{0x28, 0xb5, 0x2f, 0xfd}
-	skippableFrameMagic = []byte{0x2a, 0x4d, 0x18}
+const (
+	frameMagic          = "\x28\xb5\x2f\xfd"
+	skippableFrameMagic = "\x2a\x4d\x18"
 )
 
 func newFrameDec(o decoderOptions) *frameDec {
@@ -89,9 +89,9 @@ func (d *frameDec) reset(br byteBuffer) error {
 			copy(signature[1:], b)
 		}
 
-		if !bytes.Equal(signature[1:4], skippableFrameMagic) || signature[0]&0xf0 != 0x50 {
+		if string(signature[1:4]) != skippableFrameMagic || signature[0]&0xf0 != 0x50 {
 			if debugDecoder {
-				println("Not skippable", hex.EncodeToString(signature[:]), hex.EncodeToString(skippableFrameMagic))
+				println("Not skippable", hex.EncodeToString(signature[:]), hex.EncodeToString([]byte(skippableFrameMagic)))
 			}
 			// Break if not skippable frame.
 			break
@@ -114,9 +114,9 @@ func (d *frameDec) reset(br byteBuffer) error {
 			return err
 		}
 	}
-	if !bytes.Equal(signature[:], frameMagic) {
+	if string(signature[:]) != frameMagic {
 		if debugDecoder {
-			println("Got magic numbers: ", signature, "want:", frameMagic)
+			println("Got magic numbers: ", signature, "want:", []byte(frameMagic))
 		}
 		return ErrMagicMismatch
 	}
@@ -305,7 +305,7 @@ func (d *frameDec) checkCRC() error {
 	}
 
 	// We can overwrite upper tmp now
-	want, err := d.rawInput.readSmall(4)
+	buf, err := d.rawInput.readSmall(4)
 	if err != nil {
 		println("CRC missing?", err)
 		return err
@@ -315,22 +315,17 @@ func (d *frameDec) checkCRC() error {
 		return nil
 	}
 
-	var tmp [4]byte
-	got := d.crc.Sum64()
-	// Flip to match file order.
-	tmp[0] = byte(got >> 0)
-	tmp[1] = byte(got >> 8)
-	tmp[2] = byte(got >> 16)
-	tmp[3] = byte(got >> 24)
+	want := binary.LittleEndian.Uint32(buf[:4])
+	got := uint32(d.crc.Sum64())
 
-	if !bytes.Equal(tmp[:], want) {
+	if got != want {
 		if debugDecoder {
-			println("CRC Check Failed:", tmp[:], "!=", want)
+			printf("CRC check failed: got %08x, want %08x\n", got, want)
 		}
 		return ErrCRCMismatch
 	}
 	if debugDecoder {
-		println("CRC ok", tmp[:])
+		printf("CRC ok %08x\n", got)
 	}
 	return nil
 }


### PR DESCRIPTION
This replaces some bytes.Equal calls, which compile down to calls to runtime.memequal, with uint32 or string comparisons that become CMPL instructions (or a series of CMPBs, in one case).

The code is several dozen instructions shorter. Benchmarks show no regressions:

```
name                                                  old speed      new speed      delta
Decoder_DecoderSmall/kppkn.gtb.zst/buffered-8          459MB/s ± 0%   458MB/s ± 0%    ~     (p=0.546 n=9+9)
Decoder_DecoderSmall/kppkn.gtb.zst/unbuffered-8        566MB/s ± 3%   568MB/s ± 2%    ~     (p=0.481 n=10+10)
Decoder_DecoderSmall/geo.protodata.zst/buffered-8     1.19GB/s ± 0%  1.19GB/s ± 0%  +0.24%  (p=0.040 n=9+9)
Decoder_DecoderSmall/geo.protodata.zst/unbuffered-8    831MB/s ± 2%   832MB/s ± 2%    ~     (p=0.853 n=10+10)
Decoder_DecoderSmall/plrabn12.txt.zst/buffered-8       349MB/s ± 3%   352MB/s ± 0%    ~     (p=0.075 n=9+10)
Decoder_DecoderSmall/plrabn12.txt.zst/unbuffered-8     529MB/s ± 6%   534MB/s ± 7%    ~     (p=0.796 n=10+10)
Decoder_DecoderSmall/lcet10.txt.zst/buffered-8         421MB/s ± 1%   422MB/s ± 0%  +0.32%  (p=0.029 n=9+8)
Decoder_DecoderSmall/lcet10.txt.zst/unbuffered-8       608MB/s ± 2%   606MB/s ± 9%    ~     (p=0.897 n=8+10)
Decoder_DecoderSmall/asyoulik.txt.zst/buffered-8       367MB/s ± 0%   362MB/s ± 5%    ~     (p=0.388 n=10+9)
Decoder_DecoderSmall/asyoulik.txt.zst/unbuffered-8     454MB/s ± 4%   449MB/s ± 3%    ~     (p=0.353 n=10+10)
Decoder_DecoderSmall/alice29.txt.zst/buffered-8        360MB/s ± 0%   361MB/s ± 0%  +0.18%  (p=0.001 n=10+8)
Decoder_DecoderSmall/alice29.txt.zst/unbuffered-8      572MB/s ± 4%   569MB/s ± 8%    ~     (p=0.842 n=10+9)
Decoder_DecoderSmall/html_x_4.zst/buffered-8          2.46GB/s ± 0%  2.46GB/s ± 1%    ~     (p=0.497 n=9+10)
Decoder_DecoderSmall/html_x_4.zst/unbuffered-8        1.65GB/s ± 5%  1.67GB/s ± 6%    ~     (p=0.481 n=10+10)
Decoder_DecoderSmall/paper-100k.pdf.zst/buffered-8    3.87GB/s ± 1%  3.87GB/s ± 0%    ~     (p=0.353 n=10+10)
Decoder_DecoderSmall/paper-100k.pdf.zst/unbuffered-8  1.85GB/s ± 4%  1.84GB/s ± 7%    ~     (p=0.529 n=10+10)
Decoder_DecoderSmall/fireworks.jpeg.zst/buffered-8    8.62GB/s ± 1%  8.63GB/s ± 1%    ~     (p=0.529 n=10+10)
Decoder_DecoderSmall/fireworks.jpeg.zst/unbuffered-8  3.34GB/s ± 2%  3.34GB/s ± 3%    ~     (p=0.796 n=10+10)
Decoder_DecoderSmall/urls.10K.zst/buffered-8           587MB/s ± 1%   586MB/s ± 1%    ~     (p=0.589 n=10+9)
Decoder_DecoderSmall/urls.10K.zst/unbuffered-8         875MB/s ± 4%   877MB/s ± 2%    ~     (p=0.661 n=9+10)
Decoder_DecoderSmall/html.zst/buffered-8               962MB/s ± 0%   961MB/s ± 0%    ~     (p=0.368 n=10+9)
Decoder_DecoderSmall/html.zst/unbuffered-8             711MB/s ± 3%   709MB/s ± 1%    ~     (p=0.965 n=10+8)
Decoder_DecoderSmall/comp-data.bin.zst/buffered-8      407MB/s ± 1%   407MB/s ± 0%    ~     (p=0.684 n=10+10)
Decoder_DecoderSmall/comp-data.bin.zst/unbuffered-8    152MB/s ± 4%   152MB/s ± 3%    ~     (p=0.971 n=10+10)
```