### PR TITLE
s2: Add support for custom stream encoder

### DIFF
--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -59,6 +59,7 @@ func testOptions(t testing.TB) map[string][]WriterOption {
 	for name, opt := range testOptions {
 		x[name] = opt
 		x[name+"-snappy"] = cloneAdd(opt, WriterSnappyCompat())
+		x[name+"-custom"] = cloneAdd(opt, WriterCustomEncoder(snapref.EncodeBlockInto))
 	}
 	testOptions = x
 	return testOptions


### PR DESCRIPTION
```Go
// WriterCustomEncoder allows to override the encoder for blocks on the stream.
// The function must compress 'src' into 'dst' and return the bytes used in dst as an integer.
// Block size (initial varint) should not be added by the encoder.
// Returning value 0 indicates the block could not be compressed.
// The function should expect to be called concurrently.
func WriterCustomEncoder(fn func(dst, src []byte) int) WriterOption
```