### PR TITLE
s2c/s2sx: Use concurrent decoding

### DIFF
--- a/s2/cmd/_s2sx/_unpack/main.go
+++ b/s2/cmd/_s2sx/_unpack/main.go
@@ -96,7 +96,7 @@ func main() {
 			defer f.Close()
 			out = f
 		}
-		_, err = io.Copy(out, dec)
+		_, err = dec.DecodeConcurrent(out, 0)
 		exitErr(err)
 
 	case opUnTar:


### PR DESCRIPTION
Use concurrent decoding when recompressing and verifying.

s2sx: Use concurrent decoding with single files (non-tar)