### PR TITLE
zstd: Don't allocate dataStorage when using byteBuf

### DIFF
--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -192,15 +192,13 @@ func (b *blockDec) reset(br byteBuffer, windowSize uint64) error {
 	}
 
 	// Read block data.
-	if cap(b.dataStorage) < cSize {
+	if _, ok := br.(*byteBuf); !ok && cap(b.dataStorage) < cSize {
+		// byteBuf doesn't need a destination buffer.
 		if b.lowMem || cSize > maxCompressedBlockSize {
 			b.dataStorage = make([]byte, 0, cSize+compressedBlockOverAlloc)
 		} else {
 			b.dataStorage = make([]byte, 0, maxCompressedBlockSizeAlloc)
 		}
-	}
-	if cap(b.dst) <= maxSize {
-		b.dst = make([]byte, 0, maxSize+1)
 	}
 	b.data, err = br.readBig(cSize, b.dataStorage)
 	if err != nil {
@@ -209,6 +207,9 @@ func (b *blockDec) reset(br byteBuffer, windowSize uint64) error {
 			printf("%T", br)
 		}
 		return err
+	}
+	if cap(b.dst) <= maxSize {
+		b.dst = make([]byte, 0, maxSize+1)
 	}
 	return nil
 }


### PR DESCRIPTION
Credit to @greatroar for finding this.

Alternative to #721