### PR TITLE
flate: Improve speed in big stateless blocks.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -85,7 +85,7 @@ jobs:
       run: go build github.com/klauspost/compress/s2/cmd/s2c && go build github.com/klauspost/compress/s2/cmd/s2d&&./s2c -verify s2c &&./s2d s2c.s2&&rm ./s2c&&rm s2d&&rm s2c.s2
 
     - name: install garble
-      run: go install mvdan.cc/garble@v0.7.0
+      run: go install mvdan.cc/garble@v0.7.2
 
     - name: goreleaser deprecation
       run: curl -sfL https://git.io/goreleaser | VERSION=v1.9.2 sh -s -- check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.19.x
       -
         name: install garble
-        run: go install mvdan.cc/garble@v0.7.1
+        run: go install mvdan.cc/garble@v0.7.2
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@
 before:
   hooks:
     - ./gen.sh
-    - go install mvdan.cc/garble@latest
+    - go install mvdan.cc/garble@v0.7.2
 
 builds:
   -


### PR DESCRIPTION
Don't re-alloc and copy dict for every block when compressing more than 32KB.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkEncodeDigitsSL1e4-32     52954         52850         -0.20%
BenchmarkEncodeDigitsSL1e5-32     781061        745420        -4.56%
BenchmarkEncodeDigitsSL1e6-32     8143640       7715674       -5.26%
BenchmarkEncodeTwainSL1e4-32      68150         68415         +0.39%
BenchmarkEncodeTwainSL1e5-32      715140        687326        -3.89%
BenchmarkEncodeTwainSL1e6-32      7718175       7339694       -4.90%

benchmark                         old MB/s     new MB/s     speedup
BenchmarkEncodeDigitsSL1e4-32     188.84       189.21       1.00x
BenchmarkEncodeDigitsSL1e5-32     128.03       134.15       1.05x
BenchmarkEncodeDigitsSL1e6-32     122.80       129.61       1.06x
BenchmarkEncodeTwainSL1e4-32      146.74       146.17       1.00x
BenchmarkEncodeTwainSL1e5-32      139.83       145.49       1.04x
BenchmarkEncodeTwainSL1e6-32      129.56       136.25       1.05x

benchmark                         old allocs     new allocs     delta
BenchmarkEncodeDigitsSL1e4-32     0              0              +0.00%
BenchmarkEncodeDigitsSL1e5-32     3              0              -100.00%
BenchmarkEncodeDigitsSL1e6-32     41             0              -100.00%
BenchmarkEncodeTwainSL1e4-32      0              0              +0.00%
BenchmarkEncodeTwainSL1e5-32      3              0              -100.00%
BenchmarkEncodeTwainSL1e6-32      41             0              -100.00%

benchmark                         old bytes     new bytes     delta
BenchmarkEncodeDigitsSL1e4-32     0             0             +0.00%
BenchmarkEncodeDigitsSL1e5-32     92929         9             -99.99%
BenchmarkEncodeDigitsSL1e6-32     1298964       97            -99.99%
BenchmarkEncodeTwainSL1e4-32      0             0             +0.00%
BenchmarkEncodeTwainSL1e5-32      92928         8             -99.99%
BenchmarkEncodeTwainSL1e6-32      1298871       92            -99.99%
```