### PR TITLE
gzhttp: Use SHA256 as paranoid option

### DIFF
--- a/gzhttp/compress_test.go
+++ b/gzhttp/compress_test.go
@@ -989,7 +989,7 @@ func TestRandomJitter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wrapper, err := NewWrapper(RandomJitter(256, 1024), MinSize(10))
+	wrapper, err := NewWrapper(RandomJitter(256, 1024, false), MinSize(10))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1162,7 +1162,223 @@ func TestRandomJitter(t *testing.T) {
 	}
 
 	// Test non-content aware jitter
-	wrapper, err = NewWrapper(RandomJitter(256, -1), MinSize(10))
+	wrapper, err = NewWrapper(RandomJitter(256, -1, false), MinSize(10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler = wrapper(writePayload)
+	changed = false
+	for i := 0; i < 10; i++ {
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		result = w.Result()
+		b2, err := io.ReadAll(result.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i > 0 {
+			changed = changed || len(b2) != len(b)
+		}
+		t.Logf("attempt %d length: %d. padding: %d.", i, len(b2), len(b2)-len(refBody))
+		if len(b2) <= len(refBody) {
+			t.Errorf("no padding applied,")
+		}
+
+		// Do not mutate...
+		// Update last payload.
+		b = b2
+	}
+	if !changed {
+		t.Errorf("no change after 9 attempts")
+	}
+}
+
+func TestRandomJitterParanoid(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+
+	// 4KB input, incompressible to avoid compression variations.
+	rng := rand.New(rand.NewSource(0))
+	payload := make([]byte, 4096)
+	_, err := io.ReadFull(rng, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrapper, err := NewWrapper(RandomJitter(256, 1024, true), MinSize(10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePayload := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload)
+	})
+	referenceHandler := GzipHandler(writePayload)
+	w := httptest.NewRecorder()
+	referenceHandler.ServeHTTP(w, r)
+	result := w.Result()
+	refBody, err := io.ReadAll(result.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Unmodified length: %d", len(refBody))
+
+	handler := wrapper(writePayload)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	result = w.Result()
+	b, err := io.ReadAll(result.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(refBody) == len(b) {
+		t.Fatal("padding was not applied")
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := false
+	for i := 0; i < 10; i++ {
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		result = w.Result()
+		b2, err := io.ReadAll(result.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		changed = changed || len(b2) != len(b)
+		t.Logf("attempt %d length: %d. padding: %d.", i, len(b2), len(b2)-len(refBody))
+		if len(b2) <= len(refBody) {
+			t.Errorf("no padding applied,")
+		}
+		if i == 0 && changed {
+			t.Error("length changed without payload change", len(b), "->", len(b2))
+		}
+		// Mutate...
+		payload[0]++
+		b = b2
+	}
+	if !changed {
+		t.Errorf("no change after 9 attempts")
+	}
+
+	// Write one byte at the time to test buffer flushing.
+	handler = wrapper(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for i := range payload {
+			w.Write([]byte{payload[i]})
+		}
+	}))
+
+	for i := 0; i < 10; i++ {
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		result = w.Result()
+		b2, err := io.ReadAll(result.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("attempt %d length: %d. padding: %d.", i, len(b2), len(b2)-len(refBody))
+		if len(b2) <= len(refBody) {
+			t.Errorf("no padding applied,")
+		}
+		if i > 0 && len(b2) != len(b) {
+			t.Error("length changed without payload change", len(b), "->", len(b2))
+		}
+		// Mutate, buf after the buffer...
+		payload[2048]++
+		b = b2
+	}
+
+	// Write less than buffer
+	handler = wrapper(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload[:512])
+	}))
+	changed = false
+	for i := 0; i < 10; i++ {
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		result = w.Result()
+		b2, err := io.ReadAll(result.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i > 0 {
+			changed = changed || len(b2) != len(b)
+		}
+		t.Logf("attempt %d length: %d. padding: %d.", i, len(b2), len(b2)-512)
+		if len(b2) <= 512 {
+			t.Errorf("no padding applied,")
+		}
+		// Mutate...
+		payload[500]++
+		b = b2
+	}
+	if !changed {
+		t.Errorf("no change after 9 attempts")
+	}
+
+	// Write less than buffer, with flush in between.
+	// Checksum should be of all before flush.
+	handler = wrapper(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(payload[:256])
+		w.(http.Flusher).Flush()
+		w.Write(payload[256:512])
+	}))
+
+	changed = false
+	for i := 0; i < 10; i++ {
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		result = w.Result()
+		b2, err := io.ReadAll(result.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i > 0 {
+			changed = changed || len(b2) != len(b)
+		}
+		t.Logf("attempt %d length: %d. padding: %d.", i, len(b2), len(b2)-512)
+		if len(b2) <= 512 {
+			t.Errorf("no padding applied,")
+		}
+		// Mutate...
+		payload[200]++
+		b = b2
+	}
+	if !changed {
+		t.Errorf("no change after 9 attempts")
+	}
+
+	// Mutate *after* the flush.
+	// Should no longer affect length.
+	for i := 0; i < 10; i++ {
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		result = w.Result()
+		b2, err := io.ReadAll(result.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i > 0 {
+			changed = len(b2) != len(b)
+			if changed {
+				t.Errorf("mutating after flush seems to have affected output")
+			}
+		}
+		t.Logf("attempt %d length: %d. padding: %d.", i, len(b2), len(b2)-512)
+		if len(b2) <= 512 {
+			t.Errorf("no padding applied,")
+		}
+		// Mutate...
+		payload[400]++
+		b = b2
+	}
+
+	// Test non-content aware jitter
+	wrapper, err = NewWrapper(RandomJitter(256, -1, true), MinSize(10))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1477,10 +1693,15 @@ func BenchmarkGzipBestSpeedHandler_P100k(b *testing.B) {
 }
 
 func Benchmark2kJitter(b *testing.B) {
-	benchmark(b, false, 2048, CompressionLevel(gzip.BestSpeed), RandomJitter(32, 0))
+	benchmark(b, false, 2048, CompressionLevel(gzip.BestSpeed), RandomJitter(32, 0, false))
 }
+
+func Benchmark2kJitterParanoid(b *testing.B) {
+	benchmark(b, false, 2048, CompressionLevel(gzip.BestSpeed), RandomJitter(32, 0, true))
+}
+
 func Benchmark2kJitterRNG(b *testing.B) {
-	benchmark(b, false, 2048, CompressionLevel(gzip.BestSpeed), RandomJitter(32, -1))
+	benchmark(b, false, 2048, CompressionLevel(gzip.BestSpeed), RandomJitter(32, -1, false))
 }
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
### Paranoid?

The padding size is determined by the remainder of a CRC32 of the content.

Since the payload contains elements unknown to the attacker, there is no reason to believe they can derive any information from this remainder, or predict it.

However, for those that feel uncomfortable with a CRC32 being used for this can enable "paranoid" mode which will use SHA256 for determining the padding.

The hashing itself is about 2 orders of magnitude slower, but in overall terms will maybe only reduce speed by 10%.

Paranoid mode has no effect if buffer is < 0 (non-content aware padding).

2K payload roundtrip difference:

```
Benchmark2kJitter-32    	   67309	     17580 ns/op	 116.50 MB/s	    3478 B/op	      17 allocs/op
Benchmark2kJitterParanoid-32    	   54398	     21564 ns/op	  94.97 MB/s	    3438 B/op	      16 allocs
```
