### PR TITLE
gzhttp: Fix crypto/rand.Read usage

### DIFF
--- a/gzhttp/compress.go
+++ b/gzhttp/compress.go
@@ -231,9 +231,9 @@ func (w *GzipResponseWriter) startGzip(remain []byte) error {
 			} else {
 				// Get from rand.Reader
 				var tmp [4]byte
-				_, err := rand.Reader.Read(tmp[:])
+				_, err := rand.Read(tmp[:])
 				if err != nil {
-					return err
+					return fmt.Errorf("gzhttp: %w", err)
 				}
 				jitRNG = binary.LittleEndian.Uint32(tmp[:])
 			}


### PR DESCRIPTION
rand.Reader.Read(p) is allowed to return < len(p) bytes and no error, and the Mac implementation sometimes does. I don't know if it will do that for len(p) == 4, but rand.Read is safer in any case.

This is a security fix. I'm sending it in the clear because it only affects an unreleased version of this library.