### PR TITLE
zstd: Clean up adjustOffset asm

### DIFF
--- a/zstd/_generate/gen.go
+++ b/zstd/_generate/gen.go
@@ -744,33 +744,22 @@ func (o options) adjustOffset(name string, moP, llP Mem, offsetB reg.GPVirtual, 
 	}
 
 	Label(name + "_offsetB_1_or_0")
-	// if litLen == 0 {
-	//     offset++
-	// }
 	{
-		if true {
-			CMPQ(llP, U32(0))
-			JNE(LabelRef(name + "_offset_maybezero"))
-			INCQ(offset)
-			JMP(LabelRef(name + "_offset_nonzero"))
-		} else {
-			// No idea why this doesn't work:
-			tmp := GP64()
-			LEAQ(Mem{Base: offset, Disp: 1}, tmp)
-			CMPQ(llP, U32(0))
-			CMOVQEQ(tmp, offset)
-		}
+		// if litLen == 0 {
+		//     offset++
+		// }
+		ll0 := GP32()
+		XORL(ll0, ll0)
+		CMPQ(llP, U32(0))
+		SETEQ(ll0.As8())
+		ADDQ(ll0.As64(), offset)
 
 		// if offset == 0 {
 		//     return s.prevOffset[0]
 		// }
-		{
-			Label(name + "_offset_maybezero")
-			TESTQ(offset, offset)
-			JNZ(LabelRef(name + "_offset_nonzero"))
-			MOVQ(offsets[0], offset)
-			JMP(end)
-		}
+		JNZ(LabelRef(name + "_offset_nonzero"))
+		MOVQ(offsets[0], offset)
+		JMP(end)
 	}
 	Label(name + "_offset_nonzero")
 	{
@@ -860,26 +849,22 @@ func (o options) adjustOffsetInMemory(name string, moP, llP Mem, offsetB reg.GPV
 	}
 
 	Label(name + "_offsetB_1_or_0")
-	// if litLen == 0 {
-	//     offset++
-	// }
-
 	{
+		// if litLen == 0 {
+		//     offset++
+		// }
+		ll0 := GP32()
+		XORL(ll0, ll0)
 		CMPQ(llP, U32(0))
-		JNE(LabelRef(name + "_offset_maybezero"))
-		INCQ(offset)
-		JMP(LabelRef(name + "_offset_nonzero"))
+		SETEQ(ll0.As8())
+		ADDQ(ll0.As64(), offset)
 
 		// if offset == 0 {
 		//     return s.prevOffset[0]
 		// }
-		{
-			Label(name + "_offset_maybezero")
-			TESTQ(offset, offset)
-			JNZ(LabelRef(name + "_offset_nonzero"))
-			MOVQ(po0.Addr, offset)
-			JMP(end)
-		}
+		JNZ(LabelRef(name + "_offset_nonzero"))
+		MOVQ(po0.Addr, offset)
+		JMP(end)
 	}
 	Label(name + "_offset_nonzero")
 	{

--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -218,13 +218,10 @@ sequenceDecs_decode_amd64_skip_update:
 	JMP  sequenceDecs_decode_amd64_after_adjust
 
 sequenceDecs_decode_amd64_adjust_offsetB_1_or_0:
-	CMPQ (R10), $0x00000000
-	JNE  sequenceDecs_decode_amd64_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_amd64_adjust_offset_nonzero
-
-sequenceDecs_decode_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
+	XORL  AX, AX
+	CMPQ  (R10), $0x00000000
+	SETEQ AL
+	ADDQ  AX, CX
 	JNZ   sequenceDecs_decode_amd64_adjust_offset_nonzero
 	MOVQ  R11, CX
 	JMP   sequenceDecs_decode_amd64_after_adjust
@@ -511,13 +508,10 @@ sequenceDecs_decode_56_amd64_skip_update:
 	JMP  sequenceDecs_decode_56_amd64_after_adjust
 
 sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0:
-	CMPQ (R10), $0x00000000
-	JNE  sequenceDecs_decode_56_amd64_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_amd64_adjust_offset_nonzero
-
-sequenceDecs_decode_56_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
+	XORL  AX, AX
+	CMPQ  (R10), $0x00000000
+	SETEQ AL
+	ADDQ  AX, CX
 	JNZ   sequenceDecs_decode_56_amd64_adjust_offset_nonzero
 	MOVQ  R11, CX
 	JMP   sequenceDecs_decode_56_amd64_after_adjust
@@ -787,13 +781,10 @@ sequenceDecs_decode_bmi2_skip_update:
 	JMP  sequenceDecs_decode_bmi2_after_adjust
 
 sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_bmi2_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decode_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
+	XORL  R13, R13
+	CMPQ  (R9), $0x00000000
+	SETEQ R13
+	ADDQ  R13, CX
 	JNZ   sequenceDecs_decode_bmi2_adjust_offset_nonzero
 	MOVQ  R10, CX
 	JMP   sequenceDecs_decode_bmi2_after_adjust
@@ -1038,13 +1029,10 @@ sequenceDecs_decode_56_bmi2_skip_update:
 	JMP  sequenceDecs_decode_56_bmi2_after_adjust
 
 sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_56_bmi2_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decode_56_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
+	XORL  R13, R13
+	CMPQ  (R9), $0x00000000
+	SETEQ R13
+	ADDQ  R13, CX
 	JNZ   sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
 	MOVQ  R10, CX
 	JMP   sequenceDecs_decode_56_bmi2_after_adjust
@@ -1985,13 +1973,10 @@ sequenceDecs_decodeSync_amd64_skip_update:
 	JMP    sequenceDecs_decodeSync_amd64_after_adjust
 
 sequenceDecs_decodeSync_amd64_adjust_offsetB_1_or_0:
-	CMPQ 24(SP), $0x00000000
-	JNE  sequenceDecs_decodeSync_amd64_adjust_offset_maybezero
-	INCQ R13
-	JMP  sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
-
-sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
-	TESTQ R13, R13
+	XORL  AX, AX
+	CMPQ  24(SP), $0x00000000
+	SETEQ AL
+	ADDQ  AX, R13
 	JNZ   sequenceDecs_decodeSync_amd64_adjust_offset_nonzero
 	MOVQ  144(CX), R13
 	JMP   sequenceDecs_decodeSync_amd64_after_adjust
@@ -2495,13 +2480,10 @@ sequenceDecs_decodeSync_bmi2_skip_update:
 	JMP    sequenceDecs_decodeSync_bmi2_after_adjust
 
 sequenceDecs_decodeSync_bmi2_adjust_offsetB_1_or_0:
-	CMPQ 24(SP), $0x00000000
-	JNE  sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero
-	INCQ R13
-	JMP  sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero:
-	TESTQ R13, R13
+	XORL  R12, R12
+	CMPQ  24(SP), $0x00000000
+	SETEQ R12
+	ADDQ  R12, R13
 	JNZ   sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero
 	MOVQ  144(CX), R13
 	JMP   sequenceDecs_decodeSync_bmi2_after_adjust
@@ -3047,13 +3029,10 @@ sequenceDecs_decodeSync_safe_amd64_skip_update:
 	JMP    sequenceDecs_decodeSync_safe_amd64_after_adjust
 
 sequenceDecs_decodeSync_safe_amd64_adjust_offsetB_1_or_0:
-	CMPQ 24(SP), $0x00000000
-	JNE  sequenceDecs_decodeSync_safe_amd64_adjust_offset_maybezero
-	INCQ R13
-	JMP  sequenceDecs_decodeSync_safe_amd64_adjust_offset_nonzero
-
-sequenceDecs_decodeSync_safe_amd64_adjust_offset_maybezero:
-	TESTQ R13, R13
+	XORL  AX, AX
+	CMPQ  24(SP), $0x00000000
+	SETEQ AL
+	ADDQ  AX, R13
 	JNZ   sequenceDecs_decodeSync_safe_amd64_adjust_offset_nonzero
 	MOVQ  144(CX), R13
 	JMP   sequenceDecs_decodeSync_safe_amd64_after_adjust
@@ -3659,13 +3638,10 @@ sequenceDecs_decodeSync_safe_bmi2_skip_update:
 	JMP    sequenceDecs_decodeSync_safe_bmi2_after_adjust
 
 sequenceDecs_decodeSync_safe_bmi2_adjust_offsetB_1_or_0:
-	CMPQ 24(SP), $0x00000000
-	JNE  sequenceDecs_decodeSync_safe_bmi2_adjust_offset_maybezero
-	INCQ R13
-	JMP  sequenceDecs_decodeSync_safe_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decodeSync_safe_bmi2_adjust_offset_maybezero:
-	TESTQ R13, R13
+	XORL  R12, R12
+	CMPQ  24(SP), $0x00000000
+	SETEQ R12
+	ADDQ  R12, R13
 	JNZ   sequenceDecs_decodeSync_safe_bmi2_adjust_offset_nonzero
 	MOVQ  144(CX), R13
 	JMP   sequenceDecs_decodeSync_safe_bmi2_after_adjust


### PR DESCRIPTION
I was really hoping for a speedup from removing a conditional branch, but I didn't get one:

```
name                                                        old speed      new speed      delta
Decoder_DecodeAll/kppkn.gtb.zst-8                            471MB/s ± 0%   475MB/s ± 0%  +0.77%  (p=0.000 n=10+10)
Decoder_DecodeAll/geo.protodata.zst-8                       1.23GB/s ± 1%  1.24GB/s ± 0%  +0.79%  (p=0.001 n=9+10)
Decoder_DecodeAll/plrabn12.txt.zst-8                         372MB/s ± 1%   373MB/s ± 0%    ~     (p=0.393 n=10+10)
Decoder_DecodeAll/lcet10.txt.zst-8                           447MB/s ± 1%   448MB/s ± 0%    ~     (p=0.633 n=10+8)
Decoder_DecodeAll/asyoulik.txt.zst-8                         371MB/s ± 1%   371MB/s ± 0%    ~     (p=0.684 n=10+10)
Decoder_DecodeAll/alice29.txt.zst-8                          371MB/s ± 1%   371MB/s ± 0%    ~     (p=0.604 n=10+9)
Decoder_DecodeAll/html_x_4.zst-8                            1.56GB/s ± 1%  1.56GB/s ± 0%    ~     (p=0.019 n=9+9)
Decoder_DecodeAll/paper-100k.pdf.zst-8                      4.40GB/s ± 1%  4.43GB/s ± 1%    ~     (p=0.022 n=10+9)
Decoder_DecodeAll/fireworks.jpeg.zst-8                      9.18GB/s ± 1%  9.20GB/s ± 2%    ~     (p=0.529 n=10+10)
Decoder_DecodeAll/urls.10K.zst-8                             629MB/s ± 1%   632MB/s ± 0%  +0.54%  (p=0.001 n=10+10)
Decoder_DecodeAll/html.zst-8                                 986MB/s ± 1%   989MB/s ± 1%    ~     (p=0.050 n=10+10)
Decoder_DecodeAll/comp-data.bin.zst-8                        382MB/s ± 1%   385MB/s ± 1%    ~     (p=0.011 n=10+10)
Decoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/fastest-8   369MB/s ± 1%   368MB/s ± 0%  -0.40%  (p=0.004 n=10+9)
Decoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/default-8   380MB/s ± 0%   378MB/s ± 0%  -0.60%  (p=0.000 n=10+10)
Decoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/better-8    408MB/s ± 0%   405MB/s ± 0%  -0.72%  (p=0.000 n=8+10)
Decoder_DecodeAllFiles/Mark.Twain-Tom.Sawyer.txt/best-8      404MB/s ± 0%   401MB/s ± 0%  -0.70%  (p=0.000 n=10+9)
Decoder_DecodeAllFiles/e.txt/fastest-8                      9.32GB/s ± 1%  9.34GB/s ± 1%    ~     (p=0.673 n=8+9)
Decoder_DecodeAllFiles/e.txt/default-8                       352MB/s ± 0%   350MB/s ± 0%  -0.62%  (p=0.000 n=10+9)
Decoder_DecodeAllFiles/e.txt/better-8                        411MB/s ± 0%   410MB/s ± 1%    ~     (p=0.897 n=8+10)
Decoder_DecodeAllFiles/e.txt/best-8                          501MB/s ± 1%   502MB/s ± 0%    ~     (p=0.436 n=9+9)
Decoder_DecodeAllFiles/fse-artifact3.bin/fastest-8           993MB/s ± 2%   991MB/s ± 1%    ~     (p=0.447 n=9+10)
Decoder_DecodeAllFiles/fse-artifact3.bin/default-8          1.12GB/s ± 1%  1.12GB/s ± 1%    ~     (p=0.661 n=10+9)
Decoder_DecodeAllFiles/fse-artifact3.bin/better-8           1.00GB/s ± 0%  1.00GB/s ± 0%    ~     (p=0.780 n=10+9)
Decoder_DecodeAllFiles/fse-artifact3.bin/best-8              383MB/s ± 0%   375MB/s ± 0%  -2.05%  (p=0.000 n=8+8)
Decoder_DecodeAllFiles/gettysburg.txt/fastest-8              256MB/s ± 1%   256MB/s ± 1%    ~     (p=0.529 n=10+10)
Decoder_DecodeAllFiles/gettysburg.txt/default-8              214MB/s ± 1%   214MB/s ± 0%    ~     (p=0.968 n=10+9)
Decoder_DecodeAllFiles/gettysburg.txt/better-8               222MB/s ± 1%   221MB/s ± 1%    ~     (p=0.143 n=10+10)
Decoder_DecodeAllFiles/gettysburg.txt/best-8                 216MB/s ± 0%   217MB/s ± 0%  +0.34%  (p=0.003 n=9+10)
Decoder_DecodeAllFiles/html.txt/fastest-8                    541MB/s ± 1%   542MB/s ± 1%    ~     (p=0.211 n=10+9)
Decoder_DecodeAllFiles/html.txt/default-8                    536MB/s ± 0%   538MB/s ± 0%    ~     (p=0.023 n=10+10)
Decoder_DecodeAllFiles/html.txt/better-8                     570MB/s ± 0%   569MB/s ± 0%    ~     (p=0.436 n=10+10)
Decoder_DecodeAllFiles/html.txt/best-8                       538MB/s ± 0%   536MB/s ± 0%    ~     (p=0.012 n=10+10)
Decoder_DecodeAllFiles/pi.txt/fastest-8                     9.28GB/s ± 3%  9.29GB/s ± 2%    ~     (p=0.853 n=10+10)
Decoder_DecodeAllFiles/pi.txt/default-8                      350MB/s ± 0%   350MB/s ± 0%    ~     (p=0.754 n=10+10)
Decoder_DecodeAllFiles/pi.txt/better-8                       415MB/s ± 0%   415MB/s ± 0%    ~     (p=0.483 n=9+10)
Decoder_DecodeAllFiles/pi.txt/best-8                         504MB/s ± 0%   502MB/s ± 0%  -0.31%  (p=0.000 n=10+10)
Decoder_DecodeAllFiles/pngdata.bin/fastest-8                1.65GB/s ± 0%  1.65GB/s ± 1%    ~     (p=0.203 n=9+10)
Decoder_DecodeAllFiles/pngdata.bin/default-8                1.49GB/s ± 1%  1.49GB/s ± 1%    ~     (p=0.436 n=10+10)
Decoder_DecodeAllFiles/pngdata.bin/better-8                 1.89GB/s ± 0%  1.90GB/s ± 1%  +0.66%  (p=0.000 n=9+10)
Decoder_DecodeAllFiles/pngdata.bin/best-8                   1.51GB/s ± 0%  1.49GB/s ± 0%  -1.27%  (p=0.000 n=10+9)
Decoder_DecodeAllFiles/sharnd.out/fastest-8                 9.29GB/s ± 1%  9.29GB/s ± 2%    ~     (p=0.912 n=10+10)
Decoder_DecodeAllFiles/sharnd.out/default-8                 9.36GB/s ± 2%  9.36GB/s ± 1%    ~     (p=0.968 n=9+10)
Decoder_DecodeAllFiles/sharnd.out/better-8                  9.57GB/s ± 1%  9.56GB/s ± 1%    ~     (p=0.549 n=9+10)
Decoder_DecodeAllFiles/sharnd.out/best-8                    9.73GB/s ± 1%  9.62GB/s ± 1%    ~     (p=0.011 n=10+10)
[Geo mean]                                                   904MB/s        904MB/s       -0.03%
```