### PR TITLE
gzhttp: Remove a few unneeded allocs

### DIFF
--- a/gzhttp/writer/gzkp/gzkp.go
+++ b/gzhttp/writer/gzkp/gzkp.go
@@ -64,13 +64,13 @@ func NewWriter(w io.Writer, level int) writer.GzipWriter {
 // SetHeader will override header with any non-nil values.
 func (pw *pooledWriter) SetHeader(h writer.Header) {
 	if h.Name != nil {
-		pw.Name = *h.Name
+		pw.Name = string(h.Name)
 	}
 	if h.Extra != nil {
 		pw.Extra = *h.Extra
 	}
 	if h.Comment != nil {
-		pw.Comment = *h.Comment
+		pw.Comment = string(h.Comment)
 	}
 	if h.ModTime != nil {
 		pw.ModTime = *h.ModTime

--- a/gzhttp/writer/gzstd/stdlib.go
+++ b/gzhttp/writer/gzstd/stdlib.go
@@ -64,13 +64,13 @@ func NewWriter(w io.Writer, level int) writer.GzipWriter {
 // SetHeader will override header with any non-nil values.
 func (pw *pooledWriter) SetHeader(h writer.Header) {
 	if h.Name != nil {
-		pw.Name = *h.Name
+		pw.Name = string(h.Name)
 	}
 	if h.Extra != nil {
 		pw.Extra = *h.Extra
 	}
 	if h.Comment != nil {
-		pw.Comment = *h.Comment
+		pw.Comment = string(h.Comment)
 	}
 	if h.ModTime != nil {
 		pw.ModTime = *h.ModTime

--- a/gzhttp/writer/interface.go
+++ b/gzhttp/writer/interface.go
@@ -23,10 +23,10 @@ type GzipWriterExt interface {
 
 // Header provides nillable header fields.
 type Header struct {
-	Comment *string    // comment
+	Comment []byte     // comment, converted to string if set.
 	Extra   *[]byte    // "extra data"
 	ModTime *time.Time // modification time
-	Name    *string    // file name
+	Name    []byte     // file name, converted to string if set.
 	OS      *byte      // operating system type
 }
 


### PR DESCRIPTION
```
Before:
Benchmark2kJitter-32    	   55479	     21371 ns/op	  95.83 MB/s	    3575 B/op	      20 allocs/op

After:
Benchmark2kJitter-32    	   54948	     21599 ns/op	  94.82 MB/s	    3451 B/op	      16 allocs/op
```

Don't put too much into the speed. GC is not included. Most of the allocs are in `httptest.ResponseRecorder`.