### PR TITLE
gzhttp: Add BREACH mitigation

### DIFF
--- a/gzhttp/README.md
+++ b/gzhttp/README.md
@@ -215,6 +215,49 @@ has been reached. In this case it will assume that the minimum size has been rea
 
 If nothing has been written to the response writer, nothing will be flushed.
 
+## BREACH mitigation
+
+[BREACH](http://css.csail.mit.edu/6.858/2020/readings/breach.pdf) is a specialized attack where attacker controlled data
+is injected alongside secret data in a response body. This can lead to sidechannel attacks, where observing the compressed response
+size can reveal if there are overlaps between the secret data and the injected data.
+
+For more information see https://breachattack.com/
+
+It can be hard to judge if you are vulnerable to BREACH. 
+In general, if you do not include any user provided content in the response body you are safe,
+but if you do, or you are in doubt, you can apply mitigations.
+
+`gzhttp` can apply [Heal the Breach](https://ieeexplore.ieee.org/document/9754554), or improved content aware padding.
+
+```Go
+// RandomJitter adds 1->n random bytes to output based on checksum of payload.
+// Specify the amount of input to buffer before applying jitter.
+// This should cover the sensitive part of your response.
+// This can be used to obfuscate the exact compressed size.
+// Specifying 0 will use a buffer size of 64KB.
+// If a negative buffer is given, the amount of jitter will not be content dependent.
+// This provides *less* security than applying content based jitter.
+func RandomJitter(n, buffer int) option {
+...	
+```
+
+The jitter is added as a "Comment" field. This field has a 1 byte overhead, so actual extra size will be 2 -> n+1 (inclusive).
+
+A good option would be to apply 32 random bytes, with default 64KB buffer: `gzhttp.RandomJitter(32, 0)`.
+
+Note that flushing the data forces the padding to be applied, which means that only data before the flush is considered for content aware padding.
+
+### Examples
+
+Adding the option `gzhttp.RandomJitter(32, 50000)` will apply from 1 up to 32 bytes of random data to the output.
+
+The number of bytes added depends on the content of the first 50000 bytes, or all of them if the output was less than that.
+
+Adding the option `gzhttp.RandomJitter(32, -1)` will apply from 1 up to 32 bytes of random data to the output.
+Each call will apply a random amount of jitter. This should be considered less secure than content based jitter.
+
+This can be used if responses are very big, deterministic and the buffer size would be too big to cover where the mutation occurs.  
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/gzhttp/writer/gzkp/gzkp.go
+++ b/gzhttp/writer/gzkp/gzkp.go
@@ -61,6 +61,25 @@ func NewWriter(w io.Writer, level int) writer.GzipWriter {
 	}
 }
 
+// SetHeader will override header with any non-nil values.
+func (pw *pooledWriter) SetHeader(h writer.Header) {
+	if h.Name != nil {
+		pw.Name = *h.Name
+	}
+	if h.Extra != nil {
+		pw.Extra = *h.Extra
+	}
+	if h.Comment != nil {
+		pw.Comment = *h.Comment
+	}
+	if h.ModTime != nil {
+		pw.ModTime = *h.ModTime
+	}
+	if h.OS != nil {
+		pw.OS = *h.OS
+	}
+}
+
 func Levels() (min, max int) {
 	return gzip.StatelessCompression, gzip.BestCompression
 }

--- a/gzhttp/writer/gzstd/stdlib.go
+++ b/gzhttp/writer/gzstd/stdlib.go
@@ -61,6 +61,25 @@ func NewWriter(w io.Writer, level int) writer.GzipWriter {
 	}
 }
 
+// SetHeader will override header with any non-nil values.
+func (pw *pooledWriter) SetHeader(h writer.Header) {
+	if h.Name != nil {
+		pw.Name = *h.Name
+	}
+	if h.Extra != nil {
+		pw.Extra = *h.Extra
+	}
+	if h.Comment != nil {
+		pw.Comment = *h.Comment
+	}
+	if h.ModTime != nil {
+		pw.ModTime = *h.ModTime
+	}
+	if h.OS != nil {
+		pw.OS = *h.OS
+	}
+}
+
 func Levels() (min, max int) {
 	return gzip.HuffmanOnly, gzip.BestCompression
 }

--- a/gzhttp/writer/interface.go
+++ b/gzhttp/writer/interface.go
@@ -1,12 +1,33 @@
 package writer
 
-import "io"
+import (
+	"io"
+	"time"
+)
 
 // GzipWriter implements the functions needed for compressing content.
 type GzipWriter interface {
 	Write(p []byte) (int, error)
 	Close() error
 	Flush() error
+}
+
+// GzipWriterExt implements the functions needed for compressing content
+// and optional extensions.
+type GzipWriterExt interface {
+	GzipWriter
+
+	// SetHeader will populate header fields with non-nil values in h.
+	SetHeader(h Header)
+}
+
+// Header provides nillable header fields.
+type Header struct {
+	Comment *string    // comment
+	Extra   *[]byte    // "extra data"
+	ModTime *time.Time // modification time
+	Name    *string    // file name
+	OS      *byte      // operating system type
 }
 
 // GzipWriterFactory contains the information needed for custom gzip implementations.


### PR DESCRIPTION
See #761

## BREACH mitigation

[BREACH](http://css.csail.mit.edu/6.858/2020/readings/breach.pdf) is a specialized attack where attacker controlled data is injected alongside secret data in a response body. This can lead to sidechannel attacks, where observing the compressed response size can reveal if there are overlaps between the secret data and the injected data.

For more information see https://breachattack.com/

It can be hard to judge if you are vulnerable to BREACH. In general, if you do not include any user provided content in the response body you are safe, but if you do, or you are in doubt, you can apply mitigations.

`gzhttp` can apply [Heal the Breach](https://ieeexplore.ieee.org/document/9754554), or improved content aware padding.

```Go
// RandomJitter adds 1->n random bytes to output based on checksum of payload.
// Specify the amount of input to buffer before applying jitter.
// This should cover the sensitive part of your response.
// This can be used to obfuscate the exact compressed size.
// Specifying 0 will use a buffer size of 64KB.
// If a negative buffer is given, the amount of jitter will not be content dependent.
// This provides *less* security than applying content based jitter.
func RandomJitter(n, buffer int) option {
...
```

The jitter is added as a "Comment" field. This field has a 1 byte overhead, so actual extra size will be 2 -> n+1 (inclusive).

A good option would be to apply 32 random bytes, with default 64KB buffer: `gzhttp.RandomJitter(32, 0)`.

Note that flushing the data forces the padding to be applied, which means that only data before the flush is considered for content aware padding.

### Examples

Adding the option `gzhttp.RandomJitter(32, 50000)` will apply from 1 up to 32 bytes of random data to the output.

The number of bytes added depends on the content of the first 50000 bytes, or all of them if the output was less than that.

Adding the option `gzhttp.RandomJitter(32, -1)` will apply from 1 up to 32 bytes of random data to the output. Each call will apply a random amount of jitter. This should be considered less secure than content based jitter.

This can b