### PR TITLE
zstd: Report EOF from byteBuf.readBig

### DIFF
--- a/zstd/bytebuf.go
+++ b/zstd/bytebuf.go
@@ -54,7 +54,7 @@ func (b *byteBuf) readBig(n int, dst []byte) ([]byte, error) {
 func (b *byteBuf) readByte() (byte, error) {
 	bb := *b
 	if len(bb) < 1 {
-		return 0, nil
+		return 0, io.ErrUnexpectedEOF
 	}
 	r := bb[0]
 	*b = bb[1:]


### PR DESCRIPTION
This method was inconsistent with its cousin readerWrapper.readBig in that it returned 0, nil when the input is too short.

I'm not sure what the effects of this inconsistency are, if any. I suppose nearly all suppressed errors would have been reported someplace else.