### PR TITLE
Retract v1.14.1-v.1.14.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/klauspost/compress
 
 go 1.17
+
+retract (
+	// https://github.com/klauspost/compress/pull/503
+	v1.14.3
+	v1.14.2
+	v1.14.1
+)


### PR DESCRIPTION
Officially retract old versions due to #503

Active Jan 11, 2022 -> Feb 22, 2022