### PR TITLE
s2: Fix huge block overflow

### DIFF
--- a/s2/_generate/gen.go
+++ b/s2/_generate/gen.go
@@ -260,7 +260,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 
 		assert(func(ok LabelRef) {
 			CMPQ(tmp3, lenSrcQ)
-			JL(ok)
+			JB(ok)
 		})
 
 		MOVL(tmp3.As32(), sLimitL)
@@ -272,7 +272,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 		assert(func(ok LabelRef) {
 			// if len(src) > len(src) - len(src)>>5 - outputMargin: ok
 			CMPQ(lenSrcQ, tmp2)
-			JGE(ok)
+			JAE(ok)
 		})
 
 		LEAQ(Mem{Base: dst, Index: tmp2, Scale: 1}, tmp2)
@@ -313,7 +313,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 		// if nextS > sLimit {goto emitRemainder}
 		{
 			CMPL(nextS.As32(), sLimitL)
-			JGE(LabelRef("emit_remainder_" + name))
+			JAE(LabelRef("emit_remainder_" + name))
 		}
 		MOVQ(Mem{Base: src, Index: s, Scale: 1}, cv)
 		assert(func(ok LabelRef) {
@@ -321,7 +321,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			tmp := GP64()
 			MOVQ(lenSrcQ, tmp)
 			CMPQ(tmp, s.As64())
-			JG(ok)
+			JA(ok)
 		})
 		// move nextS to stack.
 		MOVL(nextS.As32(), nextSTempL)
@@ -339,11 +339,11 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			MOVL(table.Idx(hash1, 4), candidate2)
 			assert(func(ok LabelRef) {
 				CMPQ(hash0, U32(tableSize))
-				JL(ok)
+				JB(ok)
 			})
 			assert(func(ok LabelRef) {
 				CMPQ(hash1, U32(tableSize))
-				JL(ok)
+				JB(ok)
 			})
 
 			MOVL(s, table.Idx(hash0, 4))
@@ -362,7 +362,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			hasher.hash(hash2)
 			assert(func(ok LabelRef) {
 				CMPQ(hash2, U32(tableSize))
-				JL(ok)
+				JB(ok)
 			})
 		}
 
@@ -403,7 +403,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 				Label("repeat_extend_back_loop_" + name)
 				// if base <= nextemit {exit}
 				CMPL(base.As32(), nextEmit)
-				JLE(LabelRef("repeat_extend_back_end_" + name))
+				JBE(LabelRef("repeat_extend_back_end_" + name))
 				// if src[i-1] == src[base-1]
 				tmp, tmp2 := GP64(), GP64()
 				MOVB(Mem{Base: src, Index: i, Scale: 1, Disp: -1}, tmp.As8())
@@ -439,7 +439,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 					assert(func(ok LabelRef) {
 						// if srcleft < maxint32: ok
 						CMPQ(srcLeft, U32(0x7fffffff))
-						JL(ok)
+						JB(ok)
 					})
 					// Forward address
 					forwardStart := GP64()
@@ -485,7 +485,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			// if s >= sLimit is picked up on next loop.
 			if false {
 				CMPL(s.As32(), sLimitL)
-				JGE(LabelRef("emit_remainder_" + name))
+				JAE(LabelRef("emit_remainder_" + name))
 			}
 			JMP(LabelRef("search_loop_" + name))
 		}
@@ -496,21 +496,21 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 				tmp := GP64()
 				MOVQ(lenSrcQ, tmp)
 				CMPL(tmp.As32(), candidate)
-				JG(ok)
+				JA(ok)
 			})
 			assert(func(ok LabelRef) {
 				CMPL(s, candidate)
-				JG(ok)
+				JA(ok)
 			})
 			assert(func(ok LabelRef) {
 				tmp := GP64()
 				MOVQ(lenSrcQ, tmp)
 				CMPL(tmp.As32(), candidate2)
-				JG(ok)
+				JA(ok)
 			})
 			assert(func(ok LabelRef) {
 				CMPL(s, candidate2)
-				JG(ok)
+				JA(ok)
 			})
 
 			CMPL(Mem{Base: src, Index: candidate, Scale: 1}, cv.As32())
@@ -526,14 +526,14 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 				tmp := GP64()
 				MOVQ(lenSrcQ, tmp)
 				CMPL(tmp.As32(), candidate)
-				JG(ok)
+				JA(ok)
 			})
 			assert(func(ok LabelRef) {
 				// We may get s and s+1
 				tmp := GP32()
 				LEAL(Mem{Base: s, Disp: 2}, tmp)
 				CMPL(tmp, candidate)
-				JG(ok)
+				JA(ok)
 			})
 
 			LEAL(Mem{Base: s, Disp: 2}, tmp)
@@ -585,7 +585,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 		Label("match_extend_back_loop_" + name)
 		// if s <= nextEmit {exit}
 		CMPL(s, ne)
-		JLE(LabelRef("match_extend_back_end_" + name))
+		JBE(LabelRef("match_extend_back_end_" + name))
 		// if src[candidate-1] == src[s-1]
 		tmp, tmp2 := GP64(), GP64()
 		MOVB(Mem{Base: src, Index: candidate, Scale: 1, Disp: -1}, tmp.As8())
@@ -608,7 +608,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 		// tmp = &dst + s-nextEmit
 		LEAQ(Mem{Base: dst, Index: tmp, Scale: 1, Disp: literalMaxOverhead}, tmp)
 		CMPQ(tmp, dstLimitPtrQ)
-		JL(LabelRef("match_dst_size_check_" + name))
+		JB(LabelRef("match_dst_size_check_" + name))
 		ri, err := ReturnIndex(0).Resolve()
 		if err != nil {
 			panic(err)
@@ -641,7 +641,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			assert(func(ok LabelRef) {
 				// s must be > candidate cannot be equal.
 				CMPL(s, candidate)
-				JG(ok)
+				JA(ok)
 			})
 			// srcLeft = len(src) - s
 			srcLeft := GP64()
@@ -650,7 +650,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			assert(func(ok LabelRef) {
 				// if srcleft < maxint32: ok
 				CMPQ(srcLeft, U32(0x7fffffff))
-				JL(ok)
+				JB(ok)
 			})
 
 			a, b := GP64(), GP64()
@@ -664,7 +664,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			Label("match_nolit_end_" + name)
 			assert(func(ok LabelRef) {
 				CMPL(length.As32(), U32(math.MaxInt32))
-				JL(ok)
+				JB(ok)
 			})
 			a, b, srcLeft = nil, nil, nil
 
@@ -684,14 +684,14 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			// if s >= sLimit { end }
 			{
 				CMPL(s.As32(), sLimitL)
-				JGE(LabelRef("emit_remainder_" + name))
+				JAE(LabelRef("emit_remainder_" + name))
 			}
 			// Start load s-2 as early as possible...
 			MOVQ(Mem{Base: src, Index: s, Scale: 1, Disp: -2}, cv)
 			// Bail if we exceed the maximum size.
 			{
 				CMPQ(dst, dstLimitPtrQ)
-				JL(LabelRef("match_nolit_dst_ok_" + name))
+				JB(LabelRef("match_nolit_dst_ok_" + name))
 				ri, err := ReturnIndex(0).Resolve()
 				if err != nil {
 					panic(err)
@@ -716,11 +716,11 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 			LEAL(Mem{Base: s, Disp: -2}, sm2)
 			assert(func(ok LabelRef) {
 				CMPQ(hash0, U32(tableSize))
-				JL(ok)
+				JB(ok)
 			})
 			assert(func(ok LabelRef) {
 				CMPQ(hash1, U32(tableSize))
-				JL(ok)
+				JB(ok)
 			})
 			addr := GP64()
 			LEAQ(table.Idx(hash1, 4), addr)
@@ -748,7 +748,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 
 		LEAQ(Mem{Base: dst, Index: remain, Scale: 1, Disp: literalMaxOverhead}, dstExpect)
 		CMPQ(dstExpect, dstLimitPtrQ)
-		JL(LabelRef("emit_remainder_ok_" + name))
+		JB(LabelRef("emit_remainder_ok_" + name))
 		ri, err := ReturnIndex(0).Resolve()
 		if err != nil {
 			panic(err)
@@ -773,7 +773,7 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 		assert(func(ok LabelRef) {
 			// if dstBaseQ <  dstLimitPtrQ: ok
 			CMPQ(dst, dstLimitPtrQ)
-			JL(ok)
+			JB(ok)
 		})
 	}
 
@@ -791,14 +791,14 @@ func (o options) genEncodeBlockAsm(name string, tableBits, skipLog, hashBytes, m
 	assert(func(ok LabelRef) {
 		// if len(src) >= length: ok
 		CMPQ(lenSrcQ, length)
-		JGE(ok)
+		JAE(ok)
 	})
 	// Assert size is < len(dst)
 	if !o.skipOutput {
 		assert(func(ok LabelRef) {
 			// if len(dst) >= length: ok
 			CMPQ(lenDstQ, length)
-			JGE(ok)
+			JAE(ok)
 		})
 	}
 	Store(length, ReturnIndex(0))
@@ -923,7 +923,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 
 		assert(func(ok LabelRef) {
 			CMPQ(tmp3, lenSrcQ)
-			JL(ok)
+			JB(ok)
 		})
 
 		MOVL(tmp3.As32(), sLimitL)
@@ -935,7 +935,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		assert(func(ok LabelRef) {
 			// if len(src) > len(src) - len(src)>>5 - 5: ok
 			CMPQ(lenSrcQ, tmp2)
-			JGE(ok)
+			JAE(ok)
 		})
 
 		LEAQ(Mem{Base: dst, Index: tmp2, Scale: 1}, tmp2)
@@ -986,7 +986,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 			SUBL(nextEmitL, tmp.As32())   // tmp = s - nextEmit
 			SHRL(U8(skipLog), tmp.As32()) // tmp = (s - nextEmit) >> skipLog
 			CMPL(tmp.As32(), U8(o.maxSkip-1))
-			JLE(LabelRef("check_maxskip_ok_" + name))
+			JBE(LabelRef("check_maxskip_ok_" + name))
 			LEAL(Mem{Base: s, Disp: o.maxSkip, Scale: 1}, nextS)
 			JMP(LabelRef("check_maxskip_cont_" + name))
 
@@ -997,7 +997,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		// if nextS > sLimit {goto emitRemainder}
 		{
 			CMPL(nextS.As32(), sLimitL)
-			JGE(LabelRef("emit_remainder_" + name))
+			JAE(LabelRef("emit_remainder_" + name))
 		}
 		MOVQ(Mem{Base: src, Index: s, Scale: 1}, cv)
 		assert(func(ok LabelRef) {
@@ -1005,7 +1005,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 			tmp := GP64()
 			MOVQ(lenSrcQ, tmp)
 			CMPQ(tmp, s.As64())
-			JG(ok)
+			JA(ok)
 		})
 		// move nextS to stack.
 		MOVL(nextS.As32(), nextSTempL)
@@ -1023,11 +1023,11 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 			MOVL(sTab.Idx(hash1, 4), candidateS)
 			assert(func(ok LabelRef) {
 				CMPQ(hash0, U32(lTableSize))
-				JL(ok)
+				JB(ok)
 			})
 			assert(func(ok LabelRef) {
 				CMPQ(hash1, U32(sTableSize))
-				JL(ok)
+				JB(ok)
 			})
 
 			MOVL(s, lTab.Idx(hash0, 4))
@@ -1096,7 +1096,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 				Label("repeat_extend_back_loop_" + name)
 				// if base <= nextemit {exit}
 				CMPL(base.As32(), nextEmit)
-				JLE(LabelRef("repeat_extend_back_end_" + name))
+				JBE(LabelRef("repeat_extend_back_end_" + name))
 				// if src[i-1] == src[base-1]
 				tmp, tmp2 := GP64(), GP64()
 				MOVB(Mem{Base: src, Index: i, Scale: 1, Disp: -1}, tmp.As8())
@@ -1132,7 +1132,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 					assert(func(ok LabelRef) {
 						// if srcleft < maxint32: ok
 						CMPQ(srcLeft, U32(0x7fffffff))
-						JL(ok)
+						JB(ok)
 					})
 					// Forward address
 					forwardStart := GP64()
@@ -1168,7 +1168,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 			// if s >= sLimit is picked up on next loop.
 			if false {
 				CMPL(s.As32(), sLimitL)
-				JGE(LabelRef("emit_remainder_" + name))
+				JAE(LabelRef("emit_remainder_" + name))
 			}
 			JMP(LabelRef("search_loop_" + name))
 		}
@@ -1179,21 +1179,21 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 				tmp := GP64()
 				MOVQ(lenSrcQ, tmp)
 				CMPL(tmp.As32(), candidate)
-				JG(ok)
+				JA(ok)
 			})
 			assert(func(ok LabelRef) {
 				CMPL(s, candidate)
-				JG(ok)
+				JA(ok)
 			})
 			assert(func(ok LabelRef) {
 				tmp := GP64()
 				MOVQ(lenSrcQ, tmp)
 				CMPL(tmp.As32(), candidateS)
-				JG(ok)
+				JA(ok)
 			})
 			assert(func(ok LabelRef) {
 				CMPL(s, candidateS)
-				JG(ok)
+				JA(ok)
 			})
 
 			CMPL(longVal.As32(), cv.As32())
@@ -1219,7 +1219,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 				INCL(s)
 				assert(func(ok LabelRef) {
 					CMPQ(hash0, U32(lTableSize))
-					JL(ok)
+					JB(ok)
 				})
 				MOVL(s, lTab.Idx(hash0, 4))
 				CMPL(Mem{Base: src, Index: candidate, Scale: 1}, cv.As32())
@@ -1244,7 +1244,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		Label("match_extend_back_loop_" + name)
 		// if s <= nextEmit {exit}
 		CMPL(s, ne)
-		JLE(LabelRef("match_extend_back_end_" + name))
+		JBE(LabelRef("match_extend_back_end_" + name))
 		// if src[candidate-1] == src[s-1]
 		tmp, tmp2 := GP64(), GP64()
 		MOVB(Mem{Base: src, Index: candidate, Scale: 1, Disp: -1}, tmp.As8())
@@ -1267,7 +1267,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		// tmp = &dst + s-nextEmit
 		LEAQ(Mem{Base: dst, Index: tmp, Scale: 1, Disp: literalMaxOverhead}, tmp)
 		CMPQ(tmp, dstLimitPtrQ)
-		JL(LabelRef("match_dst_size_check_" + name))
+		JB(LabelRef("match_dst_size_check_" + name))
 		ri, err := ReturnIndex(0).Resolve()
 		if err != nil {
 			panic(err)
@@ -1288,7 +1288,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		assert(func(ok LabelRef) {
 			// s must be > candidate cannot be equal.
 			CMPL(s, candidate)
-			JG(ok)
+			JA(ok)
 		})
 		// srcLeft = len(src) - s
 		srcLeft := GP64()
@@ -1297,7 +1297,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		assert(func(ok LabelRef) {
 			// if srcleft < maxint32: ok
 			CMPQ(srcLeft, U32(0x7fffffff))
-			JL(ok)
+			JB(ok)
 		})
 
 		a, b := GP64(), GP64()
@@ -1311,7 +1311,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		Label("match_nolit_end_" + name)
 		assert(func(ok LabelRef) {
 			CMPL(length.As32(), U32(math.MaxInt32))
-			JL(ok)
+			JB(ok)
 		})
 		a, b, srcLeft = nil, nil, nil
 
@@ -1332,9 +1332,9 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 				// Check if match is better..
 				if o.maxOffset > 65535 {
 					CMPL(length.As32(), U8(1))
-					JG(LabelRef("match_length_ok_" + name))
+					JA(LabelRef("match_length_ok_" + name))
 					CMPL(offset32, U32(65535))
-					JLE(LabelRef("match_length_ok_" + name))
+					JBE(LabelRef("match_length_ok_" + name))
 					// Match is equal or worse to the encoding.
 					MOVL(nextSTempL, s)
 					INCL(s)
@@ -1373,13 +1373,13 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		// if s >= sLimit { end }
 		{
 			CMPL(s.As32(), sLimitL)
-			JGE(LabelRef("emit_remainder_" + name))
+			JAE(LabelRef("emit_remainder_" + name))
 		}
 
 		// Bail if we exceed the maximum size.
 		{
 			CMPQ(dst, dstLimitPtrQ)
-			JL(LabelRef("match_nolit_dst_ok_" + name))
+			JB(LabelRef("match_nolit_dst_ok_" + name))
 			ri, err := ReturnIndex(0).Resolve()
 			if err != nil {
 				panic(err)
@@ -1464,19 +1464,19 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		sHasher.hash(hash2)
 		assert(func(ok LabelRef) {
 			CMPQ(hash0, U32(lTableSize))
-			JL(ok)
+			JB(ok)
 		})
 		assert(func(ok LabelRef) {
 			CMPQ(hash3, U32(lTableSize))
-			JL(ok)
+			JB(ok)
 		})
 		assert(func(ok LabelRef) {
 			CMPQ(hash1, U32(sTableSize))
-			JL(ok)
+			JB(ok)
 		})
 		assert(func(ok LabelRef) {
 			CMPQ(hash2, U32(sTableSize))
-			JL(ok)
+			JB(ok)
 		})
 		MOVL(base, lTab.Idx(hash0, 4))
 		MOVL(bp1, lTab.Idx(hash3, 4))
@@ -1496,15 +1496,15 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 		lHasher.hash(hash3)
 		assert(func(ok LabelRef) {
 			CMPQ(hash0, U32(lTableSize))
-			JL(ok)
+			JB(ok)
 		})
 		assert(func(ok LabelRef) {
 			CMPQ(hash3, U32(lTableSize))
-			JL(ok)
+			JB(ok)
 		})
 		assert(func(ok LabelRef) {
 			CMPQ(hash1, U32(sTableSize))
-			JL(ok)
+			JB(ok)
 		})
 		MOVL(sm2, lTab.Idx(hash0, 4))
 		MOVL(sm1, sTab.Idx(hash1, 4))
@@ -1526,7 +1526,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 
 		LEAQ(Mem{Base: dst, Index: remain, Scale: 1, Disp: literalMaxOverhead}, dstExpect)
 		CMPQ(dstExpect, dstLimitPtrQ)
-		JL(LabelRef("emit_remainder_ok_" + name))
+		JB(LabelRef("emit_remainder_ok_" + name))
 		ri, err := ReturnIndex(0).Resolve()
 		if err != nil {
 			panic(err)
@@ -1551,7 +1551,7 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 	assert(func(ok LabelRef) {
 		// if dstBaseQ <  dstLimitPtrQ: ok
 		CMPQ(dst, dstLimitPtrQ)
-		JL(ok)
+		JB(ok)
 	})
 
 	// length := start - base (ptr arithmetic)
@@ -1564,13 +1564,13 @@ func (o options) genEncodeBetterBlockAsm(name string, lTableBits, sTableBits, sk
 	assert(func(ok LabelRef) {
 		// if len(src) >= length: ok
 		CMPQ(lenSrcQ, length)
-		JGE(ok)
+		JAE(ok)
 	})
 	// Assert size is < len(dst)
 	assert(func(ok LabelRef) {
 		// if len(dst) >= length: ok
 		CMPQ(lenDstQ, length)
-		JGE(ok)
+		JAE(ok)
 	})
 	Store(length, ReturnIndex(0))
 	RET()
@@ -1606,7 +1606,7 @@ func (o options) emitLiterals(nextEmitL Mem, base reg.GPVirtual, src reg.GPVirtu
 		SUBQ(dstBase, tmp) // tmp = dstBaseTmp - dstBase
 		// if tmp > litLen: ok
 		CMPQ(tmp, litLen.As64())
-		JG(ok)
+		JA(ok)
 	})
 	// Store updated dstBase
 	MOVQ(dstBaseTmp, dstBase)
@@ -1735,19 +1735,19 @@ func (o options) emitLiteral(name string, litLen, retval, dstBase, litBase reg.G
 
 	// Find number of bytes to emit for tag.
 	CMPL(n.As32(), U8(60))
-	JLT(LabelRef("one_byte_" + name))
+	JB(LabelRef("one_byte_" + name))
 	CMPL(n.As32(), U32(1<<8))
-	JLT(LabelRef("two_bytes_" + name))
+	JB(LabelRef("two_bytes_" + name))
 	if o.maxLen >= 1<<16 {
 		CMPL(n.As32(), U32(1<<16))
-		JLT(LabelRef("three_bytes_" + name))
+		JB(LabelRef("three_bytes_" + name))
 	} else {
-		JMP(LabelRef("three_bytes_" + name))
+		JB(LabelRef("three_bytes_" + name))
 	}
 	if o.maxLen >= 1<<16 {
 		if o.maxLen >= 1<<24 {
 			CMPL(n.As32(), U32(1<<24))
-			JLT(LabelRef("four_bytes_" + name))
+			JB(LabelRef("four_bytes_" + name))
 		} else {
 			JMP(LabelRef("four_bytes_" + name))
 		}
@@ -1800,7 +1800,7 @@ func (o options) emitLiteral(name string, litLen, retval, dstBase, litBase reg.G
 	}
 	ADDQ(U8(2), dstBase)
 	CMPL(n.As32(), U8(64))
-	JL(LabelRef("memmove_" + name))
+	JB(LabelRef("memmove_" + name))
 	JMP(LabelRef("memmove_long_" + name))
 
 	Label("one_byte_" + name)
@@ -1911,30 +1911,30 @@ func (o options) emitRepeat(name string, length reg.GPVirtual, offset reg.GPVirt
 
 	// if length <= 4 (use copied value)
 	CMPL(tmp.As32(), U8(8))
-	JLE(LabelRef("repeat_two_" + name))
+	JBE(LabelRef("repeat_two_" + name))
 
 	// length < 8 && offset < 2048
 	CMPL(tmp.As32(), U8(12))
-	JGE(LabelRef("cant_repeat_two_offset_" + name))
+	JAE(LabelRef("cant_repeat_two_offset_" + name))
 	if o.maxLen >= 2048 {
 		CMPL(offset.As32(), U32(2048))
-		JLT(LabelRef("repeat_two_offset_" + name))
+		JB(LabelRef("repeat_two_offset_" + name))
 	}
 
 	const maxRepeat = ((1 << 24) - 1) + 65536
 	Label("cant_repeat_two_offset_" + name)
 	CMPL(length.As32(), U32((1<<8)+4))
-	JLT(LabelRef("repeat_three_" + name)) // if length < (1<<8)+4
+	JB(LabelRef("repeat_three_" + name)) // if length < (1<<8)+4
 	if o.maxLen >= (1<<16)+(1<<8) {
 		CMPL(length.As32(), U32((1<<16)+(1<<8)))
-		JLT(LabelRef("repeat_four_" + name)) // if length < (1 << 16) + (1 << 8)
+		JB(LabelRef("repeat_four_" + name)) // if length < (1 << 16) + (1 << 8)
 	} else {
 		// Not needed, we should skip to it when generating.
 		// JMP(LabelRef("repeat_four_" + name)) // if length < (1 << 16) + (1 << 8)
 	}
 	if o.maxLen >= maxRepeat {
 		CMPL(length.As32(), U32(maxRepeat))
-		JLT(LabelRef("repeat_five_" + name)) // If less than 24 bits to represent.
+		JB(LabelRef("repeat_five_" + name)) // If less than 24 bits to represent.
 
 		if !o.skipOutput {
 			// We have have more than 24 bits
@@ -2118,13 +2118,13 @@ func (o options) emitCopy(name string, length, offset, retval, dstBase, dstLimit
 	if o.maxOffset >= 65536 {
 		//if offset >= 65536 {
 		CMPL(offset.As32(), U32(65536))
-		JL(LabelRef("two_byte_offset_" + name))
+		JB(LabelRef("two_byte_offset_" + name))
 
 		// offset is >= 65536
 		//	if length <= 64 goto four_bytes_remain_
 		Label("four_bytes_loop_back_" + name)
 		CMPL(length.As32(), U8(64))
-		JLE(LabelRef("four_bytes_remain_" + name))
+		JBE(LabelRef("four_bytes_remain_" + name))
 
 		if !o.skipOutput {
 			// Emit a length 64 copy, encoded as 5 bytes.
@@ -2145,7 +2145,7 @@ func (o options) emitCopy(name string, length, offset, retval, dstBase, dstLimit
 
 		//	if length >= 4 {
 		CMPL(length.As32(), U8(4))
-		JL(LabelRef("four_bytes_remain_" + name))
+		JB(LabelRef("four_bytes_remain_" + name))
 
 		// Emit remaining as repeats
 		//	return 5 + emitRepeat(dst[5:], offset, length)
@@ -2190,7 +2190,7 @@ func (o options) emitCopy(name string, length, offset, retval, dstBase, dstLimit
 
 	//if length > 64 {
 	CMPL(length.As32(), U8(64))
-	JLE(LabelRef("two_byte_offset_short_" + name))
+	JBE(LabelRef("two_byte_offset_short_" + name))
 
 	// if offset < 2048 {
 	if !o.snappy {
@@ -2260,10 +2260,10 @@ func (o options) emitCopy(name string, length, offset, retval, dstBase, dstLimit
 
 	//if length >= 12 || offset >= 2048 {
 	CMPL(length.As32(), U8(12))
-	JGE(LabelRef("emit_copy_three_" + name))
+	JAE(LabelRef("emit_copy_three_" + name))
 	if o.maxOffset >= 2048 {
 		CMPL(offset.As32(), U32(2048))
-		JGE(LabelRef("emit_copy_three_" + name))
+		JAE(LabelRef("emit_copy_three_" + name))
 	}
 	// Emit the remaining copy, encoded as 2 bytes.
 	// dst[1] = uint8(offset)
@@ -2338,14 +2338,14 @@ func (o options) genMemMoveShort(name string, dst, src, length reg.GPVirtual, en
 		JE(LabelRef(name + "move_3"))
 	} else if o.outputMargin >= 4 && o.outputMargin < 8 {
 		CMPQ(length, U8(4))
-		JLE(LabelRef(name + "move_4"))
+		JBE(LabelRef(name + "move_4"))
 	}
 	if o.outputMargin <= 7 {
 		CMPQ(length, U8(8))
 		JB(LabelRef(name + "move_4through7"))
 	} else if o.outputMargin >= 8 {
 		CMPQ(length, U8(8))
-		JLE(LabelRef(name + "move_8"))
+		JBE(LabelRef(name + "move_8"))
 	}
 	CMPQ(length, U8(16))
 	JBE(LabelRef(name + "move_8through16"))
@@ -2707,7 +2707,7 @@ func (o options) matchLen(name string, a, b, len reg.GPVirtual, end LabelRef) re
 	XORL(matched, matched)
 
 	CMPL(len.As32(), U8(8))
-	JL(LabelRef("matchlen_match4_" + name))
+	JB(LabelRef("matchlen_match4_" + name))
 
 	Label("matchlen_loopback_" + name)
 	MOVQ(Mem{Base: a, Index: matched, Scale: 1}, tmp)
@@ -2733,14 +2733,14 @@ func (o options) matchLen(name string, a, b, len reg.GPVirtual, end LabelRef) re
 	LEAL(Mem{Base: len, Disp: -8}, len.As32())
 	LEAL(Mem{Base: matched, Disp: 8}, matched)
 	CMPL(len.As32(), U8(8))
-	JGE(LabelRef("matchlen_loopback_" + name))
+	JAE(LabelRef("matchlen_loopback_" + name))
 	JZ(end)
 
 	// Less than 8 bytes left.
 	// Test 4 bytes...
 	Label("matchlen_match4_" + name)
 	CMPL(len.As32(), U8(4))
-	JL(LabelRef("matchlen_match2_" + name))
+	JB(LabelRef("matchlen_match2_" + name))
 	MOVL(Mem{Base: a, Index: matched, Scale: 1}, tmp.As32())
 	CMPL(Mem{Base: b, Index: matched, Scale: 1}, tmp.As32())
 	JNE(LabelRef("matchlen_match2_" + name))
@@ -2750,7 +2750,7 @@ func (o options) matchLen(name string, a, b, len reg.GPVirtual, end LabelRef) re
 	// Test 2 bytes...
 	Label("matchlen_match2_" + name)
 	CMPL(len.As32(), U8(2))
-	JL(LabelRef("matchlen_match1_" + name))
+	JB(LabelRef("matchlen_match1_" + name))
 	MOVW(Mem{Base: a, Index: matched, Scale: 1}, tmp.As16())
 	CMPW(Mem{Base: b, Index: matched, Scale: 1}, tmp.As16())
 	JNE(LabelRef("matchlen_match1_" + name))
@@ -2760,7 +2760,7 @@ func (o options) matchLen(name string, a, b, len reg.GPVirtual, end LabelRef) re
 	// Test 1 byte...
 	Label("matchlen_match1_" + name)
 	CMPL(len.As32(), U8(1))
-	JL(end)
+	JB(end)
 	MOVB(Mem{Base: a, Index: matched, Scale: 1}, tmp.As8())
 	CMPB(Mem{Base: b, Index: matched, Scale: 1}, tmp.As8())
 	JNE(end)
@@ -2820,7 +2820,7 @@ func (o options) matchLenAlt(name string, a, b, len reg.GPVirtual, end LabelRef)
 		Label("matchlen_four_loopback_" + name)
 		assert(func(ok LabelRef) {
 			CMPL(len.As32(), U32(math.MaxInt32))
-			JL(ok)
+			JB(ok)
 		})
 
 		MOVL(Mem{Base: a}, tmp.As32())

--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"os"
 	"runtime"
@@ -400,6 +401,60 @@ func TestIndex(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestEncodeHuge(t *testing.T) {
+	if true {
+		t.Skip("Takes too much memory")
+	}
+	test := func(t *testing.T, data []byte) {
+		comp := Encode(make([]byte, MaxEncodedLen(len(data))), data)
+		decoded, err := Decode(nil, comp)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if !bytes.Equal(data, decoded) {
+			t.Error("block decoder mismatch")
+			return
+		}
+		if mel := MaxEncodedLen(len(data)); len(comp) > mel {
+			t.Error(fmt.Errorf("MaxEncodedLen Exceed: input: %d, mel: %d, got %d", len(data), mel, len(comp)))
+			return
+		}
+		comp = EncodeBetter(make([]byte, MaxEncodedLen(len(data))), data)
+		decoded, err = Decode(nil, comp)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if !bytes.Equal(data, decoded) {
+			t.Error("block decoder mismatch")
+			return
+		}
+		if mel := MaxEncodedLen(len(data)); len(comp) > mel {
+			t.Error(fmt.Errorf("MaxEncodedLen Exceed: input: %d, mel: %d, got %d", len(data), mel, len(comp)))
+			return
+		}
+
+		comp = EncodeBest(make([]byte, MaxEncodedLen(len(data))), data)
+		decoded, err = Decode(nil, comp)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if !bytes.Equal(data, decoded) {
+			t.Error("block decoder mismatch")
+			return
+		}
+		if mel := MaxEncodedLen(len(data)); len(comp) > mel {
+			t.Error(fmt.Errorf("MaxEncodedLen Exceed: input: %d, mel: %d, got %d", len(data), mel, len(comp)))
+			return
+		}
+	}
+	test(t, make([]byte, math.MaxInt32))
+	test(t, make([]byte, math.MaxInt32+math.MaxUint16))
+	test(t, make([]byte, MaxBlockSize))
 }
 
 func BenchmarkIndexFind(b *testing.B) {

--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -453,7 +453,10 @@ func TestEncodeHuge(t *testing.T) {
 		}
 	}
 	test(t, make([]byte, math.MaxInt32))
-	test(t, make([]byte, math.MaxInt32+math.MaxUint16))
+	if math.MaxInt > math.MaxInt32 {
+		x := int64(math.MaxInt32 + math.MaxUint16)
+		test(t, make([]byte, x))
+	}
 	test(t, make([]byte, MaxBlockSize))
 }
 

--- a/s2/encodeblock_amd64.s
+++ b/s2/encodeblock_amd64.s
@@ -52,7 +52,7 @@ search_loop_encodeBlockAsm:
 	SHRL  $0x06, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBlockAsm
+	JAE   emit_remainder_encodeBlockAsm
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -90,7 +90,7 @@ search_loop_encodeBlockAsm:
 
 repeat_extend_back_loop_encodeBlockAsm:
 	CMPL SI, DI
-	JLE  repeat_extend_back_end_encodeBlockAsm
+	JBE  repeat_extend_back_end_encodeBlockAsm
 	MOVB -1(DX)(BX*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -109,13 +109,13 @@ repeat_extend_back_end_encodeBlockAsm:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeBlockAsm
+	JB   one_byte_repeat_emit_encodeBlockAsm
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeBlockAsm
+	JB   two_bytes_repeat_emit_encodeBlockAsm
 	CMPL BX, $0x00010000
-	JLT  three_bytes_repeat_emit_encodeBlockAsm
+	JB   three_bytes_repeat_emit_encodeBlockAsm
 	CMPL BX, $0x01000000
-	JLT  four_bytes_repeat_emit_encodeBlockAsm
+	JB   four_bytes_repeat_emit_encodeBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL BX, 1(AX)
 	ADDQ $0x05, AX
@@ -141,7 +141,7 @@ two_bytes_repeat_emit_encodeBlockAsm:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeBlockAsm
+	JB   memmove_repeat_emit_encodeBlockAsm
 	JMP  memmove_long_repeat_emit_encodeBlockAsm
 
 one_byte_repeat_emit_encodeBlockAsm:
@@ -154,7 +154,7 @@ memmove_repeat_emit_encodeBlockAsm:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeBlockAsm_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -250,7 +250,7 @@ emit_literal_done_repeat_emit_encodeBlockAsm:
 	// matchLen
 	XORL R11, R11
 	CMPL R8, $0x08
-	JL   matchlen_match4_repeat_extend_encodeBlockAsm
+	JB   matchlen_match4_repeat_extend_encodeBlockAsm
 
 matchlen_loopback_repeat_extend_encodeBlockAsm:
 	MOVQ  (R9)(R11*1), R10
@@ -273,12 +273,12 @@ matchlen_loop_repeat_extend_encodeBlockAsm:
 	LEAL -8(R8), R8
 	LEAL 8(R11), R11
 	CMPL R8, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeBlockAsm
+	JAE  matchlen_loopback_repeat_extend_encodeBlockAsm
 	JZ   repeat_extend_forward_end_encodeBlockAsm
 
 matchlen_match4_repeat_extend_encodeBlockAsm:
 	CMPL R8, $0x04
-	JL   matchlen_match2_repeat_extend_encodeBlockAsm
+	JB   matchlen_match2_repeat_extend_encodeBlockAsm
 	MOVL (R9)(R11*1), R10
 	CMPL (BX)(R11*1), R10
 	JNE  matchlen_match2_repeat_extend_encodeBlockAsm
@@ -287,7 +287,7 @@ matchlen_match4_repeat_extend_encodeBlockAsm:
 
 matchlen_match2_repeat_extend_encodeBlockAsm:
 	CMPL R8, $0x02
-	JL   matchlen_match1_repeat_extend_encodeBlockAsm
+	JB   matchlen_match1_repeat_extend_encodeBlockAsm
 	MOVW (R9)(R11*1), R10
 	CMPW (BX)(R11*1), R10
 	JNE  matchlen_match1_repeat_extend_encodeBlockAsm
@@ -296,7 +296,7 @@ matchlen_match2_repeat_extend_encodeBlockAsm:
 
 matchlen_match1_repeat_extend_encodeBlockAsm:
 	CMPL R8, $0x01
-	JL   repeat_extend_forward_end_encodeBlockAsm
+	JB   repeat_extend_forward_end_encodeBlockAsm
 	MOVB (R9)(R11*1), R10
 	CMPB (BX)(R11*1), R10
 	JNE  repeat_extend_forward_end_encodeBlockAsm
@@ -315,19 +315,19 @@ emit_repeat_again_match_repeat_encodeBlockAsm:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_match_repeat_encodeBlockAsm
+	JBE  repeat_two_match_repeat_encodeBlockAsm
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_match_repeat_encodeBlockAsm
+	JAE  cant_repeat_two_offset_match_repeat_encodeBlockAsm
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_match_repeat_encodeBlockAsm
+	JB   repeat_two_offset_match_repeat_encodeBlockAsm
 
 cant_repeat_two_offset_match_repeat_encodeBlockAsm:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_match_repeat_encodeBlockAsm
+	JB   repeat_three_match_repeat_encodeBlockAsm
 	CMPL BX, $0x00010100
-	JLT  repeat_four_match_repeat_encodeBlockAsm
+	JB   repeat_four_match_repeat_encodeBlockAsm
 	CMPL BX, $0x0100ffff
-	JLT  repeat_five_match_repeat_encodeBlockAsm
+	JB   repeat_five_match_repeat_encodeBlockAsm
 	LEAL -16842747(BX), BX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -379,34 +379,34 @@ repeat_two_offset_match_repeat_encodeBlockAsm:
 repeat_as_copy_encodeBlockAsm:
 	// emitCopy
 	CMPL SI, $0x00010000
-	JL   two_byte_offset_repeat_as_copy_encodeBlockAsm
+	JB   two_byte_offset_repeat_as_copy_encodeBlockAsm
 	CMPL BX, $0x40
-	JLE  four_bytes_remain_repeat_as_copy_encodeBlockAsm
+	JBE  four_bytes_remain_repeat_as_copy_encodeBlockAsm
 	MOVB $0xff, (AX)
 	MOVL SI, 1(AX)
 	LEAL -64(BX), BX
 	ADDQ $0x05, AX
 	CMPL BX, $0x04
-	JL   four_bytes_remain_repeat_as_copy_encodeBlockAsm
+	JB   four_bytes_remain_repeat_as_copy_encodeBlockAsm
 
 	// emitRepeat
 emit_repeat_again_repeat_as_copy_encodeBlockAsm_emit_copy:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm_emit_copy
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm_emit_copy
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm_emit_copy
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm_emit_copy
 	CMPL BX, $0x00010100
-	JLT  repeat_four_repeat_as_copy_encodeBlockAsm_emit_copy
+	JB   repeat_four_repeat_as_copy_encodeBlockAsm_emit_copy
 	CMPL BX, $0x0100ffff
-	JLT  repeat_five_repeat_as_copy_encodeBlockAsm_emit_copy
+	JB   repeat_five_repeat_as_copy_encodeBlockAsm_emit_copy
 	LEAL -16842747(BX), BX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -467,7 +467,7 @@ four_bytes_remain_repeat_as_copy_encodeBlockAsm:
 
 two_byte_offset_repeat_as_copy_encodeBlockAsm:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm
+	JBE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm
 	CMPL SI, $0x00000800
 	JAE  long_offset_short_repeat_as_copy_encodeBlockAsm
 	MOVL $0x00000001, DI
@@ -489,19 +489,19 @@ emit_repeat_again_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
 	CMPL BX, $0x00010100
-	JLT  repeat_four_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_four_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
 	CMPL BX, $0x0100ffff
-	JLT  repeat_five_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_five_repeat_as_copy_encodeBlockAsm_emit_copy_short_2b
 	LEAL -16842747(BX), BX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -561,19 +561,19 @@ emit_repeat_again_repeat_as_copy_encodeBlockAsm_emit_copy_short:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm_emit_copy_short
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm_emit_copy_short
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm_emit_copy_short:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm_emit_copy_short
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm_emit_copy_short
 	CMPL BX, $0x00010100
-	JLT  repeat_four_repeat_as_copy_encodeBlockAsm_emit_copy_short
+	JB   repeat_four_repeat_as_copy_encodeBlockAsm_emit_copy_short
 	CMPL BX, $0x0100ffff
-	JLT  repeat_five_repeat_as_copy_encodeBlockAsm_emit_copy_short
+	JB   repeat_five_repeat_as_copy_encodeBlockAsm_emit_copy_short
 	LEAL -16842747(BX), BX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -626,9 +626,9 @@ two_byte_offset_short_repeat_as_copy_encodeBlockAsm:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -679,7 +679,7 @@ candidate_match_encodeBlockAsm:
 
 match_extend_back_loop_encodeBlockAsm:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBlockAsm
+	JBE  match_extend_back_end_encodeBlockAsm
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -694,7 +694,7 @@ match_extend_back_end_encodeBlockAsm:
 	SUBL 12(SP), SI
 	LEAQ 5(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBlockAsm
+	JB   match_dst_size_check_encodeBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -709,13 +709,13 @@ match_dst_size_check_encodeBlockAsm:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeBlockAsm
+	JB   one_byte_match_emit_encodeBlockAsm
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeBlockAsm
+	JB   two_bytes_match_emit_encodeBlockAsm
 	CMPL DI, $0x00010000
-	JLT  three_bytes_match_emit_encodeBlockAsm
+	JB   three_bytes_match_emit_encodeBlockAsm
 	CMPL DI, $0x01000000
-	JLT  four_bytes_match_emit_encodeBlockAsm
+	JB   four_bytes_match_emit_encodeBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL DI, 1(AX)
 	ADDQ $0x05, AX
@@ -741,7 +741,7 @@ two_bytes_match_emit_encodeBlockAsm:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeBlockAsm
+	JB   memmove_match_emit_encodeBlockAsm
 	JMP  memmove_long_match_emit_encodeBlockAsm
 
 one_byte_match_emit_encodeBlockAsm:
@@ -754,7 +754,7 @@ memmove_match_emit_encodeBlockAsm:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeBlockAsm_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeBlockAsm_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeBlockAsm_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -853,7 +853,7 @@ match_nolit_loop_encodeBlockAsm:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBlockAsm
+	JB   matchlen_match4_match_nolit_encodeBlockAsm
 
 matchlen_loopback_match_nolit_encodeBlockAsm:
 	MOVQ  (DI)(R9*1), R8
@@ -876,12 +876,12 @@ matchlen_loop_match_nolit_encodeBlockAsm:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBlockAsm
+	JAE  matchlen_loopback_match_nolit_encodeBlockAsm
 	JZ   match_nolit_end_encodeBlockAsm
 
 matchlen_match4_match_nolit_encodeBlockAsm:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBlockAsm
+	JB   matchlen_match2_match_nolit_encodeBlockAsm
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeBlockAsm
@@ -890,7 +890,7 @@ matchlen_match4_match_nolit_encodeBlockAsm:
 
 matchlen_match2_match_nolit_encodeBlockAsm:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBlockAsm
+	JB   matchlen_match1_match_nolit_encodeBlockAsm
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeBlockAsm
@@ -899,7 +899,7 @@ matchlen_match2_match_nolit_encodeBlockAsm:
 
 matchlen_match1_match_nolit_encodeBlockAsm:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeBlockAsm
+	JB   match_nolit_end_encodeBlockAsm
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeBlockAsm
@@ -913,34 +913,34 @@ match_nolit_end_encodeBlockAsm:
 
 	// emitCopy
 	CMPL BX, $0x00010000
-	JL   two_byte_offset_match_nolit_encodeBlockAsm
+	JB   two_byte_offset_match_nolit_encodeBlockAsm
 	CMPL R9, $0x40
-	JLE  four_bytes_remain_match_nolit_encodeBlockAsm
+	JBE  four_bytes_remain_match_nolit_encodeBlockAsm
 	MOVB $0xff, (AX)
 	MOVL BX, 1(AX)
 	LEAL -64(R9), R9
 	ADDQ $0x05, AX
 	CMPL R9, $0x04
-	JL   four_bytes_remain_match_nolit_encodeBlockAsm
+	JB   four_bytes_remain_match_nolit_encodeBlockAsm
 
 	// emitRepeat
 emit_repeat_again_match_nolit_encodeBlockAsm_emit_copy:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm_emit_copy
+	JBE  repeat_two_match_nolit_encodeBlockAsm_emit_copy
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm_emit_copy
+	JB   repeat_three_match_nolit_encodeBlockAsm_emit_copy
 	CMPL R9, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBlockAsm_emit_copy
+	JB   repeat_four_match_nolit_encodeBlockAsm_emit_copy
 	CMPL R9, $0x0100ffff
-	JLT  repeat_five_match_nolit_encodeBlockAsm_emit_copy
+	JB   repeat_five_match_nolit_encodeBlockAsm_emit_copy
 	LEAL -16842747(R9), R9
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -1001,7 +1001,7 @@ four_bytes_remain_match_nolit_encodeBlockAsm:
 
 two_byte_offset_match_nolit_encodeBlockAsm:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBlockAsm
+	JBE  two_byte_offset_short_match_nolit_encodeBlockAsm
 	CMPL BX, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBlockAsm
 	MOVL $0x00000001, SI
@@ -1023,19 +1023,19 @@ emit_repeat_again_match_nolit_encodeBlockAsm_emit_copy_short_2b:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBlockAsm_emit_copy_short_2b
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short_2b
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short_2b:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBlockAsm_emit_copy_short_2b
 	CMPL R9, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_four_match_nolit_encodeBlockAsm_emit_copy_short_2b
 	CMPL R9, $0x0100ffff
-	JLT  repeat_five_match_nolit_encodeBlockAsm_emit_copy_short_2b
+	JB   repeat_five_match_nolit_encodeBlockAsm_emit_copy_short_2b
 	LEAL -16842747(R9), R9
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -1095,19 +1095,19 @@ emit_repeat_again_match_nolit_encodeBlockAsm_emit_copy_short:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBlockAsm_emit_copy_short
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm_emit_copy_short:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBlockAsm_emit_copy_short
 	CMPL R9, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBlockAsm_emit_copy_short
+	JB   repeat_four_match_nolit_encodeBlockAsm_emit_copy_short
 	CMPL R9, $0x0100ffff
-	JLT  repeat_five_match_nolit_encodeBlockAsm_emit_copy_short
+	JB   repeat_five_match_nolit_encodeBlockAsm_emit_copy_short
 	LEAL -16842747(R9), R9
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -1160,9 +1160,9 @@ two_byte_offset_short_match_nolit_encodeBlockAsm:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -1180,10 +1180,10 @@ emit_copy_three_match_nolit_encodeBlockAsm:
 
 match_nolit_emitcopy_end_encodeBlockAsm:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBlockAsm
+	JAE  emit_remainder_encodeBlockAsm
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBlockAsm
+	JB   match_nolit_dst_ok_encodeBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -1213,7 +1213,7 @@ emit_remainder_encodeBlockAsm:
 	SUBL 12(SP), CX
 	LEAQ 5(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBlockAsm
+	JB   emit_remainder_ok_encodeBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -1228,13 +1228,13 @@ emit_remainder_ok_encodeBlockAsm:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBlockAsm
+	JB   one_byte_emit_remainder_encodeBlockAsm
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBlockAsm
+	JB   two_bytes_emit_remainder_encodeBlockAsm
 	CMPL DX, $0x00010000
-	JLT  three_bytes_emit_remainder_encodeBlockAsm
+	JB   three_bytes_emit_remainder_encodeBlockAsm
 	CMPL DX, $0x01000000
-	JLT  four_bytes_emit_remainder_encodeBlockAsm
+	JB   four_bytes_emit_remainder_encodeBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL DX, 1(AX)
 	ADDQ $0x05, AX
@@ -1260,7 +1260,7 @@ two_bytes_emit_remainder_encodeBlockAsm:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBlockAsm
+	JB   memmove_emit_remainder_encodeBlockAsm
 	JMP  memmove_long_emit_remainder_encodeBlockAsm
 
 one_byte_emit_remainder_encodeBlockAsm:
@@ -1423,7 +1423,7 @@ search_loop_encodeBlockAsm4MB:
 	SHRL  $0x06, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBlockAsm4MB
+	JAE   emit_remainder_encodeBlockAsm4MB
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -1461,7 +1461,7 @@ search_loop_encodeBlockAsm4MB:
 
 repeat_extend_back_loop_encodeBlockAsm4MB:
 	CMPL SI, DI
-	JLE  repeat_extend_back_end_encodeBlockAsm4MB
+	JBE  repeat_extend_back_end_encodeBlockAsm4MB
 	MOVB -1(DX)(BX*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -1480,11 +1480,11 @@ repeat_extend_back_end_encodeBlockAsm4MB:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeBlockAsm4MB
+	JB   one_byte_repeat_emit_encodeBlockAsm4MB
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeBlockAsm4MB
+	JB   two_bytes_repeat_emit_encodeBlockAsm4MB
 	CMPL BX, $0x00010000
-	JLT  three_bytes_repeat_emit_encodeBlockAsm4MB
+	JB   three_bytes_repeat_emit_encodeBlockAsm4MB
 	MOVL BX, R10
 	SHRL $0x10, R10
 	MOVB $0xf8, (AX)
@@ -1504,7 +1504,7 @@ two_bytes_repeat_emit_encodeBlockAsm4MB:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeBlockAsm4MB
+	JB   memmove_repeat_emit_encodeBlockAsm4MB
 	JMP  memmove_long_repeat_emit_encodeBlockAsm4MB
 
 one_byte_repeat_emit_encodeBlockAsm4MB:
@@ -1517,7 +1517,7 @@ memmove_repeat_emit_encodeBlockAsm4MB:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeBlockAsm4MB_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm4MB_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm4MB_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -1613,7 +1613,7 @@ emit_literal_done_repeat_emit_encodeBlockAsm4MB:
 	// matchLen
 	XORL R11, R11
 	CMPL R8, $0x08
-	JL   matchlen_match4_repeat_extend_encodeBlockAsm4MB
+	JB   matchlen_match4_repeat_extend_encodeBlockAsm4MB
 
 matchlen_loopback_repeat_extend_encodeBlockAsm4MB:
 	MOVQ  (R9)(R11*1), R10
@@ -1636,12 +1636,12 @@ matchlen_loop_repeat_extend_encodeBlockAsm4MB:
 	LEAL -8(R8), R8
 	LEAL 8(R11), R11
 	CMPL R8, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeBlockAsm4MB
+	JAE  matchlen_loopback_repeat_extend_encodeBlockAsm4MB
 	JZ   repeat_extend_forward_end_encodeBlockAsm4MB
 
 matchlen_match4_repeat_extend_encodeBlockAsm4MB:
 	CMPL R8, $0x04
-	JL   matchlen_match2_repeat_extend_encodeBlockAsm4MB
+	JB   matchlen_match2_repeat_extend_encodeBlockAsm4MB
 	MOVL (R9)(R11*1), R10
 	CMPL (BX)(R11*1), R10
 	JNE  matchlen_match2_repeat_extend_encodeBlockAsm4MB
@@ -1650,7 +1650,7 @@ matchlen_match4_repeat_extend_encodeBlockAsm4MB:
 
 matchlen_match2_repeat_extend_encodeBlockAsm4MB:
 	CMPL R8, $0x02
-	JL   matchlen_match1_repeat_extend_encodeBlockAsm4MB
+	JB   matchlen_match1_repeat_extend_encodeBlockAsm4MB
 	MOVW (R9)(R11*1), R10
 	CMPW (BX)(R11*1), R10
 	JNE  matchlen_match1_repeat_extend_encodeBlockAsm4MB
@@ -1659,7 +1659,7 @@ matchlen_match2_repeat_extend_encodeBlockAsm4MB:
 
 matchlen_match1_repeat_extend_encodeBlockAsm4MB:
 	CMPL R8, $0x01
-	JL   repeat_extend_forward_end_encodeBlockAsm4MB
+	JB   repeat_extend_forward_end_encodeBlockAsm4MB
 	MOVB (R9)(R11*1), R10
 	CMPB (BX)(R11*1), R10
 	JNE  repeat_extend_forward_end_encodeBlockAsm4MB
@@ -1677,17 +1677,17 @@ repeat_extend_forward_end_encodeBlockAsm4MB:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_match_repeat_encodeBlockAsm4MB
+	JBE  repeat_two_match_repeat_encodeBlockAsm4MB
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_match_repeat_encodeBlockAsm4MB
+	JAE  cant_repeat_two_offset_match_repeat_encodeBlockAsm4MB
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_match_repeat_encodeBlockAsm4MB
+	JB   repeat_two_offset_match_repeat_encodeBlockAsm4MB
 
 cant_repeat_two_offset_match_repeat_encodeBlockAsm4MB:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_match_repeat_encodeBlockAsm4MB
+	JB   repeat_three_match_repeat_encodeBlockAsm4MB
 	CMPL BX, $0x00010100
-	JLT  repeat_four_match_repeat_encodeBlockAsm4MB
+	JB   repeat_four_match_repeat_encodeBlockAsm4MB
 	LEAL -65536(BX), BX
 	MOVL BX, SI
 	MOVW $0x001d, (AX)
@@ -1732,31 +1732,31 @@ repeat_two_offset_match_repeat_encodeBlockAsm4MB:
 repeat_as_copy_encodeBlockAsm4MB:
 	// emitCopy
 	CMPL SI, $0x00010000
-	JL   two_byte_offset_repeat_as_copy_encodeBlockAsm4MB
+	JB   two_byte_offset_repeat_as_copy_encodeBlockAsm4MB
 	CMPL BX, $0x40
-	JLE  four_bytes_remain_repeat_as_copy_encodeBlockAsm4MB
+	JBE  four_bytes_remain_repeat_as_copy_encodeBlockAsm4MB
 	MOVB $0xff, (AX)
 	MOVL SI, 1(AX)
 	LEAL -64(BX), BX
 	ADDQ $0x05, AX
 	CMPL BX, $0x04
-	JL   four_bytes_remain_repeat_as_copy_encodeBlockAsm4MB
+	JB   four_bytes_remain_repeat_as_copy_encodeBlockAsm4MB
 
 	// emitRepeat
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm4MB_emit_copy
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm4MB_emit_copy
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm4MB_emit_copy
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm4MB_emit_copy
 	CMPL BX, $0x00010100
-	JLT  repeat_four_repeat_as_copy_encodeBlockAsm4MB_emit_copy
+	JB   repeat_four_repeat_as_copy_encodeBlockAsm4MB_emit_copy
 	LEAL -65536(BX), BX
 	MOVL BX, SI
 	MOVW $0x001d, (AX)
@@ -1810,7 +1810,7 @@ four_bytes_remain_repeat_as_copy_encodeBlockAsm4MB:
 
 two_byte_offset_repeat_as_copy_encodeBlockAsm4MB:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm4MB
+	JBE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm4MB
 	CMPL SI, $0x00000800
 	JAE  long_offset_short_repeat_as_copy_encodeBlockAsm4MB
 	MOVL $0x00000001, DI
@@ -1829,17 +1829,17 @@ two_byte_offset_repeat_as_copy_encodeBlockAsm4MB:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
 	CMPL BX, $0x00010100
-	JLT  repeat_four_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_four_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short_2b
 	LEAL -65536(BX), BX
 	MOVL BX, SI
 	MOVW $0x001d, (AX)
@@ -1891,17 +1891,17 @@ long_offset_short_repeat_as_copy_encodeBlockAsm4MB:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
 	CMPL BX, $0x00010100
-	JLT  repeat_four_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
+	JB   repeat_four_repeat_as_copy_encodeBlockAsm4MB_emit_copy_short
 	LEAL -65536(BX), BX
 	MOVL BX, SI
 	MOVW $0x001d, (AX)
@@ -1947,9 +1947,9 @@ two_byte_offset_short_repeat_as_copy_encodeBlockAsm4MB:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm4MB
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm4MB
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm4MB
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm4MB
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -2000,7 +2000,7 @@ candidate_match_encodeBlockAsm4MB:
 
 match_extend_back_loop_encodeBlockAsm4MB:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBlockAsm4MB
+	JBE  match_extend_back_end_encodeBlockAsm4MB
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -2015,7 +2015,7 @@ match_extend_back_end_encodeBlockAsm4MB:
 	SUBL 12(SP), SI
 	LEAQ 4(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBlockAsm4MB
+	JB   match_dst_size_check_encodeBlockAsm4MB
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -2030,11 +2030,11 @@ match_dst_size_check_encodeBlockAsm4MB:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeBlockAsm4MB
+	JB   one_byte_match_emit_encodeBlockAsm4MB
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeBlockAsm4MB
+	JB   two_bytes_match_emit_encodeBlockAsm4MB
 	CMPL DI, $0x00010000
-	JLT  three_bytes_match_emit_encodeBlockAsm4MB
+	JB   three_bytes_match_emit_encodeBlockAsm4MB
 	MOVL DI, R9
 	SHRL $0x10, R9
 	MOVB $0xf8, (AX)
@@ -2054,7 +2054,7 @@ two_bytes_match_emit_encodeBlockAsm4MB:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeBlockAsm4MB
+	JB   memmove_match_emit_encodeBlockAsm4MB
 	JMP  memmove_long_match_emit_encodeBlockAsm4MB
 
 one_byte_match_emit_encodeBlockAsm4MB:
@@ -2067,7 +2067,7 @@ memmove_match_emit_encodeBlockAsm4MB:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeBlockAsm4MB_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeBlockAsm4MB_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeBlockAsm4MB_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -2166,7 +2166,7 @@ match_nolit_loop_encodeBlockAsm4MB:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBlockAsm4MB
+	JB   matchlen_match4_match_nolit_encodeBlockAsm4MB
 
 matchlen_loopback_match_nolit_encodeBlockAsm4MB:
 	MOVQ  (DI)(R9*1), R8
@@ -2189,12 +2189,12 @@ matchlen_loop_match_nolit_encodeBlockAsm4MB:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBlockAsm4MB
+	JAE  matchlen_loopback_match_nolit_encodeBlockAsm4MB
 	JZ   match_nolit_end_encodeBlockAsm4MB
 
 matchlen_match4_match_nolit_encodeBlockAsm4MB:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBlockAsm4MB
+	JB   matchlen_match2_match_nolit_encodeBlockAsm4MB
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeBlockAsm4MB
@@ -2203,7 +2203,7 @@ matchlen_match4_match_nolit_encodeBlockAsm4MB:
 
 matchlen_match2_match_nolit_encodeBlockAsm4MB:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBlockAsm4MB
+	JB   matchlen_match1_match_nolit_encodeBlockAsm4MB
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeBlockAsm4MB
@@ -2212,7 +2212,7 @@ matchlen_match2_match_nolit_encodeBlockAsm4MB:
 
 matchlen_match1_match_nolit_encodeBlockAsm4MB:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeBlockAsm4MB
+	JB   match_nolit_end_encodeBlockAsm4MB
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeBlockAsm4MB
@@ -2226,31 +2226,31 @@ match_nolit_end_encodeBlockAsm4MB:
 
 	// emitCopy
 	CMPL BX, $0x00010000
-	JL   two_byte_offset_match_nolit_encodeBlockAsm4MB
+	JB   two_byte_offset_match_nolit_encodeBlockAsm4MB
 	CMPL R9, $0x40
-	JLE  four_bytes_remain_match_nolit_encodeBlockAsm4MB
+	JBE  four_bytes_remain_match_nolit_encodeBlockAsm4MB
 	MOVB $0xff, (AX)
 	MOVL BX, 1(AX)
 	LEAL -64(R9), R9
 	ADDQ $0x05, AX
 	CMPL R9, $0x04
-	JL   four_bytes_remain_match_nolit_encodeBlockAsm4MB
+	JB   four_bytes_remain_match_nolit_encodeBlockAsm4MB
 
 	// emitRepeat
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm4MB_emit_copy
+	JBE  repeat_two_match_nolit_encodeBlockAsm4MB_emit_copy
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm4MB_emit_copy
+	JB   repeat_three_match_nolit_encodeBlockAsm4MB_emit_copy
 	CMPL R9, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBlockAsm4MB_emit_copy
+	JB   repeat_four_match_nolit_encodeBlockAsm4MB_emit_copy
 	LEAL -65536(R9), R9
 	MOVL R9, BX
 	MOVW $0x001d, (AX)
@@ -2304,7 +2304,7 @@ four_bytes_remain_match_nolit_encodeBlockAsm4MB:
 
 two_byte_offset_match_nolit_encodeBlockAsm4MB:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBlockAsm4MB
+	JBE  two_byte_offset_short_match_nolit_encodeBlockAsm4MB
 	CMPL BX, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBlockAsm4MB
 	MOVL $0x00000001, SI
@@ -2323,17 +2323,17 @@ two_byte_offset_match_nolit_encodeBlockAsm4MB:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
 	CMPL R9, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_four_match_nolit_encodeBlockAsm4MB_emit_copy_short_2b
 	LEAL -65536(R9), R9
 	MOVL R9, BX
 	MOVW $0x001d, (AX)
@@ -2385,17 +2385,17 @@ long_offset_short_match_nolit_encodeBlockAsm4MB:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm4MB_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBlockAsm4MB_emit_copy_short
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm4MB_emit_copy_short:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm4MB_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBlockAsm4MB_emit_copy_short
 	CMPL R9, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBlockAsm4MB_emit_copy_short
+	JB   repeat_four_match_nolit_encodeBlockAsm4MB_emit_copy_short
 	LEAL -65536(R9), R9
 	MOVL R9, BX
 	MOVW $0x001d, (AX)
@@ -2441,9 +2441,9 @@ two_byte_offset_short_match_nolit_encodeBlockAsm4MB:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm4MB
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm4MB
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm4MB
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm4MB
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -2461,10 +2461,10 @@ emit_copy_three_match_nolit_encodeBlockAsm4MB:
 
 match_nolit_emitcopy_end_encodeBlockAsm4MB:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBlockAsm4MB
+	JAE  emit_remainder_encodeBlockAsm4MB
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBlockAsm4MB
+	JB   match_nolit_dst_ok_encodeBlockAsm4MB
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -2494,7 +2494,7 @@ emit_remainder_encodeBlockAsm4MB:
 	SUBL 12(SP), CX
 	LEAQ 4(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBlockAsm4MB
+	JB   emit_remainder_ok_encodeBlockAsm4MB
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -2509,11 +2509,11 @@ emit_remainder_ok_encodeBlockAsm4MB:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBlockAsm4MB
+	JB   one_byte_emit_remainder_encodeBlockAsm4MB
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBlockAsm4MB
+	JB   two_bytes_emit_remainder_encodeBlockAsm4MB
 	CMPL DX, $0x00010000
-	JLT  three_bytes_emit_remainder_encodeBlockAsm4MB
+	JB   three_bytes_emit_remainder_encodeBlockAsm4MB
 	MOVL DX, BX
 	SHRL $0x10, BX
 	MOVB $0xf8, (AX)
@@ -2533,7 +2533,7 @@ two_bytes_emit_remainder_encodeBlockAsm4MB:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBlockAsm4MB
+	JB   memmove_emit_remainder_encodeBlockAsm4MB
 	JMP  memmove_long_emit_remainder_encodeBlockAsm4MB
 
 one_byte_emit_remainder_encodeBlockAsm4MB:
@@ -2696,7 +2696,7 @@ search_loop_encodeBlockAsm12B:
 	SHRL  $0x05, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBlockAsm12B
+	JAE   emit_remainder_encodeBlockAsm12B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x000000cf1bbcdcbb, R8
@@ -2734,7 +2734,7 @@ search_loop_encodeBlockAsm12B:
 
 repeat_extend_back_loop_encodeBlockAsm12B:
 	CMPL SI, DI
-	JLE  repeat_extend_back_end_encodeBlockAsm12B
+	JBE  repeat_extend_back_end_encodeBlockAsm12B
 	MOVB -1(DX)(BX*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -2753,9 +2753,12 @@ repeat_extend_back_end_encodeBlockAsm12B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeBlockAsm12B
+	JB   one_byte_repeat_emit_encodeBlockAsm12B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeBlockAsm12B
+	JB   two_bytes_repeat_emit_encodeBlockAsm12B
+	JB   three_bytes_repeat_emit_encodeBlockAsm12B
+
+three_bytes_repeat_emit_encodeBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -2766,7 +2769,7 @@ two_bytes_repeat_emit_encodeBlockAsm12B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeBlockAsm12B
+	JB   memmove_repeat_emit_encodeBlockAsm12B
 	JMP  memmove_long_repeat_emit_encodeBlockAsm12B
 
 one_byte_repeat_emit_encodeBlockAsm12B:
@@ -2779,7 +2782,7 @@ memmove_repeat_emit_encodeBlockAsm12B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeBlockAsm12B_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm12B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm12B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -2875,7 +2878,7 @@ emit_literal_done_repeat_emit_encodeBlockAsm12B:
 	// matchLen
 	XORL R11, R11
 	CMPL R8, $0x08
-	JL   matchlen_match4_repeat_extend_encodeBlockAsm12B
+	JB   matchlen_match4_repeat_extend_encodeBlockAsm12B
 
 matchlen_loopback_repeat_extend_encodeBlockAsm12B:
 	MOVQ  (R9)(R11*1), R10
@@ -2898,12 +2901,12 @@ matchlen_loop_repeat_extend_encodeBlockAsm12B:
 	LEAL -8(R8), R8
 	LEAL 8(R11), R11
 	CMPL R8, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeBlockAsm12B
+	JAE  matchlen_loopback_repeat_extend_encodeBlockAsm12B
 	JZ   repeat_extend_forward_end_encodeBlockAsm12B
 
 matchlen_match4_repeat_extend_encodeBlockAsm12B:
 	CMPL R8, $0x04
-	JL   matchlen_match2_repeat_extend_encodeBlockAsm12B
+	JB   matchlen_match2_repeat_extend_encodeBlockAsm12B
 	MOVL (R9)(R11*1), R10
 	CMPL (BX)(R11*1), R10
 	JNE  matchlen_match2_repeat_extend_encodeBlockAsm12B
@@ -2912,7 +2915,7 @@ matchlen_match4_repeat_extend_encodeBlockAsm12B:
 
 matchlen_match2_repeat_extend_encodeBlockAsm12B:
 	CMPL R8, $0x02
-	JL   matchlen_match1_repeat_extend_encodeBlockAsm12B
+	JB   matchlen_match1_repeat_extend_encodeBlockAsm12B
 	MOVW (R9)(R11*1), R10
 	CMPW (BX)(R11*1), R10
 	JNE  matchlen_match1_repeat_extend_encodeBlockAsm12B
@@ -2921,7 +2924,7 @@ matchlen_match2_repeat_extend_encodeBlockAsm12B:
 
 matchlen_match1_repeat_extend_encodeBlockAsm12B:
 	CMPL R8, $0x01
-	JL   repeat_extend_forward_end_encodeBlockAsm12B
+	JB   repeat_extend_forward_end_encodeBlockAsm12B
 	MOVB (R9)(R11*1), R10
 	CMPB (BX)(R11*1), R10
 	JNE  repeat_extend_forward_end_encodeBlockAsm12B
@@ -2939,15 +2942,15 @@ repeat_extend_forward_end_encodeBlockAsm12B:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_match_repeat_encodeBlockAsm12B
+	JBE  repeat_two_match_repeat_encodeBlockAsm12B
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_match_repeat_encodeBlockAsm12B
+	JAE  cant_repeat_two_offset_match_repeat_encodeBlockAsm12B
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_match_repeat_encodeBlockAsm12B
+	JB   repeat_two_offset_match_repeat_encodeBlockAsm12B
 
 cant_repeat_two_offset_match_repeat_encodeBlockAsm12B:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_match_repeat_encodeBlockAsm12B
+	JB   repeat_three_match_repeat_encodeBlockAsm12B
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -2982,7 +2985,7 @@ repeat_two_offset_match_repeat_encodeBlockAsm12B:
 repeat_as_copy_encodeBlockAsm12B:
 	// emitCopy
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm12B
+	JBE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm12B
 	CMPL SI, $0x00000800
 	JAE  long_offset_short_repeat_as_copy_encodeBlockAsm12B
 	MOVL $0x00000001, DI
@@ -3001,15 +3004,15 @@ repeat_as_copy_encodeBlockAsm12B:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm12B_emit_copy_short_2b
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -3051,15 +3054,15 @@ long_offset_short_repeat_as_copy_encodeBlockAsm12B:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm12B_emit_copy_short:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm12B_emit_copy_short
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -3095,9 +3098,9 @@ two_byte_offset_short_repeat_as_copy_encodeBlockAsm12B:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm12B
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm12B
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm12B
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm12B
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -3148,7 +3151,7 @@ candidate_match_encodeBlockAsm12B:
 
 match_extend_back_loop_encodeBlockAsm12B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBlockAsm12B
+	JBE  match_extend_back_end_encodeBlockAsm12B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -3163,7 +3166,7 @@ match_extend_back_end_encodeBlockAsm12B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBlockAsm12B
+	JB   match_dst_size_check_encodeBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -3178,9 +3181,12 @@ match_dst_size_check_encodeBlockAsm12B:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeBlockAsm12B
+	JB   one_byte_match_emit_encodeBlockAsm12B
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeBlockAsm12B
+	JB   two_bytes_match_emit_encodeBlockAsm12B
+	JB   three_bytes_match_emit_encodeBlockAsm12B
+
+three_bytes_match_emit_encodeBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW DI, 1(AX)
 	ADDQ $0x03, AX
@@ -3191,7 +3197,7 @@ two_bytes_match_emit_encodeBlockAsm12B:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeBlockAsm12B
+	JB   memmove_match_emit_encodeBlockAsm12B
 	JMP  memmove_long_match_emit_encodeBlockAsm12B
 
 one_byte_match_emit_encodeBlockAsm12B:
@@ -3204,7 +3210,7 @@ memmove_match_emit_encodeBlockAsm12B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeBlockAsm12B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeBlockAsm12B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeBlockAsm12B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -3303,7 +3309,7 @@ match_nolit_loop_encodeBlockAsm12B:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBlockAsm12B
+	JB   matchlen_match4_match_nolit_encodeBlockAsm12B
 
 matchlen_loopback_match_nolit_encodeBlockAsm12B:
 	MOVQ  (DI)(R9*1), R8
@@ -3326,12 +3332,12 @@ matchlen_loop_match_nolit_encodeBlockAsm12B:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBlockAsm12B
+	JAE  matchlen_loopback_match_nolit_encodeBlockAsm12B
 	JZ   match_nolit_end_encodeBlockAsm12B
 
 matchlen_match4_match_nolit_encodeBlockAsm12B:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBlockAsm12B
+	JB   matchlen_match2_match_nolit_encodeBlockAsm12B
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeBlockAsm12B
@@ -3340,7 +3346,7 @@ matchlen_match4_match_nolit_encodeBlockAsm12B:
 
 matchlen_match2_match_nolit_encodeBlockAsm12B:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBlockAsm12B
+	JB   matchlen_match1_match_nolit_encodeBlockAsm12B
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeBlockAsm12B
@@ -3349,7 +3355,7 @@ matchlen_match2_match_nolit_encodeBlockAsm12B:
 
 matchlen_match1_match_nolit_encodeBlockAsm12B:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeBlockAsm12B
+	JB   match_nolit_end_encodeBlockAsm12B
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeBlockAsm12B
@@ -3363,7 +3369,7 @@ match_nolit_end_encodeBlockAsm12B:
 
 	// emitCopy
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBlockAsm12B
+	JBE  two_byte_offset_short_match_nolit_encodeBlockAsm12B
 	CMPL BX, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBlockAsm12B
 	MOVL $0x00000001, SI
@@ -3382,15 +3388,15 @@ match_nolit_end_encodeBlockAsm12B:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short_2b:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBlockAsm12B_emit_copy_short_2b
 	LEAL -256(R9), R9
 	MOVW $0x0019, (AX)
 	MOVW R9, 2(AX)
@@ -3432,15 +3438,15 @@ long_offset_short_match_nolit_encodeBlockAsm12B:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm12B_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBlockAsm12B_emit_copy_short
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm12B_emit_copy_short:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm12B_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBlockAsm12B_emit_copy_short
 	LEAL -256(R9), R9
 	MOVW $0x0019, (AX)
 	MOVW R9, 2(AX)
@@ -3476,9 +3482,9 @@ two_byte_offset_short_match_nolit_encodeBlockAsm12B:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm12B
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm12B
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -3496,10 +3502,10 @@ emit_copy_three_match_nolit_encodeBlockAsm12B:
 
 match_nolit_emitcopy_end_encodeBlockAsm12B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBlockAsm12B
+	JAE  emit_remainder_encodeBlockAsm12B
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBlockAsm12B
+	JB   match_nolit_dst_ok_encodeBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -3529,7 +3535,7 @@ emit_remainder_encodeBlockAsm12B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBlockAsm12B
+	JB   emit_remainder_ok_encodeBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -3544,9 +3550,12 @@ emit_remainder_ok_encodeBlockAsm12B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBlockAsm12B
+	JB   one_byte_emit_remainder_encodeBlockAsm12B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBlockAsm12B
+	JB   two_bytes_emit_remainder_encodeBlockAsm12B
+	JB   three_bytes_emit_remainder_encodeBlockAsm12B
+
+three_bytes_emit_remainder_encodeBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -3557,7 +3566,7 @@ two_bytes_emit_remainder_encodeBlockAsm12B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBlockAsm12B
+	JB   memmove_emit_remainder_encodeBlockAsm12B
 	JMP  memmove_long_emit_remainder_encodeBlockAsm12B
 
 one_byte_emit_remainder_encodeBlockAsm12B:
@@ -3720,7 +3729,7 @@ search_loop_encodeBlockAsm10B:
 	SHRL  $0x05, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBlockAsm10B
+	JAE   emit_remainder_encodeBlockAsm10B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x9e3779b1, R8
@@ -3758,7 +3767,7 @@ search_loop_encodeBlockAsm10B:
 
 repeat_extend_back_loop_encodeBlockAsm10B:
 	CMPL SI, DI
-	JLE  repeat_extend_back_end_encodeBlockAsm10B
+	JBE  repeat_extend_back_end_encodeBlockAsm10B
 	MOVB -1(DX)(BX*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -3777,9 +3786,12 @@ repeat_extend_back_end_encodeBlockAsm10B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeBlockAsm10B
+	JB   one_byte_repeat_emit_encodeBlockAsm10B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeBlockAsm10B
+	JB   two_bytes_repeat_emit_encodeBlockAsm10B
+	JB   three_bytes_repeat_emit_encodeBlockAsm10B
+
+three_bytes_repeat_emit_encodeBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -3790,7 +3802,7 @@ two_bytes_repeat_emit_encodeBlockAsm10B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeBlockAsm10B
+	JB   memmove_repeat_emit_encodeBlockAsm10B
 	JMP  memmove_long_repeat_emit_encodeBlockAsm10B
 
 one_byte_repeat_emit_encodeBlockAsm10B:
@@ -3803,7 +3815,7 @@ memmove_repeat_emit_encodeBlockAsm10B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeBlockAsm10B_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm10B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm10B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -3899,7 +3911,7 @@ emit_literal_done_repeat_emit_encodeBlockAsm10B:
 	// matchLen
 	XORL R11, R11
 	CMPL R8, $0x08
-	JL   matchlen_match4_repeat_extend_encodeBlockAsm10B
+	JB   matchlen_match4_repeat_extend_encodeBlockAsm10B
 
 matchlen_loopback_repeat_extend_encodeBlockAsm10B:
 	MOVQ  (R9)(R11*1), R10
@@ -3922,12 +3934,12 @@ matchlen_loop_repeat_extend_encodeBlockAsm10B:
 	LEAL -8(R8), R8
 	LEAL 8(R11), R11
 	CMPL R8, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeBlockAsm10B
+	JAE  matchlen_loopback_repeat_extend_encodeBlockAsm10B
 	JZ   repeat_extend_forward_end_encodeBlockAsm10B
 
 matchlen_match4_repeat_extend_encodeBlockAsm10B:
 	CMPL R8, $0x04
-	JL   matchlen_match2_repeat_extend_encodeBlockAsm10B
+	JB   matchlen_match2_repeat_extend_encodeBlockAsm10B
 	MOVL (R9)(R11*1), R10
 	CMPL (BX)(R11*1), R10
 	JNE  matchlen_match2_repeat_extend_encodeBlockAsm10B
@@ -3936,7 +3948,7 @@ matchlen_match4_repeat_extend_encodeBlockAsm10B:
 
 matchlen_match2_repeat_extend_encodeBlockAsm10B:
 	CMPL R8, $0x02
-	JL   matchlen_match1_repeat_extend_encodeBlockAsm10B
+	JB   matchlen_match1_repeat_extend_encodeBlockAsm10B
 	MOVW (R9)(R11*1), R10
 	CMPW (BX)(R11*1), R10
 	JNE  matchlen_match1_repeat_extend_encodeBlockAsm10B
@@ -3945,7 +3957,7 @@ matchlen_match2_repeat_extend_encodeBlockAsm10B:
 
 matchlen_match1_repeat_extend_encodeBlockAsm10B:
 	CMPL R8, $0x01
-	JL   repeat_extend_forward_end_encodeBlockAsm10B
+	JB   repeat_extend_forward_end_encodeBlockAsm10B
 	MOVB (R9)(R11*1), R10
 	CMPB (BX)(R11*1), R10
 	JNE  repeat_extend_forward_end_encodeBlockAsm10B
@@ -3963,15 +3975,15 @@ repeat_extend_forward_end_encodeBlockAsm10B:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_match_repeat_encodeBlockAsm10B
+	JBE  repeat_two_match_repeat_encodeBlockAsm10B
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_match_repeat_encodeBlockAsm10B
+	JAE  cant_repeat_two_offset_match_repeat_encodeBlockAsm10B
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_match_repeat_encodeBlockAsm10B
+	JB   repeat_two_offset_match_repeat_encodeBlockAsm10B
 
 cant_repeat_two_offset_match_repeat_encodeBlockAsm10B:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_match_repeat_encodeBlockAsm10B
+	JB   repeat_three_match_repeat_encodeBlockAsm10B
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -4006,7 +4018,7 @@ repeat_two_offset_match_repeat_encodeBlockAsm10B:
 repeat_as_copy_encodeBlockAsm10B:
 	// emitCopy
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm10B
+	JBE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm10B
 	CMPL SI, $0x00000800
 	JAE  long_offset_short_repeat_as_copy_encodeBlockAsm10B
 	MOVL $0x00000001, DI
@@ -4025,15 +4037,15 @@ repeat_as_copy_encodeBlockAsm10B:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm10B_emit_copy_short_2b
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -4075,15 +4087,15 @@ long_offset_short_repeat_as_copy_encodeBlockAsm10B:
 	MOVL BX, DI
 	LEAL -4(BX), BX
 	CMPL DI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
 	CMPL DI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
 	CMPL SI, $0x00000800
-	JLT  repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
+	JB   repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm10B_emit_copy_short:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm10B_emit_copy_short
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -4119,9 +4131,9 @@ two_byte_offset_short_repeat_as_copy_encodeBlockAsm10B:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm10B
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm10B
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm10B
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm10B
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -4172,7 +4184,7 @@ candidate_match_encodeBlockAsm10B:
 
 match_extend_back_loop_encodeBlockAsm10B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBlockAsm10B
+	JBE  match_extend_back_end_encodeBlockAsm10B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -4187,7 +4199,7 @@ match_extend_back_end_encodeBlockAsm10B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBlockAsm10B
+	JB   match_dst_size_check_encodeBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -4202,9 +4214,12 @@ match_dst_size_check_encodeBlockAsm10B:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeBlockAsm10B
+	JB   one_byte_match_emit_encodeBlockAsm10B
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeBlockAsm10B
+	JB   two_bytes_match_emit_encodeBlockAsm10B
+	JB   three_bytes_match_emit_encodeBlockAsm10B
+
+three_bytes_match_emit_encodeBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW DI, 1(AX)
 	ADDQ $0x03, AX
@@ -4215,7 +4230,7 @@ two_bytes_match_emit_encodeBlockAsm10B:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeBlockAsm10B
+	JB   memmove_match_emit_encodeBlockAsm10B
 	JMP  memmove_long_match_emit_encodeBlockAsm10B
 
 one_byte_match_emit_encodeBlockAsm10B:
@@ -4228,7 +4243,7 @@ memmove_match_emit_encodeBlockAsm10B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeBlockAsm10B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeBlockAsm10B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeBlockAsm10B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -4327,7 +4342,7 @@ match_nolit_loop_encodeBlockAsm10B:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBlockAsm10B
+	JB   matchlen_match4_match_nolit_encodeBlockAsm10B
 
 matchlen_loopback_match_nolit_encodeBlockAsm10B:
 	MOVQ  (DI)(R9*1), R8
@@ -4350,12 +4365,12 @@ matchlen_loop_match_nolit_encodeBlockAsm10B:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBlockAsm10B
+	JAE  matchlen_loopback_match_nolit_encodeBlockAsm10B
 	JZ   match_nolit_end_encodeBlockAsm10B
 
 matchlen_match4_match_nolit_encodeBlockAsm10B:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBlockAsm10B
+	JB   matchlen_match2_match_nolit_encodeBlockAsm10B
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeBlockAsm10B
@@ -4364,7 +4379,7 @@ matchlen_match4_match_nolit_encodeBlockAsm10B:
 
 matchlen_match2_match_nolit_encodeBlockAsm10B:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBlockAsm10B
+	JB   matchlen_match1_match_nolit_encodeBlockAsm10B
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeBlockAsm10B
@@ -4373,7 +4388,7 @@ matchlen_match2_match_nolit_encodeBlockAsm10B:
 
 matchlen_match1_match_nolit_encodeBlockAsm10B:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeBlockAsm10B
+	JB   match_nolit_end_encodeBlockAsm10B
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeBlockAsm10B
@@ -4387,7 +4402,7 @@ match_nolit_end_encodeBlockAsm10B:
 
 	// emitCopy
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBlockAsm10B
+	JBE  two_byte_offset_short_match_nolit_encodeBlockAsm10B
 	CMPL BX, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBlockAsm10B
 	MOVL $0x00000001, SI
@@ -4406,15 +4421,15 @@ match_nolit_end_encodeBlockAsm10B:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short_2b:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBlockAsm10B_emit_copy_short_2b
 	LEAL -256(R9), R9
 	MOVW $0x0019, (AX)
 	MOVW R9, 2(AX)
@@ -4456,15 +4471,15 @@ long_offset_short_match_nolit_encodeBlockAsm10B:
 	MOVL R9, SI
 	LEAL -4(R9), R9
 	CMPL SI, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm10B_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBlockAsm10B_emit_copy_short
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short
 	CMPL BX, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm10B_emit_copy_short:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm10B_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBlockAsm10B_emit_copy_short
 	LEAL -256(R9), R9
 	MOVW $0x0019, (AX)
 	MOVW R9, 2(AX)
@@ -4500,9 +4515,9 @@ two_byte_offset_short_match_nolit_encodeBlockAsm10B:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm10B
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm10B
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -4520,10 +4535,10 @@ emit_copy_three_match_nolit_encodeBlockAsm10B:
 
 match_nolit_emitcopy_end_encodeBlockAsm10B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBlockAsm10B
+	JAE  emit_remainder_encodeBlockAsm10B
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBlockAsm10B
+	JB   match_nolit_dst_ok_encodeBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -4553,7 +4568,7 @@ emit_remainder_encodeBlockAsm10B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBlockAsm10B
+	JB   emit_remainder_ok_encodeBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -4568,9 +4583,12 @@ emit_remainder_ok_encodeBlockAsm10B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBlockAsm10B
+	JB   one_byte_emit_remainder_encodeBlockAsm10B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBlockAsm10B
+	JB   two_bytes_emit_remainder_encodeBlockAsm10B
+	JB   three_bytes_emit_remainder_encodeBlockAsm10B
+
+three_bytes_emit_remainder_encodeBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -4581,7 +4599,7 @@ two_bytes_emit_remainder_encodeBlockAsm10B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBlockAsm10B
+	JB   memmove_emit_remainder_encodeBlockAsm10B
 	JMP  memmove_long_emit_remainder_encodeBlockAsm10B
 
 one_byte_emit_remainder_encodeBlockAsm10B:
@@ -4744,7 +4762,7 @@ search_loop_encodeBlockAsm8B:
 	SHRL  $0x04, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBlockAsm8B
+	JAE   emit_remainder_encodeBlockAsm8B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x9e3779b1, R8
@@ -4782,7 +4800,7 @@ search_loop_encodeBlockAsm8B:
 
 repeat_extend_back_loop_encodeBlockAsm8B:
 	CMPL SI, DI
-	JLE  repeat_extend_back_end_encodeBlockAsm8B
+	JBE  repeat_extend_back_end_encodeBlockAsm8B
 	MOVB -1(DX)(BX*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -4801,9 +4819,12 @@ repeat_extend_back_end_encodeBlockAsm8B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeBlockAsm8B
+	JB   one_byte_repeat_emit_encodeBlockAsm8B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeBlockAsm8B
+	JB   two_bytes_repeat_emit_encodeBlockAsm8B
+	JB   three_bytes_repeat_emit_encodeBlockAsm8B
+
+three_bytes_repeat_emit_encodeBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -4814,7 +4835,7 @@ two_bytes_repeat_emit_encodeBlockAsm8B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeBlockAsm8B
+	JB   memmove_repeat_emit_encodeBlockAsm8B
 	JMP  memmove_long_repeat_emit_encodeBlockAsm8B
 
 one_byte_repeat_emit_encodeBlockAsm8B:
@@ -4827,7 +4848,7 @@ memmove_repeat_emit_encodeBlockAsm8B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeBlockAsm8B_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm8B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeBlockAsm8B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -4923,7 +4944,7 @@ emit_literal_done_repeat_emit_encodeBlockAsm8B:
 	// matchLen
 	XORL R11, R11
 	CMPL R8, $0x08
-	JL   matchlen_match4_repeat_extend_encodeBlockAsm8B
+	JB   matchlen_match4_repeat_extend_encodeBlockAsm8B
 
 matchlen_loopback_repeat_extend_encodeBlockAsm8B:
 	MOVQ  (R9)(R11*1), R10
@@ -4946,12 +4967,12 @@ matchlen_loop_repeat_extend_encodeBlockAsm8B:
 	LEAL -8(R8), R8
 	LEAL 8(R11), R11
 	CMPL R8, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeBlockAsm8B
+	JAE  matchlen_loopback_repeat_extend_encodeBlockAsm8B
 	JZ   repeat_extend_forward_end_encodeBlockAsm8B
 
 matchlen_match4_repeat_extend_encodeBlockAsm8B:
 	CMPL R8, $0x04
-	JL   matchlen_match2_repeat_extend_encodeBlockAsm8B
+	JB   matchlen_match2_repeat_extend_encodeBlockAsm8B
 	MOVL (R9)(R11*1), R10
 	CMPL (BX)(R11*1), R10
 	JNE  matchlen_match2_repeat_extend_encodeBlockAsm8B
@@ -4960,7 +4981,7 @@ matchlen_match4_repeat_extend_encodeBlockAsm8B:
 
 matchlen_match2_repeat_extend_encodeBlockAsm8B:
 	CMPL R8, $0x02
-	JL   matchlen_match1_repeat_extend_encodeBlockAsm8B
+	JB   matchlen_match1_repeat_extend_encodeBlockAsm8B
 	MOVW (R9)(R11*1), R10
 	CMPW (BX)(R11*1), R10
 	JNE  matchlen_match1_repeat_extend_encodeBlockAsm8B
@@ -4969,7 +4990,7 @@ matchlen_match2_repeat_extend_encodeBlockAsm8B:
 
 matchlen_match1_repeat_extend_encodeBlockAsm8B:
 	CMPL R8, $0x01
-	JL   repeat_extend_forward_end_encodeBlockAsm8B
+	JB   repeat_extend_forward_end_encodeBlockAsm8B
 	MOVB (R9)(R11*1), R10
 	CMPB (BX)(R11*1), R10
 	JNE  repeat_extend_forward_end_encodeBlockAsm8B
@@ -4987,13 +5008,13 @@ repeat_extend_forward_end_encodeBlockAsm8B:
 	MOVL BX, SI
 	LEAL -4(BX), BX
 	CMPL SI, $0x08
-	JLE  repeat_two_match_repeat_encodeBlockAsm8B
+	JBE  repeat_two_match_repeat_encodeBlockAsm8B
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_match_repeat_encodeBlockAsm8B
+	JAE  cant_repeat_two_offset_match_repeat_encodeBlockAsm8B
 
 cant_repeat_two_offset_match_repeat_encodeBlockAsm8B:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_match_repeat_encodeBlockAsm8B
+	JB   repeat_three_match_repeat_encodeBlockAsm8B
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -5026,7 +5047,7 @@ repeat_two_match_repeat_encodeBlockAsm8B:
 repeat_as_copy_encodeBlockAsm8B:
 	// emitCopy
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm8B
+	JBE  two_byte_offset_short_repeat_as_copy_encodeBlockAsm8B
 	CMPL SI, $0x00000800
 	JAE  long_offset_short_repeat_as_copy_encodeBlockAsm8B
 	MOVL $0x00000001, DI
@@ -5045,13 +5066,13 @@ repeat_as_copy_encodeBlockAsm8B:
 	MOVL BX, SI
 	LEAL -4(BX), BX
 	CMPL SI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm8B_emit_copy_short_2b
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm8B_emit_copy_short_2b
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm8B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm8B_emit_copy_short_2b
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm8B_emit_copy_short_2b:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm8B_emit_copy_short_2b
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm8B_emit_copy_short_2b
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -5091,13 +5112,13 @@ long_offset_short_repeat_as_copy_encodeBlockAsm8B:
 	MOVL BX, SI
 	LEAL -4(BX), BX
 	CMPL SI, $0x08
-	JLE  repeat_two_repeat_as_copy_encodeBlockAsm8B_emit_copy_short
+	JBE  repeat_two_repeat_as_copy_encodeBlockAsm8B_emit_copy_short
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm8B_emit_copy_short
+	JAE  cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm8B_emit_copy_short
 
 cant_repeat_two_offset_repeat_as_copy_encodeBlockAsm8B_emit_copy_short:
 	CMPL BX, $0x00000104
-	JLT  repeat_three_repeat_as_copy_encodeBlockAsm8B_emit_copy_short
+	JB   repeat_three_repeat_as_copy_encodeBlockAsm8B_emit_copy_short
 	LEAL -256(BX), BX
 	MOVW $0x0019, (AX)
 	MOVW BX, 2(AX)
@@ -5131,7 +5152,7 @@ two_byte_offset_short_repeat_as_copy_encodeBlockAsm8B:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeBlockAsm8B
+	JAE  emit_copy_three_repeat_as_copy_encodeBlockAsm8B
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -5182,7 +5203,7 @@ candidate_match_encodeBlockAsm8B:
 
 match_extend_back_loop_encodeBlockAsm8B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBlockAsm8B
+	JBE  match_extend_back_end_encodeBlockAsm8B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -5197,7 +5218,7 @@ match_extend_back_end_encodeBlockAsm8B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBlockAsm8B
+	JB   match_dst_size_check_encodeBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -5212,9 +5233,12 @@ match_dst_size_check_encodeBlockAsm8B:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeBlockAsm8B
+	JB   one_byte_match_emit_encodeBlockAsm8B
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeBlockAsm8B
+	JB   two_bytes_match_emit_encodeBlockAsm8B
+	JB   three_bytes_match_emit_encodeBlockAsm8B
+
+three_bytes_match_emit_encodeBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW DI, 1(AX)
 	ADDQ $0x03, AX
@@ -5225,7 +5249,7 @@ two_bytes_match_emit_encodeBlockAsm8B:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeBlockAsm8B
+	JB   memmove_match_emit_encodeBlockAsm8B
 	JMP  memmove_long_match_emit_encodeBlockAsm8B
 
 one_byte_match_emit_encodeBlockAsm8B:
@@ -5238,7 +5262,7 @@ memmove_match_emit_encodeBlockAsm8B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeBlockAsm8B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeBlockAsm8B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeBlockAsm8B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -5337,7 +5361,7 @@ match_nolit_loop_encodeBlockAsm8B:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBlockAsm8B
+	JB   matchlen_match4_match_nolit_encodeBlockAsm8B
 
 matchlen_loopback_match_nolit_encodeBlockAsm8B:
 	MOVQ  (DI)(R9*1), R8
@@ -5360,12 +5384,12 @@ matchlen_loop_match_nolit_encodeBlockAsm8B:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBlockAsm8B
+	JAE  matchlen_loopback_match_nolit_encodeBlockAsm8B
 	JZ   match_nolit_end_encodeBlockAsm8B
 
 matchlen_match4_match_nolit_encodeBlockAsm8B:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBlockAsm8B
+	JB   matchlen_match2_match_nolit_encodeBlockAsm8B
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeBlockAsm8B
@@ -5374,7 +5398,7 @@ matchlen_match4_match_nolit_encodeBlockAsm8B:
 
 matchlen_match2_match_nolit_encodeBlockAsm8B:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBlockAsm8B
+	JB   matchlen_match1_match_nolit_encodeBlockAsm8B
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeBlockAsm8B
@@ -5383,7 +5407,7 @@ matchlen_match2_match_nolit_encodeBlockAsm8B:
 
 matchlen_match1_match_nolit_encodeBlockAsm8B:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeBlockAsm8B
+	JB   match_nolit_end_encodeBlockAsm8B
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeBlockAsm8B
@@ -5397,7 +5421,7 @@ match_nolit_end_encodeBlockAsm8B:
 
 	// emitCopy
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBlockAsm8B
+	JBE  two_byte_offset_short_match_nolit_encodeBlockAsm8B
 	CMPL BX, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBlockAsm8B
 	MOVL $0x00000001, SI
@@ -5416,13 +5440,13 @@ match_nolit_end_encodeBlockAsm8B:
 	MOVL R9, BX
 	LEAL -4(R9), R9
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm8B_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBlockAsm8B_emit_copy_short_2b
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm8B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm8B_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm8B_emit_copy_short_2b:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm8B_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBlockAsm8B_emit_copy_short_2b
 	LEAL -256(R9), R9
 	MOVW $0x0019, (AX)
 	MOVW R9, 2(AX)
@@ -5462,13 +5486,13 @@ long_offset_short_match_nolit_encodeBlockAsm8B:
 	MOVL R9, BX
 	LEAL -4(R9), R9
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBlockAsm8B_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBlockAsm8B_emit_copy_short
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBlockAsm8B_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBlockAsm8B_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBlockAsm8B_emit_copy_short:
 	CMPL R9, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBlockAsm8B_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBlockAsm8B_emit_copy_short
 	LEAL -256(R9), R9
 	MOVW $0x0019, (AX)
 	MOVW R9, 2(AX)
@@ -5502,7 +5526,7 @@ two_byte_offset_short_match_nolit_encodeBlockAsm8B:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBlockAsm8B
+	JAE  emit_copy_three_match_nolit_encodeBlockAsm8B
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -5520,10 +5544,10 @@ emit_copy_three_match_nolit_encodeBlockAsm8B:
 
 match_nolit_emitcopy_end_encodeBlockAsm8B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBlockAsm8B
+	JAE  emit_remainder_encodeBlockAsm8B
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBlockAsm8B
+	JB   match_nolit_dst_ok_encodeBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -5553,7 +5577,7 @@ emit_remainder_encodeBlockAsm8B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBlockAsm8B
+	JB   emit_remainder_ok_encodeBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -5568,9 +5592,12 @@ emit_remainder_ok_encodeBlockAsm8B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBlockAsm8B
+	JB   one_byte_emit_remainder_encodeBlockAsm8B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBlockAsm8B
+	JB   two_bytes_emit_remainder_encodeBlockAsm8B
+	JB   three_bytes_emit_remainder_encodeBlockAsm8B
+
+three_bytes_emit_remainder_encodeBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -5581,7 +5608,7 @@ two_bytes_emit_remainder_encodeBlockAsm8B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBlockAsm8B
+	JB   memmove_emit_remainder_encodeBlockAsm8B
 	JMP  memmove_long_emit_remainder_encodeBlockAsm8B
 
 one_byte_emit_remainder_encodeBlockAsm8B:
@@ -5743,7 +5770,7 @@ search_loop_encodeBetterBlockAsm:
 	SUBL 12(SP), BX
 	SHRL $0x07, BX
 	CMPL BX, $0x63
-	JLE  check_maxskip_ok_encodeBetterBlockAsm
+	JBE  check_maxskip_ok_encodeBetterBlockAsm
 	LEAL 100(CX), BX
 	JMP  check_maxskip_cont_encodeBetterBlockAsm
 
@@ -5752,7 +5779,7 @@ check_maxskip_ok_encodeBetterBlockAsm:
 
 check_maxskip_cont_encodeBetterBlockAsm:
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBetterBlockAsm
+	JAE   emit_remainder_encodeBetterBlockAsm
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x00cf1bbcdcbfa563, R8
@@ -5807,7 +5834,7 @@ candidate_match_encodeBetterBlockAsm:
 
 match_extend_back_loop_encodeBetterBlockAsm:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBetterBlockAsm
+	JBE  match_extend_back_end_encodeBetterBlockAsm
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -5822,7 +5849,7 @@ match_extend_back_end_encodeBetterBlockAsm:
 	SUBL 12(SP), SI
 	LEAQ 5(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBetterBlockAsm
+	JB   match_dst_size_check_encodeBetterBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -5838,7 +5865,7 @@ match_dst_size_check_encodeBetterBlockAsm:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBetterBlockAsm
+	JB   matchlen_match4_match_nolit_encodeBetterBlockAsm
 
 matchlen_loopback_match_nolit_encodeBetterBlockAsm:
 	MOVQ  (R8)(R11*1), R10
@@ -5861,12 +5888,12 @@ matchlen_loop_match_nolit_encodeBetterBlockAsm:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBetterBlockAsm
+	JAE  matchlen_loopback_match_nolit_encodeBetterBlockAsm
 	JZ   match_nolit_end_encodeBetterBlockAsm
 
 matchlen_match4_match_nolit_encodeBetterBlockAsm:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBetterBlockAsm
+	JB   matchlen_match2_match_nolit_encodeBetterBlockAsm
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeBetterBlockAsm
@@ -5875,7 +5902,7 @@ matchlen_match4_match_nolit_encodeBetterBlockAsm:
 
 matchlen_match2_match_nolit_encodeBetterBlockAsm:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBetterBlockAsm
+	JB   matchlen_match1_match_nolit_encodeBetterBlockAsm
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeBetterBlockAsm
@@ -5884,7 +5911,7 @@ matchlen_match2_match_nolit_encodeBetterBlockAsm:
 
 matchlen_match1_match_nolit_encodeBetterBlockAsm:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeBetterBlockAsm
+	JB   match_nolit_end_encodeBetterBlockAsm
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeBetterBlockAsm
@@ -5898,9 +5925,9 @@ match_nolit_end_encodeBetterBlockAsm:
 	CMPL 16(SP), DI
 	JEQ  match_is_repeat_encodeBetterBlockAsm
 	CMPL R11, $0x01
-	JG   match_length_ok_encodeBetterBlockAsm
+	JA   match_length_ok_encodeBetterBlockAsm
 	CMPL DI, $0x0000ffff
-	JLE  match_length_ok_encodeBetterBlockAsm
+	JBE  match_length_ok_encodeBetterBlockAsm
 	MOVL 20(SP), CX
 	INCL CX
 	JMP  search_loop_encodeBetterBlockAsm
@@ -5916,13 +5943,13 @@ match_length_ok_encodeBetterBlockAsm:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeBetterBlockAsm
+	JB   one_byte_match_emit_encodeBetterBlockAsm
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeBetterBlockAsm
+	JB   two_bytes_match_emit_encodeBetterBlockAsm
 	CMPL BX, $0x00010000
-	JLT  three_bytes_match_emit_encodeBetterBlockAsm
+	JB   three_bytes_match_emit_encodeBetterBlockAsm
 	CMPL BX, $0x01000000
-	JLT  four_bytes_match_emit_encodeBetterBlockAsm
+	JB   four_bytes_match_emit_encodeBetterBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL BX, 1(AX)
 	ADDQ $0x05, AX
@@ -5948,7 +5975,7 @@ two_bytes_match_emit_encodeBetterBlockAsm:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeBetterBlockAsm
+	JB   memmove_match_emit_encodeBetterBlockAsm
 	JMP  memmove_long_match_emit_encodeBetterBlockAsm
 
 one_byte_match_emit_encodeBetterBlockAsm:
@@ -5961,7 +5988,7 @@ memmove_match_emit_encodeBetterBlockAsm:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_encodeBetterBlockAsm_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_encodeBetterBlockAsm_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_encodeBetterBlockAsm_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -6061,34 +6088,34 @@ emit_literal_done_match_emit_encodeBetterBlockAsm:
 
 	// emitCopy
 	CMPL DI, $0x00010000
-	JL   two_byte_offset_match_nolit_encodeBetterBlockAsm
+	JB   two_byte_offset_match_nolit_encodeBetterBlockAsm
 	CMPL R11, $0x40
-	JLE  four_bytes_remain_match_nolit_encodeBetterBlockAsm
+	JBE  four_bytes_remain_match_nolit_encodeBetterBlockAsm
 	MOVB $0xff, (AX)
 	MOVL DI, 1(AX)
 	LEAL -64(R11), R11
 	ADDQ $0x05, AX
 	CMPL R11, $0x04
-	JL   four_bytes_remain_match_nolit_encodeBetterBlockAsm
+	JB   four_bytes_remain_match_nolit_encodeBetterBlockAsm
 
 	// emitRepeat
 emit_repeat_again_match_nolit_encodeBetterBlockAsm_emit_copy:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm_emit_copy
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm_emit_copy
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm_emit_copy
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm_emit_copy
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBetterBlockAsm_emit_copy
+	JB   repeat_four_match_nolit_encodeBetterBlockAsm_emit_copy
 	CMPL R11, $0x0100ffff
-	JLT  repeat_five_match_nolit_encodeBetterBlockAsm_emit_copy
+	JB   repeat_five_match_nolit_encodeBetterBlockAsm_emit_copy
 	LEAL -16842747(R11), R11
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -6149,7 +6176,7 @@ four_bytes_remain_match_nolit_encodeBetterBlockAsm:
 
 two_byte_offset_match_nolit_encodeBetterBlockAsm:
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm
+	JBE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm
 	CMPL DI, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBetterBlockAsm
 	MOVL $0x00000001, BX
@@ -6171,19 +6198,19 @@ emit_repeat_again_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
+	JB   repeat_four_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
 	CMPL R11, $0x0100ffff
-	JLT  repeat_five_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
+	JB   repeat_five_match_nolit_encodeBetterBlockAsm_emit_copy_short_2b
 	LEAL -16842747(R11), R11
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -6243,19 +6270,19 @@ emit_repeat_again_match_nolit_encodeBetterBlockAsm_emit_copy_short:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm_emit_copy_short
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm_emit_copy_short:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm_emit_copy_short
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBetterBlockAsm_emit_copy_short
+	JB   repeat_four_match_nolit_encodeBetterBlockAsm_emit_copy_short
 	CMPL R11, $0x0100ffff
-	JLT  repeat_five_match_nolit_encodeBetterBlockAsm_emit_copy_short
+	JB   repeat_five_match_nolit_encodeBetterBlockAsm_emit_copy_short
 	LEAL -16842747(R11), R11
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -6308,9 +6335,9 @@ two_byte_offset_short_match_nolit_encodeBetterBlockAsm:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -6337,13 +6364,13 @@ match_is_repeat_encodeBetterBlockAsm:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_repeat_encodeBetterBlockAsm
+	JB   one_byte_match_emit_repeat_encodeBetterBlockAsm
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_repeat_encodeBetterBlockAsm
+	JB   two_bytes_match_emit_repeat_encodeBetterBlockAsm
 	CMPL BX, $0x00010000
-	JLT  three_bytes_match_emit_repeat_encodeBetterBlockAsm
+	JB   three_bytes_match_emit_repeat_encodeBetterBlockAsm
 	CMPL BX, $0x01000000
-	JLT  four_bytes_match_emit_repeat_encodeBetterBlockAsm
+	JB   four_bytes_match_emit_repeat_encodeBetterBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL BX, 1(AX)
 	ADDQ $0x05, AX
@@ -6369,7 +6396,7 @@ two_bytes_match_emit_repeat_encodeBetterBlockAsm:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_repeat_encodeBetterBlockAsm
+	JB   memmove_match_emit_repeat_encodeBetterBlockAsm
 	JMP  memmove_long_match_emit_repeat_encodeBetterBlockAsm
 
 one_byte_match_emit_repeat_encodeBetterBlockAsm:
@@ -6382,7 +6409,7 @@ memmove_match_emit_repeat_encodeBetterBlockAsm:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -6485,19 +6512,19 @@ emit_repeat_again_match_nolit_repeat_encodeBetterBlockAsm:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm
+	JBE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm
+	JAE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm
+	JB   repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm
 
 cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_repeat_encodeBetterBlockAsm
+	JB   repeat_three_match_nolit_repeat_encodeBetterBlockAsm
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_repeat_encodeBetterBlockAsm
+	JB   repeat_four_match_nolit_repeat_encodeBetterBlockAsm
 	CMPL R11, $0x0100ffff
-	JLT  repeat_five_match_nolit_repeat_encodeBetterBlockAsm
+	JB   repeat_five_match_nolit_repeat_encodeBetterBlockAsm
 	LEAL -16842747(R11), R11
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -6547,9 +6574,9 @@ repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm:
 
 match_nolit_emitcopy_end_encodeBetterBlockAsm:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBetterBlockAsm
+	JAE  emit_remainder_encodeBetterBlockAsm
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBetterBlockAsm
+	JB   match_nolit_dst_ok_encodeBetterBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -6605,7 +6632,7 @@ emit_remainder_encodeBetterBlockAsm:
 	SUBL 12(SP), CX
 	LEAQ 5(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBetterBlockAsm
+	JB   emit_remainder_ok_encodeBetterBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -6620,13 +6647,13 @@ emit_remainder_ok_encodeBetterBlockAsm:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBetterBlockAsm
+	JB   one_byte_emit_remainder_encodeBetterBlockAsm
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBetterBlockAsm
+	JB   two_bytes_emit_remainder_encodeBetterBlockAsm
 	CMPL DX, $0x00010000
-	JLT  three_bytes_emit_remainder_encodeBetterBlockAsm
+	JB   three_bytes_emit_remainder_encodeBetterBlockAsm
 	CMPL DX, $0x01000000
-	JLT  four_bytes_emit_remainder_encodeBetterBlockAsm
+	JB   four_bytes_emit_remainder_encodeBetterBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL DX, 1(AX)
 	ADDQ $0x05, AX
@@ -6652,7 +6679,7 @@ two_bytes_emit_remainder_encodeBetterBlockAsm:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBetterBlockAsm
+	JB   memmove_emit_remainder_encodeBetterBlockAsm
 	JMP  memmove_long_emit_remainder_encodeBetterBlockAsm
 
 one_byte_emit_remainder_encodeBetterBlockAsm:
@@ -6814,7 +6841,7 @@ search_loop_encodeBetterBlockAsm4MB:
 	SUBL 12(SP), BX
 	SHRL $0x07, BX
 	CMPL BX, $0x63
-	JLE  check_maxskip_ok_encodeBetterBlockAsm4MB
+	JBE  check_maxskip_ok_encodeBetterBlockAsm4MB
 	LEAL 100(CX), BX
 	JMP  check_maxskip_cont_encodeBetterBlockAsm4MB
 
@@ -6823,7 +6850,7 @@ check_maxskip_ok_encodeBetterBlockAsm4MB:
 
 check_maxskip_cont_encodeBetterBlockAsm4MB:
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBetterBlockAsm4MB
+	JAE   emit_remainder_encodeBetterBlockAsm4MB
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x00cf1bbcdcbfa563, R8
@@ -6878,7 +6905,7 @@ candidate_match_encodeBetterBlockAsm4MB:
 
 match_extend_back_loop_encodeBetterBlockAsm4MB:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBetterBlockAsm4MB
+	JBE  match_extend_back_end_encodeBetterBlockAsm4MB
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -6893,7 +6920,7 @@ match_extend_back_end_encodeBetterBlockAsm4MB:
 	SUBL 12(SP), SI
 	LEAQ 4(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBetterBlockAsm4MB
+	JB   match_dst_size_check_encodeBetterBlockAsm4MB
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -6909,7 +6936,7 @@ match_dst_size_check_encodeBetterBlockAsm4MB:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBetterBlockAsm4MB
+	JB   matchlen_match4_match_nolit_encodeBetterBlockAsm4MB
 
 matchlen_loopback_match_nolit_encodeBetterBlockAsm4MB:
 	MOVQ  (R8)(R11*1), R10
@@ -6932,12 +6959,12 @@ matchlen_loop_match_nolit_encodeBetterBlockAsm4MB:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBetterBlockAsm4MB
+	JAE  matchlen_loopback_match_nolit_encodeBetterBlockAsm4MB
 	JZ   match_nolit_end_encodeBetterBlockAsm4MB
 
 matchlen_match4_match_nolit_encodeBetterBlockAsm4MB:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBetterBlockAsm4MB
+	JB   matchlen_match2_match_nolit_encodeBetterBlockAsm4MB
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeBetterBlockAsm4MB
@@ -6946,7 +6973,7 @@ matchlen_match4_match_nolit_encodeBetterBlockAsm4MB:
 
 matchlen_match2_match_nolit_encodeBetterBlockAsm4MB:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBetterBlockAsm4MB
+	JB   matchlen_match1_match_nolit_encodeBetterBlockAsm4MB
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeBetterBlockAsm4MB
@@ -6955,7 +6982,7 @@ matchlen_match2_match_nolit_encodeBetterBlockAsm4MB:
 
 matchlen_match1_match_nolit_encodeBetterBlockAsm4MB:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeBetterBlockAsm4MB
+	JB   match_nolit_end_encodeBetterBlockAsm4MB
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeBetterBlockAsm4MB
@@ -6969,9 +6996,9 @@ match_nolit_end_encodeBetterBlockAsm4MB:
 	CMPL 16(SP), DI
 	JEQ  match_is_repeat_encodeBetterBlockAsm4MB
 	CMPL R11, $0x01
-	JG   match_length_ok_encodeBetterBlockAsm4MB
+	JA   match_length_ok_encodeBetterBlockAsm4MB
 	CMPL DI, $0x0000ffff
-	JLE  match_length_ok_encodeBetterBlockAsm4MB
+	JBE  match_length_ok_encodeBetterBlockAsm4MB
 	MOVL 20(SP), CX
 	INCL CX
 	JMP  search_loop_encodeBetterBlockAsm4MB
@@ -6987,11 +7014,11 @@ match_length_ok_encodeBetterBlockAsm4MB:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeBetterBlockAsm4MB
+	JB   one_byte_match_emit_encodeBetterBlockAsm4MB
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeBetterBlockAsm4MB
+	JB   two_bytes_match_emit_encodeBetterBlockAsm4MB
 	CMPL BX, $0x00010000
-	JLT  three_bytes_match_emit_encodeBetterBlockAsm4MB
+	JB   three_bytes_match_emit_encodeBetterBlockAsm4MB
 	MOVL BX, R10
 	SHRL $0x10, R10
 	MOVB $0xf8, (AX)
@@ -7011,7 +7038,7 @@ two_bytes_match_emit_encodeBetterBlockAsm4MB:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeBetterBlockAsm4MB
+	JB   memmove_match_emit_encodeBetterBlockAsm4MB
 	JMP  memmove_long_match_emit_encodeBetterBlockAsm4MB
 
 one_byte_match_emit_encodeBetterBlockAsm4MB:
@@ -7024,7 +7051,7 @@ memmove_match_emit_encodeBetterBlockAsm4MB:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_encodeBetterBlockAsm4MB_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_encodeBetterBlockAsm4MB_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_encodeBetterBlockAsm4MB_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -7124,31 +7151,31 @@ emit_literal_done_match_emit_encodeBetterBlockAsm4MB:
 
 	// emitCopy
 	CMPL DI, $0x00010000
-	JL   two_byte_offset_match_nolit_encodeBetterBlockAsm4MB
+	JB   two_byte_offset_match_nolit_encodeBetterBlockAsm4MB
 	CMPL R11, $0x40
-	JLE  four_bytes_remain_match_nolit_encodeBetterBlockAsm4MB
+	JBE  four_bytes_remain_match_nolit_encodeBetterBlockAsm4MB
 	MOVB $0xff, (AX)
 	MOVL DI, 1(AX)
 	LEAL -64(R11), R11
 	ADDQ $0x05, AX
 	CMPL R11, $0x04
-	JL   four_bytes_remain_match_nolit_encodeBetterBlockAsm4MB
+	JB   four_bytes_remain_match_nolit_encodeBetterBlockAsm4MB
 
 	// emitRepeat
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm4MB_emit_copy
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm4MB_emit_copy
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm4MB_emit_copy
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm4MB_emit_copy
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBetterBlockAsm4MB_emit_copy
+	JB   repeat_four_match_nolit_encodeBetterBlockAsm4MB_emit_copy
 	LEAL -65536(R11), R11
 	MOVL R11, DI
 	MOVW $0x001d, (AX)
@@ -7202,7 +7229,7 @@ four_bytes_remain_match_nolit_encodeBetterBlockAsm4MB:
 
 two_byte_offset_match_nolit_encodeBetterBlockAsm4MB:
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm4MB
+	JBE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm4MB
 	CMPL DI, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBetterBlockAsm4MB
 	MOVL $0x00000001, BX
@@ -7221,17 +7248,17 @@ two_byte_offset_match_nolit_encodeBetterBlockAsm4MB:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
+	JB   repeat_four_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short_2b
 	LEAL -65536(R11), R11
 	MOVL R11, DI
 	MOVW $0x001d, (AX)
@@ -7283,17 +7310,17 @@ long_offset_short_match_nolit_encodeBetterBlockAsm4MB:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
+	JB   repeat_four_match_nolit_encodeBetterBlockAsm4MB_emit_copy_short
 	LEAL -65536(R11), R11
 	MOVL R11, DI
 	MOVW $0x001d, (AX)
@@ -7339,9 +7366,9 @@ two_byte_offset_short_match_nolit_encodeBetterBlockAsm4MB:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm4MB
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm4MB
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm4MB
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm4MB
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -7368,11 +7395,11 @@ match_is_repeat_encodeBetterBlockAsm4MB:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_repeat_encodeBetterBlockAsm4MB
+	JB   one_byte_match_emit_repeat_encodeBetterBlockAsm4MB
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_repeat_encodeBetterBlockAsm4MB
+	JB   two_bytes_match_emit_repeat_encodeBetterBlockAsm4MB
 	CMPL BX, $0x00010000
-	JLT  three_bytes_match_emit_repeat_encodeBetterBlockAsm4MB
+	JB   three_bytes_match_emit_repeat_encodeBetterBlockAsm4MB
 	MOVL BX, R10
 	SHRL $0x10, R10
 	MOVB $0xf8, (AX)
@@ -7392,7 +7419,7 @@ two_bytes_match_emit_repeat_encodeBetterBlockAsm4MB:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_repeat_encodeBetterBlockAsm4MB
+	JB   memmove_match_emit_repeat_encodeBetterBlockAsm4MB
 	JMP  memmove_long_match_emit_repeat_encodeBetterBlockAsm4MB
 
 one_byte_match_emit_repeat_encodeBetterBlockAsm4MB:
@@ -7405,7 +7432,7 @@ memmove_match_emit_repeat_encodeBetterBlockAsm4MB:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm4MB_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm4MB_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm4MB_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -7507,17 +7534,17 @@ emit_literal_done_match_emit_repeat_encodeBetterBlockAsm4MB:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm4MB
+	JBE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm4MB
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm4MB
+	JAE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm4MB
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm4MB
+	JB   repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm4MB
 
 cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm4MB:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_repeat_encodeBetterBlockAsm4MB
+	JB   repeat_three_match_nolit_repeat_encodeBetterBlockAsm4MB
 	CMPL R11, $0x00010100
-	JLT  repeat_four_match_nolit_repeat_encodeBetterBlockAsm4MB
+	JB   repeat_four_match_nolit_repeat_encodeBetterBlockAsm4MB
 	LEAL -65536(R11), R11
 	MOVL R11, DI
 	MOVW $0x001d, (AX)
@@ -7560,9 +7587,9 @@ repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm4MB:
 
 match_nolit_emitcopy_end_encodeBetterBlockAsm4MB:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBetterBlockAsm4MB
+	JAE  emit_remainder_encodeBetterBlockAsm4MB
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBetterBlockAsm4MB
+	JB   match_nolit_dst_ok_encodeBetterBlockAsm4MB
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -7618,7 +7645,7 @@ emit_remainder_encodeBetterBlockAsm4MB:
 	SUBL 12(SP), CX
 	LEAQ 4(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBetterBlockAsm4MB
+	JB   emit_remainder_ok_encodeBetterBlockAsm4MB
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -7633,11 +7660,11 @@ emit_remainder_ok_encodeBetterBlockAsm4MB:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBetterBlockAsm4MB
+	JB   one_byte_emit_remainder_encodeBetterBlockAsm4MB
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBetterBlockAsm4MB
+	JB   two_bytes_emit_remainder_encodeBetterBlockAsm4MB
 	CMPL DX, $0x00010000
-	JLT  three_bytes_emit_remainder_encodeBetterBlockAsm4MB
+	JB   three_bytes_emit_remainder_encodeBetterBlockAsm4MB
 	MOVL DX, BX
 	SHRL $0x10, BX
 	MOVB $0xf8, (AX)
@@ -7657,7 +7684,7 @@ two_bytes_emit_remainder_encodeBetterBlockAsm4MB:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBetterBlockAsm4MB
+	JB   memmove_emit_remainder_encodeBetterBlockAsm4MB
 	JMP  memmove_long_emit_remainder_encodeBetterBlockAsm4MB
 
 one_byte_emit_remainder_encodeBetterBlockAsm4MB:
@@ -7820,7 +7847,7 @@ search_loop_encodeBetterBlockAsm12B:
 	SHRL  $0x06, BX
 	LEAL  1(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBetterBlockAsm12B
+	JAE   emit_remainder_encodeBetterBlockAsm12B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -7875,7 +7902,7 @@ candidate_match_encodeBetterBlockAsm12B:
 
 match_extend_back_loop_encodeBetterBlockAsm12B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBetterBlockAsm12B
+	JBE  match_extend_back_end_encodeBetterBlockAsm12B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -7890,7 +7917,7 @@ match_extend_back_end_encodeBetterBlockAsm12B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBetterBlockAsm12B
+	JB   match_dst_size_check_encodeBetterBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -7906,7 +7933,7 @@ match_dst_size_check_encodeBetterBlockAsm12B:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBetterBlockAsm12B
+	JB   matchlen_match4_match_nolit_encodeBetterBlockAsm12B
 
 matchlen_loopback_match_nolit_encodeBetterBlockAsm12B:
 	MOVQ  (R8)(R11*1), R10
@@ -7929,12 +7956,12 @@ matchlen_loop_match_nolit_encodeBetterBlockAsm12B:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBetterBlockAsm12B
+	JAE  matchlen_loopback_match_nolit_encodeBetterBlockAsm12B
 	JZ   match_nolit_end_encodeBetterBlockAsm12B
 
 matchlen_match4_match_nolit_encodeBetterBlockAsm12B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBetterBlockAsm12B
+	JB   matchlen_match2_match_nolit_encodeBetterBlockAsm12B
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeBetterBlockAsm12B
@@ -7943,7 +7970,7 @@ matchlen_match4_match_nolit_encodeBetterBlockAsm12B:
 
 matchlen_match2_match_nolit_encodeBetterBlockAsm12B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBetterBlockAsm12B
+	JB   matchlen_match1_match_nolit_encodeBetterBlockAsm12B
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeBetterBlockAsm12B
@@ -7952,7 +7979,7 @@ matchlen_match2_match_nolit_encodeBetterBlockAsm12B:
 
 matchlen_match1_match_nolit_encodeBetterBlockAsm12B:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeBetterBlockAsm12B
+	JB   match_nolit_end_encodeBetterBlockAsm12B
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeBetterBlockAsm12B
@@ -7975,9 +8002,12 @@ match_nolit_end_encodeBetterBlockAsm12B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeBetterBlockAsm12B
+	JB   one_byte_match_emit_encodeBetterBlockAsm12B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeBetterBlockAsm12B
+	JB   two_bytes_match_emit_encodeBetterBlockAsm12B
+	JB   three_bytes_match_emit_encodeBetterBlockAsm12B
+
+three_bytes_match_emit_encodeBetterBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -7988,7 +8018,7 @@ two_bytes_match_emit_encodeBetterBlockAsm12B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeBetterBlockAsm12B
+	JB   memmove_match_emit_encodeBetterBlockAsm12B
 	JMP  memmove_long_match_emit_encodeBetterBlockAsm12B
 
 one_byte_match_emit_encodeBetterBlockAsm12B:
@@ -8001,7 +8031,7 @@ memmove_match_emit_encodeBetterBlockAsm12B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_encodeBetterBlockAsm12B_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_encodeBetterBlockAsm12B_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_encodeBetterBlockAsm12B_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -8101,7 +8131,7 @@ emit_literal_done_match_emit_encodeBetterBlockAsm12B:
 
 	// emitCopy
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm12B
+	JBE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm12B
 	CMPL DI, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBetterBlockAsm12B
 	MOVL $0x00000001, BX
@@ -8120,15 +8150,15 @@ emit_literal_done_match_emit_encodeBetterBlockAsm12B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm12B_emit_copy_short_2b
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -8170,15 +8200,15 @@ long_offset_short_match_nolit_encodeBetterBlockAsm12B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm12B_emit_copy_short:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm12B_emit_copy_short
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -8214,9 +8244,9 @@ two_byte_offset_short_match_nolit_encodeBetterBlockAsm12B:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm12B
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm12B
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -8243,9 +8273,12 @@ match_is_repeat_encodeBetterBlockAsm12B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_repeat_encodeBetterBlockAsm12B
+	JB   one_byte_match_emit_repeat_encodeBetterBlockAsm12B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_repeat_encodeBetterBlockAsm12B
+	JB   two_bytes_match_emit_repeat_encodeBetterBlockAsm12B
+	JB   three_bytes_match_emit_repeat_encodeBetterBlockAsm12B
+
+three_bytes_match_emit_repeat_encodeBetterBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -8256,7 +8289,7 @@ two_bytes_match_emit_repeat_encodeBetterBlockAsm12B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_repeat_encodeBetterBlockAsm12B
+	JB   memmove_match_emit_repeat_encodeBetterBlockAsm12B
 	JMP  memmove_long_match_emit_repeat_encodeBetterBlockAsm12B
 
 one_byte_match_emit_repeat_encodeBetterBlockAsm12B:
@@ -8269,7 +8302,7 @@ memmove_match_emit_repeat_encodeBetterBlockAsm12B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm12B_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm12B_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm12B_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -8371,15 +8404,15 @@ emit_literal_done_match_emit_repeat_encodeBetterBlockAsm12B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm12B
+	JBE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm12B
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm12B
+	JAE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm12B
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm12B
+	JB   repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm12B
 
 cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm12B:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_repeat_encodeBetterBlockAsm12B
+	JB   repeat_three_match_nolit_repeat_encodeBetterBlockAsm12B
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -8412,9 +8445,9 @@ repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm12B:
 
 match_nolit_emitcopy_end_encodeBetterBlockAsm12B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBetterBlockAsm12B
+	JAE  emit_remainder_encodeBetterBlockAsm12B
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBetterBlockAsm12B
+	JB   match_nolit_dst_ok_encodeBetterBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -8470,7 +8503,7 @@ emit_remainder_encodeBetterBlockAsm12B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBetterBlockAsm12B
+	JB   emit_remainder_ok_encodeBetterBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -8485,9 +8518,12 @@ emit_remainder_ok_encodeBetterBlockAsm12B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBetterBlockAsm12B
+	JB   one_byte_emit_remainder_encodeBetterBlockAsm12B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBetterBlockAsm12B
+	JB   two_bytes_emit_remainder_encodeBetterBlockAsm12B
+	JB   three_bytes_emit_remainder_encodeBetterBlockAsm12B
+
+three_bytes_emit_remainder_encodeBetterBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -8498,7 +8534,7 @@ two_bytes_emit_remainder_encodeBetterBlockAsm12B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBetterBlockAsm12B
+	JB   memmove_emit_remainder_encodeBetterBlockAsm12B
 	JMP  memmove_long_emit_remainder_encodeBetterBlockAsm12B
 
 one_byte_emit_remainder_encodeBetterBlockAsm12B:
@@ -8661,7 +8697,7 @@ search_loop_encodeBetterBlockAsm10B:
 	SHRL  $0x05, BX
 	LEAL  1(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBetterBlockAsm10B
+	JAE   emit_remainder_encodeBetterBlockAsm10B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -8716,7 +8752,7 @@ candidate_match_encodeBetterBlockAsm10B:
 
 match_extend_back_loop_encodeBetterBlockAsm10B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBetterBlockAsm10B
+	JBE  match_extend_back_end_encodeBetterBlockAsm10B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -8731,7 +8767,7 @@ match_extend_back_end_encodeBetterBlockAsm10B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBetterBlockAsm10B
+	JB   match_dst_size_check_encodeBetterBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -8747,7 +8783,7 @@ match_dst_size_check_encodeBetterBlockAsm10B:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBetterBlockAsm10B
+	JB   matchlen_match4_match_nolit_encodeBetterBlockAsm10B
 
 matchlen_loopback_match_nolit_encodeBetterBlockAsm10B:
 	MOVQ  (R8)(R11*1), R10
@@ -8770,12 +8806,12 @@ matchlen_loop_match_nolit_encodeBetterBlockAsm10B:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBetterBlockAsm10B
+	JAE  matchlen_loopback_match_nolit_encodeBetterBlockAsm10B
 	JZ   match_nolit_end_encodeBetterBlockAsm10B
 
 matchlen_match4_match_nolit_encodeBetterBlockAsm10B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBetterBlockAsm10B
+	JB   matchlen_match2_match_nolit_encodeBetterBlockAsm10B
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeBetterBlockAsm10B
@@ -8784,7 +8820,7 @@ matchlen_match4_match_nolit_encodeBetterBlockAsm10B:
 
 matchlen_match2_match_nolit_encodeBetterBlockAsm10B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBetterBlockAsm10B
+	JB   matchlen_match1_match_nolit_encodeBetterBlockAsm10B
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeBetterBlockAsm10B
@@ -8793,7 +8829,7 @@ matchlen_match2_match_nolit_encodeBetterBlockAsm10B:
 
 matchlen_match1_match_nolit_encodeBetterBlockAsm10B:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeBetterBlockAsm10B
+	JB   match_nolit_end_encodeBetterBlockAsm10B
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeBetterBlockAsm10B
@@ -8816,9 +8852,12 @@ match_nolit_end_encodeBetterBlockAsm10B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeBetterBlockAsm10B
+	JB   one_byte_match_emit_encodeBetterBlockAsm10B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeBetterBlockAsm10B
+	JB   two_bytes_match_emit_encodeBetterBlockAsm10B
+	JB   three_bytes_match_emit_encodeBetterBlockAsm10B
+
+three_bytes_match_emit_encodeBetterBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -8829,7 +8868,7 @@ two_bytes_match_emit_encodeBetterBlockAsm10B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeBetterBlockAsm10B
+	JB   memmove_match_emit_encodeBetterBlockAsm10B
 	JMP  memmove_long_match_emit_encodeBetterBlockAsm10B
 
 one_byte_match_emit_encodeBetterBlockAsm10B:
@@ -8842,7 +8881,7 @@ memmove_match_emit_encodeBetterBlockAsm10B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_encodeBetterBlockAsm10B_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_encodeBetterBlockAsm10B_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_encodeBetterBlockAsm10B_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -8942,7 +8981,7 @@ emit_literal_done_match_emit_encodeBetterBlockAsm10B:
 
 	// emitCopy
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm10B
+	JBE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm10B
 	CMPL DI, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBetterBlockAsm10B
 	MOVL $0x00000001, BX
@@ -8961,15 +9000,15 @@ emit_literal_done_match_emit_encodeBetterBlockAsm10B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm10B_emit_copy_short_2b
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -9011,15 +9050,15 @@ long_offset_short_match_nolit_encodeBetterBlockAsm10B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
+	JB   repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm10B_emit_copy_short:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm10B_emit_copy_short
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -9055,9 +9094,9 @@ two_byte_offset_short_match_nolit_encodeBetterBlockAsm10B:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm10B
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm10B
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -9084,9 +9123,12 @@ match_is_repeat_encodeBetterBlockAsm10B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_repeat_encodeBetterBlockAsm10B
+	JB   one_byte_match_emit_repeat_encodeBetterBlockAsm10B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_repeat_encodeBetterBlockAsm10B
+	JB   two_bytes_match_emit_repeat_encodeBetterBlockAsm10B
+	JB   three_bytes_match_emit_repeat_encodeBetterBlockAsm10B
+
+three_bytes_match_emit_repeat_encodeBetterBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -9097,7 +9139,7 @@ two_bytes_match_emit_repeat_encodeBetterBlockAsm10B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_repeat_encodeBetterBlockAsm10B
+	JB   memmove_match_emit_repeat_encodeBetterBlockAsm10B
 	JMP  memmove_long_match_emit_repeat_encodeBetterBlockAsm10B
 
 one_byte_match_emit_repeat_encodeBetterBlockAsm10B:
@@ -9110,7 +9152,7 @@ memmove_match_emit_repeat_encodeBetterBlockAsm10B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm10B_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm10B_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm10B_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -9212,15 +9254,15 @@ emit_literal_done_match_emit_repeat_encodeBetterBlockAsm10B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm10B
+	JBE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm10B
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm10B
+	JAE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm10B
 	CMPL DI, $0x00000800
-	JLT  repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm10B
+	JB   repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm10B
 
 cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm10B:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_repeat_encodeBetterBlockAsm10B
+	JB   repeat_three_match_nolit_repeat_encodeBetterBlockAsm10B
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -9253,9 +9295,9 @@ repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm10B:
 
 match_nolit_emitcopy_end_encodeBetterBlockAsm10B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBetterBlockAsm10B
+	JAE  emit_remainder_encodeBetterBlockAsm10B
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBetterBlockAsm10B
+	JB   match_nolit_dst_ok_encodeBetterBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -9311,7 +9353,7 @@ emit_remainder_encodeBetterBlockAsm10B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBetterBlockAsm10B
+	JB   emit_remainder_ok_encodeBetterBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -9326,9 +9368,12 @@ emit_remainder_ok_encodeBetterBlockAsm10B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBetterBlockAsm10B
+	JB   one_byte_emit_remainder_encodeBetterBlockAsm10B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBetterBlockAsm10B
+	JB   two_bytes_emit_remainder_encodeBetterBlockAsm10B
+	JB   three_bytes_emit_remainder_encodeBetterBlockAsm10B
+
+three_bytes_emit_remainder_encodeBetterBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -9339,7 +9384,7 @@ two_bytes_emit_remainder_encodeBetterBlockAsm10B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBetterBlockAsm10B
+	JB   memmove_emit_remainder_encodeBetterBlockAsm10B
 	JMP  memmove_long_emit_remainder_encodeBetterBlockAsm10B
 
 one_byte_emit_remainder_encodeBetterBlockAsm10B:
@@ -9502,7 +9547,7 @@ search_loop_encodeBetterBlockAsm8B:
 	SHRL  $0x04, BX
 	LEAL  1(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeBetterBlockAsm8B
+	JAE   emit_remainder_encodeBetterBlockAsm8B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -9557,7 +9602,7 @@ candidate_match_encodeBetterBlockAsm8B:
 
 match_extend_back_loop_encodeBetterBlockAsm8B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeBetterBlockAsm8B
+	JBE  match_extend_back_end_encodeBetterBlockAsm8B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -9572,7 +9617,7 @@ match_extend_back_end_encodeBetterBlockAsm8B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeBetterBlockAsm8B
+	JB   match_dst_size_check_encodeBetterBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -9588,7 +9633,7 @@ match_dst_size_check_encodeBetterBlockAsm8B:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeBetterBlockAsm8B
+	JB   matchlen_match4_match_nolit_encodeBetterBlockAsm8B
 
 matchlen_loopback_match_nolit_encodeBetterBlockAsm8B:
 	MOVQ  (R8)(R11*1), R10
@@ -9611,12 +9656,12 @@ matchlen_loop_match_nolit_encodeBetterBlockAsm8B:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeBetterBlockAsm8B
+	JAE  matchlen_loopback_match_nolit_encodeBetterBlockAsm8B
 	JZ   match_nolit_end_encodeBetterBlockAsm8B
 
 matchlen_match4_match_nolit_encodeBetterBlockAsm8B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeBetterBlockAsm8B
+	JB   matchlen_match2_match_nolit_encodeBetterBlockAsm8B
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeBetterBlockAsm8B
@@ -9625,7 +9670,7 @@ matchlen_match4_match_nolit_encodeBetterBlockAsm8B:
 
 matchlen_match2_match_nolit_encodeBetterBlockAsm8B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeBetterBlockAsm8B
+	JB   matchlen_match1_match_nolit_encodeBetterBlockAsm8B
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeBetterBlockAsm8B
@@ -9634,7 +9679,7 @@ matchlen_match2_match_nolit_encodeBetterBlockAsm8B:
 
 matchlen_match1_match_nolit_encodeBetterBlockAsm8B:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeBetterBlockAsm8B
+	JB   match_nolit_end_encodeBetterBlockAsm8B
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeBetterBlockAsm8B
@@ -9657,9 +9702,12 @@ match_nolit_end_encodeBetterBlockAsm8B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeBetterBlockAsm8B
+	JB   one_byte_match_emit_encodeBetterBlockAsm8B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeBetterBlockAsm8B
+	JB   two_bytes_match_emit_encodeBetterBlockAsm8B
+	JB   three_bytes_match_emit_encodeBetterBlockAsm8B
+
+three_bytes_match_emit_encodeBetterBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -9670,7 +9718,7 @@ two_bytes_match_emit_encodeBetterBlockAsm8B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeBetterBlockAsm8B
+	JB   memmove_match_emit_encodeBetterBlockAsm8B
 	JMP  memmove_long_match_emit_encodeBetterBlockAsm8B
 
 one_byte_match_emit_encodeBetterBlockAsm8B:
@@ -9683,7 +9731,7 @@ memmove_match_emit_encodeBetterBlockAsm8B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x04
-	JLE  emit_lit_memmove_match_emit_encodeBetterBlockAsm8B_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_encodeBetterBlockAsm8B_memmove_move_4
 	CMPQ R8, $0x08
 	JB   emit_lit_memmove_match_emit_encodeBetterBlockAsm8B_memmove_move_4through7
 	CMPQ R8, $0x10
@@ -9783,7 +9831,7 @@ emit_literal_done_match_emit_encodeBetterBlockAsm8B:
 
 	// emitCopy
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm8B
+	JBE  two_byte_offset_short_match_nolit_encodeBetterBlockAsm8B
 	CMPL DI, $0x00000800
 	JAE  long_offset_short_match_nolit_encodeBetterBlockAsm8B
 	MOVL $0x00000001, BX
@@ -9802,13 +9850,13 @@ emit_literal_done_match_emit_encodeBetterBlockAsm8B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm8B_emit_copy_short_2b
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm8B_emit_copy_short_2b
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm8B_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm8B_emit_copy_short_2b
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm8B_emit_copy_short_2b:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm8B_emit_copy_short_2b
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm8B_emit_copy_short_2b
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -9848,13 +9896,13 @@ long_offset_short_match_nolit_encodeBetterBlockAsm8B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_encodeBetterBlockAsm8B_emit_copy_short
+	JBE  repeat_two_match_nolit_encodeBetterBlockAsm8B_emit_copy_short
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm8B_emit_copy_short
+	JAE  cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm8B_emit_copy_short
 
 cant_repeat_two_offset_match_nolit_encodeBetterBlockAsm8B_emit_copy_short:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_encodeBetterBlockAsm8B_emit_copy_short
+	JB   repeat_three_match_nolit_encodeBetterBlockAsm8B_emit_copy_short
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -9888,7 +9936,7 @@ two_byte_offset_short_match_nolit_encodeBetterBlockAsm8B:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeBetterBlockAsm8B
+	JAE  emit_copy_three_match_nolit_encodeBetterBlockAsm8B
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -9915,9 +9963,12 @@ match_is_repeat_encodeBetterBlockAsm8B:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_repeat_encodeBetterBlockAsm8B
+	JB   one_byte_match_emit_repeat_encodeBetterBlockAsm8B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_repeat_encodeBetterBlockAsm8B
+	JB   two_bytes_match_emit_repeat_encodeBetterBlockAsm8B
+	JB   three_bytes_match_emit_repeat_encodeBetterBlockAsm8B
+
+three_bytes_match_emit_repeat_encodeBetterBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -9928,7 +9979,7 @@ two_bytes_match_emit_repeat_encodeBetterBlockAsm8B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_repeat_encodeBetterBlockAsm8B
+	JB   memmove_match_emit_repeat_encodeBetterBlockAsm8B
 	JMP  memmove_long_match_emit_repeat_encodeBetterBlockAsm8B
 
 one_byte_match_emit_repeat_encodeBetterBlockAsm8B:
@@ -9941,7 +9992,7 @@ memmove_match_emit_repeat_encodeBetterBlockAsm8B:
 
 	// genMemMoveShort
 	CMPQ DI, $0x04
-	JLE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm8B_memmove_move_4
+	JBE  emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm8B_memmove_move_4
 	CMPQ DI, $0x08
 	JB   emit_lit_memmove_match_emit_repeat_encodeBetterBlockAsm8B_memmove_move_4through7
 	CMPQ DI, $0x10
@@ -10043,13 +10094,13 @@ emit_literal_done_match_emit_repeat_encodeBetterBlockAsm8B:
 	MOVL R11, BX
 	LEAL -4(R11), R11
 	CMPL BX, $0x08
-	JLE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm8B
+	JBE  repeat_two_match_nolit_repeat_encodeBetterBlockAsm8B
 	CMPL BX, $0x0c
-	JGE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm8B
+	JAE  cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm8B
 
 cant_repeat_two_offset_match_nolit_repeat_encodeBetterBlockAsm8B:
 	CMPL R11, $0x00000104
-	JLT  repeat_three_match_nolit_repeat_encodeBetterBlockAsm8B
+	JB   repeat_three_match_nolit_repeat_encodeBetterBlockAsm8B
 	LEAL -256(R11), R11
 	MOVW $0x0019, (AX)
 	MOVW R11, 2(AX)
@@ -10080,9 +10131,9 @@ repeat_two_match_nolit_repeat_encodeBetterBlockAsm8B:
 
 match_nolit_emitcopy_end_encodeBetterBlockAsm8B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeBetterBlockAsm8B
+	JAE  emit_remainder_encodeBetterBlockAsm8B
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeBetterBlockAsm8B
+	JB   match_nolit_dst_ok_encodeBetterBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -10138,7 +10189,7 @@ emit_remainder_encodeBetterBlockAsm8B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeBetterBlockAsm8B
+	JB   emit_remainder_ok_encodeBetterBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -10153,9 +10204,12 @@ emit_remainder_ok_encodeBetterBlockAsm8B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeBetterBlockAsm8B
+	JB   one_byte_emit_remainder_encodeBetterBlockAsm8B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeBetterBlockAsm8B
+	JB   two_bytes_emit_remainder_encodeBetterBlockAsm8B
+	JB   three_bytes_emit_remainder_encodeBetterBlockAsm8B
+
+three_bytes_emit_remainder_encodeBetterBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -10166,7 +10220,7 @@ two_bytes_emit_remainder_encodeBetterBlockAsm8B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeBetterBlockAsm8B
+	JB   memmove_emit_remainder_encodeBetterBlockAsm8B
 	JMP  memmove_long_emit_remainder_encodeBetterBlockAsm8B
 
 one_byte_emit_remainder_encodeBetterBlockAsm8B:
@@ -10329,7 +10383,7 @@ search_loop_encodeSnappyBlockAsm:
 	SHRL  $0x06, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBlockAsm
+	JAE   emit_remainder_encodeSnappyBlockAsm
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -10367,7 +10421,7 @@ search_loop_encodeSnappyBlockAsm:
 
 repeat_extend_back_loop_encodeSnappyBlockAsm:
 	CMPL SI, BX
-	JLE  repeat_extend_back_end_encodeSnappyBlockAsm
+	JBE  repeat_extend_back_end_encodeSnappyBlockAsm
 	MOVB -1(DX)(DI*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -10386,13 +10440,13 @@ repeat_extend_back_end_encodeSnappyBlockAsm:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeSnappyBlockAsm
+	JB   one_byte_repeat_emit_encodeSnappyBlockAsm
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeSnappyBlockAsm
+	JB   two_bytes_repeat_emit_encodeSnappyBlockAsm
 	CMPL BX, $0x00010000
-	JLT  three_bytes_repeat_emit_encodeSnappyBlockAsm
+	JB   three_bytes_repeat_emit_encodeSnappyBlockAsm
 	CMPL BX, $0x01000000
-	JLT  four_bytes_repeat_emit_encodeSnappyBlockAsm
+	JB   four_bytes_repeat_emit_encodeSnappyBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL BX, 1(AX)
 	ADDQ $0x05, AX
@@ -10418,7 +10472,7 @@ two_bytes_repeat_emit_encodeSnappyBlockAsm:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeSnappyBlockAsm
+	JB   memmove_repeat_emit_encodeSnappyBlockAsm
 	JMP  memmove_long_repeat_emit_encodeSnappyBlockAsm
 
 one_byte_repeat_emit_encodeSnappyBlockAsm:
@@ -10431,7 +10485,7 @@ memmove_repeat_emit_encodeSnappyBlockAsm:
 
 	// genMemMoveShort
 	CMPQ DI, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm_memmove_move_8
 	CMPQ DI, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm_memmove_move_8through16
 	CMPQ DI, $0x20
@@ -10527,7 +10581,7 @@ emit_literal_done_repeat_emit_encodeSnappyBlockAsm:
 	// matchLen
 	XORL R10, R10
 	CMPL DI, $0x08
-	JL   matchlen_match4_repeat_extend_encodeSnappyBlockAsm
+	JB   matchlen_match4_repeat_extend_encodeSnappyBlockAsm
 
 matchlen_loopback_repeat_extend_encodeSnappyBlockAsm:
 	MOVQ  (R8)(R10*1), R9
@@ -10550,12 +10604,12 @@ matchlen_loop_repeat_extend_encodeSnappyBlockAsm:
 	LEAL -8(DI), DI
 	LEAL 8(R10), R10
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm
+	JAE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm
 	JZ   repeat_extend_forward_end_encodeSnappyBlockAsm
 
 matchlen_match4_repeat_extend_encodeSnappyBlockAsm:
 	CMPL DI, $0x04
-	JL   matchlen_match2_repeat_extend_encodeSnappyBlockAsm
+	JB   matchlen_match2_repeat_extend_encodeSnappyBlockAsm
 	MOVL (R8)(R10*1), R9
 	CMPL (BX)(R10*1), R9
 	JNE  matchlen_match2_repeat_extend_encodeSnappyBlockAsm
@@ -10564,7 +10618,7 @@ matchlen_match4_repeat_extend_encodeSnappyBlockAsm:
 
 matchlen_match2_repeat_extend_encodeSnappyBlockAsm:
 	CMPL DI, $0x02
-	JL   matchlen_match1_repeat_extend_encodeSnappyBlockAsm
+	JB   matchlen_match1_repeat_extend_encodeSnappyBlockAsm
 	MOVW (R8)(R10*1), R9
 	CMPW (BX)(R10*1), R9
 	JNE  matchlen_match1_repeat_extend_encodeSnappyBlockAsm
@@ -10573,7 +10627,7 @@ matchlen_match2_repeat_extend_encodeSnappyBlockAsm:
 
 matchlen_match1_repeat_extend_encodeSnappyBlockAsm:
 	CMPL DI, $0x01
-	JL   repeat_extend_forward_end_encodeSnappyBlockAsm
+	JB   repeat_extend_forward_end_encodeSnappyBlockAsm
 	MOVB (R8)(R10*1), R9
 	CMPB (BX)(R10*1), R9
 	JNE  repeat_extend_forward_end_encodeSnappyBlockAsm
@@ -10587,17 +10641,17 @@ repeat_extend_forward_end_encodeSnappyBlockAsm:
 
 	// emitCopy
 	CMPL SI, $0x00010000
-	JL   two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm
+	JB   two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm
 
 four_bytes_loop_back_repeat_as_copy_encodeSnappyBlockAsm:
 	CMPL BX, $0x40
-	JLE  four_bytes_remain_repeat_as_copy_encodeSnappyBlockAsm
+	JBE  four_bytes_remain_repeat_as_copy_encodeSnappyBlockAsm
 	MOVB $0xff, (AX)
 	MOVL SI, 1(AX)
 	LEAL -64(BX), BX
 	ADDQ $0x05, AX
 	CMPL BX, $0x04
-	JL   four_bytes_remain_repeat_as_copy_encodeSnappyBlockAsm
+	JB   four_bytes_remain_repeat_as_copy_encodeSnappyBlockAsm
 	JMP  four_bytes_loop_back_repeat_as_copy_encodeSnappyBlockAsm
 
 four_bytes_remain_repeat_as_copy_encodeSnappyBlockAsm:
@@ -10612,7 +10666,7 @@ four_bytes_remain_repeat_as_copy_encodeSnappyBlockAsm:
 
 two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm
+	JBE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm
 	MOVB $0xee, (AX)
 	MOVW SI, 1(AX)
 	LEAL -60(BX), BX
@@ -10623,9 +10677,9 @@ two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -10676,7 +10730,7 @@ candidate_match_encodeSnappyBlockAsm:
 
 match_extend_back_loop_encodeSnappyBlockAsm:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBlockAsm
+	JBE  match_extend_back_end_encodeSnappyBlockAsm
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -10691,7 +10745,7 @@ match_extend_back_end_encodeSnappyBlockAsm:
 	SUBL 12(SP), SI
 	LEAQ 5(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBlockAsm
+	JB   match_dst_size_check_encodeSnappyBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -10706,13 +10760,13 @@ match_dst_size_check_encodeSnappyBlockAsm:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBlockAsm
+	JB   one_byte_match_emit_encodeSnappyBlockAsm
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBlockAsm
+	JB   two_bytes_match_emit_encodeSnappyBlockAsm
 	CMPL DI, $0x00010000
-	JLT  three_bytes_match_emit_encodeSnappyBlockAsm
+	JB   three_bytes_match_emit_encodeSnappyBlockAsm
 	CMPL DI, $0x01000000
-	JLT  four_bytes_match_emit_encodeSnappyBlockAsm
+	JB   four_bytes_match_emit_encodeSnappyBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL DI, 1(AX)
 	ADDQ $0x05, AX
@@ -10738,7 +10792,7 @@ two_bytes_match_emit_encodeSnappyBlockAsm:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeSnappyBlockAsm
+	JB   memmove_match_emit_encodeSnappyBlockAsm
 	JMP  memmove_long_match_emit_encodeSnappyBlockAsm
 
 one_byte_match_emit_encodeSnappyBlockAsm:
@@ -10751,7 +10805,7 @@ memmove_match_emit_encodeSnappyBlockAsm:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -10850,7 +10904,7 @@ match_nolit_loop_encodeSnappyBlockAsm:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBlockAsm
+	JB   matchlen_match4_match_nolit_encodeSnappyBlockAsm
 
 matchlen_loopback_match_nolit_encodeSnappyBlockAsm:
 	MOVQ  (DI)(R9*1), R8
@@ -10873,12 +10927,12 @@ matchlen_loop_match_nolit_encodeSnappyBlockAsm:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm
 	JZ   match_nolit_end_encodeSnappyBlockAsm
 
 matchlen_match4_match_nolit_encodeSnappyBlockAsm:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBlockAsm
+	JB   matchlen_match2_match_nolit_encodeSnappyBlockAsm
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeSnappyBlockAsm
@@ -10887,7 +10941,7 @@ matchlen_match4_match_nolit_encodeSnappyBlockAsm:
 
 matchlen_match2_match_nolit_encodeSnappyBlockAsm:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBlockAsm
+	JB   matchlen_match1_match_nolit_encodeSnappyBlockAsm
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeSnappyBlockAsm
@@ -10896,7 +10950,7 @@ matchlen_match2_match_nolit_encodeSnappyBlockAsm:
 
 matchlen_match1_match_nolit_encodeSnappyBlockAsm:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeSnappyBlockAsm
+	JB   match_nolit_end_encodeSnappyBlockAsm
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeSnappyBlockAsm
@@ -10910,17 +10964,17 @@ match_nolit_end_encodeSnappyBlockAsm:
 
 	// emitCopy
 	CMPL BX, $0x00010000
-	JL   two_byte_offset_match_nolit_encodeSnappyBlockAsm
+	JB   two_byte_offset_match_nolit_encodeSnappyBlockAsm
 
 four_bytes_loop_back_match_nolit_encodeSnappyBlockAsm:
 	CMPL R9, $0x40
-	JLE  four_bytes_remain_match_nolit_encodeSnappyBlockAsm
+	JBE  four_bytes_remain_match_nolit_encodeSnappyBlockAsm
 	MOVB $0xff, (AX)
 	MOVL BX, 1(AX)
 	LEAL -64(R9), R9
 	ADDQ $0x05, AX
 	CMPL R9, $0x04
-	JL   four_bytes_remain_match_nolit_encodeSnappyBlockAsm
+	JB   four_bytes_remain_match_nolit_encodeSnappyBlockAsm
 	JMP  four_bytes_loop_back_match_nolit_encodeSnappyBlockAsm
 
 four_bytes_remain_match_nolit_encodeSnappyBlockAsm:
@@ -10935,7 +10989,7 @@ four_bytes_remain_match_nolit_encodeSnappyBlockAsm:
 
 two_byte_offset_match_nolit_encodeSnappyBlockAsm:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm
 	MOVB $0xee, (AX)
 	MOVW BX, 1(AX)
 	LEAL -60(R9), R9
@@ -10946,9 +11000,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBlockAsm:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -10966,10 +11020,10 @@ emit_copy_three_match_nolit_encodeSnappyBlockAsm:
 
 match_nolit_emitcopy_end_encodeSnappyBlockAsm:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBlockAsm
+	JAE  emit_remainder_encodeSnappyBlockAsm
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBlockAsm
+	JB   match_nolit_dst_ok_encodeSnappyBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -10999,7 +11053,7 @@ emit_remainder_encodeSnappyBlockAsm:
 	SUBL 12(SP), CX
 	LEAQ 5(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBlockAsm
+	JB   emit_remainder_ok_encodeSnappyBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -11014,13 +11068,13 @@ emit_remainder_ok_encodeSnappyBlockAsm:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBlockAsm
+	JB   one_byte_emit_remainder_encodeSnappyBlockAsm
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBlockAsm
+	JB   two_bytes_emit_remainder_encodeSnappyBlockAsm
 	CMPL DX, $0x00010000
-	JLT  three_bytes_emit_remainder_encodeSnappyBlockAsm
+	JB   three_bytes_emit_remainder_encodeSnappyBlockAsm
 	CMPL DX, $0x01000000
-	JLT  four_bytes_emit_remainder_encodeSnappyBlockAsm
+	JB   four_bytes_emit_remainder_encodeSnappyBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL DX, 1(AX)
 	ADDQ $0x05, AX
@@ -11046,7 +11100,7 @@ two_bytes_emit_remainder_encodeSnappyBlockAsm:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBlockAsm
+	JB   memmove_emit_remainder_encodeSnappyBlockAsm
 	JMP  memmove_long_emit_remainder_encodeSnappyBlockAsm
 
 one_byte_emit_remainder_encodeSnappyBlockAsm:
@@ -11209,7 +11263,7 @@ search_loop_encodeSnappyBlockAsm64K:
 	SHRL  $0x06, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBlockAsm64K
+	JAE   emit_remainder_encodeSnappyBlockAsm64K
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -11247,7 +11301,7 @@ search_loop_encodeSnappyBlockAsm64K:
 
 repeat_extend_back_loop_encodeSnappyBlockAsm64K:
 	CMPL SI, BX
-	JLE  repeat_extend_back_end_encodeSnappyBlockAsm64K
+	JBE  repeat_extend_back_end_encodeSnappyBlockAsm64K
 	MOVB -1(DX)(DI*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -11266,9 +11320,12 @@ repeat_extend_back_end_encodeSnappyBlockAsm64K:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeSnappyBlockAsm64K
+	JB   one_byte_repeat_emit_encodeSnappyBlockAsm64K
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeSnappyBlockAsm64K
+	JB   two_bytes_repeat_emit_encodeSnappyBlockAsm64K
+	JB   three_bytes_repeat_emit_encodeSnappyBlockAsm64K
+
+three_bytes_repeat_emit_encodeSnappyBlockAsm64K:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -11279,7 +11336,7 @@ two_bytes_repeat_emit_encodeSnappyBlockAsm64K:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeSnappyBlockAsm64K
+	JB   memmove_repeat_emit_encodeSnappyBlockAsm64K
 	JMP  memmove_long_repeat_emit_encodeSnappyBlockAsm64K
 
 one_byte_repeat_emit_encodeSnappyBlockAsm64K:
@@ -11292,7 +11349,7 @@ memmove_repeat_emit_encodeSnappyBlockAsm64K:
 
 	// genMemMoveShort
 	CMPQ DI, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_8
 	CMPQ DI, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm64K_memmove_move_8through16
 	CMPQ DI, $0x20
@@ -11388,7 +11445,7 @@ emit_literal_done_repeat_emit_encodeSnappyBlockAsm64K:
 	// matchLen
 	XORL R10, R10
 	CMPL DI, $0x08
-	JL   matchlen_match4_repeat_extend_encodeSnappyBlockAsm64K
+	JB   matchlen_match4_repeat_extend_encodeSnappyBlockAsm64K
 
 matchlen_loopback_repeat_extend_encodeSnappyBlockAsm64K:
 	MOVQ  (R8)(R10*1), R9
@@ -11411,12 +11468,12 @@ matchlen_loop_repeat_extend_encodeSnappyBlockAsm64K:
 	LEAL -8(DI), DI
 	LEAL 8(R10), R10
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm64K
+	JAE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm64K
 	JZ   repeat_extend_forward_end_encodeSnappyBlockAsm64K
 
 matchlen_match4_repeat_extend_encodeSnappyBlockAsm64K:
 	CMPL DI, $0x04
-	JL   matchlen_match2_repeat_extend_encodeSnappyBlockAsm64K
+	JB   matchlen_match2_repeat_extend_encodeSnappyBlockAsm64K
 	MOVL (R8)(R10*1), R9
 	CMPL (BX)(R10*1), R9
 	JNE  matchlen_match2_repeat_extend_encodeSnappyBlockAsm64K
@@ -11425,7 +11482,7 @@ matchlen_match4_repeat_extend_encodeSnappyBlockAsm64K:
 
 matchlen_match2_repeat_extend_encodeSnappyBlockAsm64K:
 	CMPL DI, $0x02
-	JL   matchlen_match1_repeat_extend_encodeSnappyBlockAsm64K
+	JB   matchlen_match1_repeat_extend_encodeSnappyBlockAsm64K
 	MOVW (R8)(R10*1), R9
 	CMPW (BX)(R10*1), R9
 	JNE  matchlen_match1_repeat_extend_encodeSnappyBlockAsm64K
@@ -11434,7 +11491,7 @@ matchlen_match2_repeat_extend_encodeSnappyBlockAsm64K:
 
 matchlen_match1_repeat_extend_encodeSnappyBlockAsm64K:
 	CMPL DI, $0x01
-	JL   repeat_extend_forward_end_encodeSnappyBlockAsm64K
+	JB   repeat_extend_forward_end_encodeSnappyBlockAsm64K
 	MOVB (R8)(R10*1), R9
 	CMPB (BX)(R10*1), R9
 	JNE  repeat_extend_forward_end_encodeSnappyBlockAsm64K
@@ -11449,7 +11506,7 @@ repeat_extend_forward_end_encodeSnappyBlockAsm64K:
 	// emitCopy
 two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm64K:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm64K
+	JBE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm64K
 	MOVB $0xee, (AX)
 	MOVW SI, 1(AX)
 	LEAL -60(BX), BX
@@ -11460,9 +11517,9 @@ two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm64K:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm64K
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm64K
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm64K
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm64K
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -11513,7 +11570,7 @@ candidate_match_encodeSnappyBlockAsm64K:
 
 match_extend_back_loop_encodeSnappyBlockAsm64K:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBlockAsm64K
+	JBE  match_extend_back_end_encodeSnappyBlockAsm64K
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -11528,7 +11585,7 @@ match_extend_back_end_encodeSnappyBlockAsm64K:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBlockAsm64K
+	JB   match_dst_size_check_encodeSnappyBlockAsm64K
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -11543,9 +11600,12 @@ match_dst_size_check_encodeSnappyBlockAsm64K:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBlockAsm64K
+	JB   one_byte_match_emit_encodeSnappyBlockAsm64K
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBlockAsm64K
+	JB   two_bytes_match_emit_encodeSnappyBlockAsm64K
+	JB   three_bytes_match_emit_encodeSnappyBlockAsm64K
+
+three_bytes_match_emit_encodeSnappyBlockAsm64K:
 	MOVB $0xf4, (AX)
 	MOVW DI, 1(AX)
 	ADDQ $0x03, AX
@@ -11556,7 +11616,7 @@ two_bytes_match_emit_encodeSnappyBlockAsm64K:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeSnappyBlockAsm64K
+	JB   memmove_match_emit_encodeSnappyBlockAsm64K
 	JMP  memmove_long_match_emit_encodeSnappyBlockAsm64K
 
 one_byte_match_emit_encodeSnappyBlockAsm64K:
@@ -11569,7 +11629,7 @@ memmove_match_emit_encodeSnappyBlockAsm64K:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm64K_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -11668,7 +11728,7 @@ match_nolit_loop_encodeSnappyBlockAsm64K:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBlockAsm64K
+	JB   matchlen_match4_match_nolit_encodeSnappyBlockAsm64K
 
 matchlen_loopback_match_nolit_encodeSnappyBlockAsm64K:
 	MOVQ  (DI)(R9*1), R8
@@ -11691,12 +11751,12 @@ matchlen_loop_match_nolit_encodeSnappyBlockAsm64K:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm64K
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm64K
 	JZ   match_nolit_end_encodeSnappyBlockAsm64K
 
 matchlen_match4_match_nolit_encodeSnappyBlockAsm64K:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBlockAsm64K
+	JB   matchlen_match2_match_nolit_encodeSnappyBlockAsm64K
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeSnappyBlockAsm64K
@@ -11705,7 +11765,7 @@ matchlen_match4_match_nolit_encodeSnappyBlockAsm64K:
 
 matchlen_match2_match_nolit_encodeSnappyBlockAsm64K:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBlockAsm64K
+	JB   matchlen_match1_match_nolit_encodeSnappyBlockAsm64K
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeSnappyBlockAsm64K
@@ -11714,7 +11774,7 @@ matchlen_match2_match_nolit_encodeSnappyBlockAsm64K:
 
 matchlen_match1_match_nolit_encodeSnappyBlockAsm64K:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeSnappyBlockAsm64K
+	JB   match_nolit_end_encodeSnappyBlockAsm64K
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeSnappyBlockAsm64K
@@ -11729,7 +11789,7 @@ match_nolit_end_encodeSnappyBlockAsm64K:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBlockAsm64K:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm64K
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm64K
 	MOVB $0xee, (AX)
 	MOVW BX, 1(AX)
 	LEAL -60(R9), R9
@@ -11740,9 +11800,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBlockAsm64K:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm64K
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm64K
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm64K
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm64K
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -11760,10 +11820,10 @@ emit_copy_three_match_nolit_encodeSnappyBlockAsm64K:
 
 match_nolit_emitcopy_end_encodeSnappyBlockAsm64K:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBlockAsm64K
+	JAE  emit_remainder_encodeSnappyBlockAsm64K
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBlockAsm64K
+	JB   match_nolit_dst_ok_encodeSnappyBlockAsm64K
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -11793,7 +11853,7 @@ emit_remainder_encodeSnappyBlockAsm64K:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBlockAsm64K
+	JB   emit_remainder_ok_encodeSnappyBlockAsm64K
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -11808,9 +11868,12 @@ emit_remainder_ok_encodeSnappyBlockAsm64K:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBlockAsm64K
+	JB   one_byte_emit_remainder_encodeSnappyBlockAsm64K
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBlockAsm64K
+	JB   two_bytes_emit_remainder_encodeSnappyBlockAsm64K
+	JB   three_bytes_emit_remainder_encodeSnappyBlockAsm64K
+
+three_bytes_emit_remainder_encodeSnappyBlockAsm64K:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -11821,7 +11884,7 @@ two_bytes_emit_remainder_encodeSnappyBlockAsm64K:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBlockAsm64K
+	JB   memmove_emit_remainder_encodeSnappyBlockAsm64K
 	JMP  memmove_long_emit_remainder_encodeSnappyBlockAsm64K
 
 one_byte_emit_remainder_encodeSnappyBlockAsm64K:
@@ -11984,7 +12047,7 @@ search_loop_encodeSnappyBlockAsm12B:
 	SHRL  $0x05, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBlockAsm12B
+	JAE   emit_remainder_encodeSnappyBlockAsm12B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x000000cf1bbcdcbb, R8
@@ -12022,7 +12085,7 @@ search_loop_encodeSnappyBlockAsm12B:
 
 repeat_extend_back_loop_encodeSnappyBlockAsm12B:
 	CMPL SI, BX
-	JLE  repeat_extend_back_end_encodeSnappyBlockAsm12B
+	JBE  repeat_extend_back_end_encodeSnappyBlockAsm12B
 	MOVB -1(DX)(DI*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -12041,9 +12104,12 @@ repeat_extend_back_end_encodeSnappyBlockAsm12B:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeSnappyBlockAsm12B
+	JB   one_byte_repeat_emit_encodeSnappyBlockAsm12B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeSnappyBlockAsm12B
+	JB   two_bytes_repeat_emit_encodeSnappyBlockAsm12B
+	JB   three_bytes_repeat_emit_encodeSnappyBlockAsm12B
+
+three_bytes_repeat_emit_encodeSnappyBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -12054,7 +12120,7 @@ two_bytes_repeat_emit_encodeSnappyBlockAsm12B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeSnappyBlockAsm12B
+	JB   memmove_repeat_emit_encodeSnappyBlockAsm12B
 	JMP  memmove_long_repeat_emit_encodeSnappyBlockAsm12B
 
 one_byte_repeat_emit_encodeSnappyBlockAsm12B:
@@ -12067,7 +12133,7 @@ memmove_repeat_emit_encodeSnappyBlockAsm12B:
 
 	// genMemMoveShort
 	CMPQ DI, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm12B_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm12B_memmove_move_8
 	CMPQ DI, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm12B_memmove_move_8through16
 	CMPQ DI, $0x20
@@ -12163,7 +12229,7 @@ emit_literal_done_repeat_emit_encodeSnappyBlockAsm12B:
 	// matchLen
 	XORL R10, R10
 	CMPL DI, $0x08
-	JL   matchlen_match4_repeat_extend_encodeSnappyBlockAsm12B
+	JB   matchlen_match4_repeat_extend_encodeSnappyBlockAsm12B
 
 matchlen_loopback_repeat_extend_encodeSnappyBlockAsm12B:
 	MOVQ  (R8)(R10*1), R9
@@ -12186,12 +12252,12 @@ matchlen_loop_repeat_extend_encodeSnappyBlockAsm12B:
 	LEAL -8(DI), DI
 	LEAL 8(R10), R10
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm12B
+	JAE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm12B
 	JZ   repeat_extend_forward_end_encodeSnappyBlockAsm12B
 
 matchlen_match4_repeat_extend_encodeSnappyBlockAsm12B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_repeat_extend_encodeSnappyBlockAsm12B
+	JB   matchlen_match2_repeat_extend_encodeSnappyBlockAsm12B
 	MOVL (R8)(R10*1), R9
 	CMPL (BX)(R10*1), R9
 	JNE  matchlen_match2_repeat_extend_encodeSnappyBlockAsm12B
@@ -12200,7 +12266,7 @@ matchlen_match4_repeat_extend_encodeSnappyBlockAsm12B:
 
 matchlen_match2_repeat_extend_encodeSnappyBlockAsm12B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_repeat_extend_encodeSnappyBlockAsm12B
+	JB   matchlen_match1_repeat_extend_encodeSnappyBlockAsm12B
 	MOVW (R8)(R10*1), R9
 	CMPW (BX)(R10*1), R9
 	JNE  matchlen_match1_repeat_extend_encodeSnappyBlockAsm12B
@@ -12209,7 +12275,7 @@ matchlen_match2_repeat_extend_encodeSnappyBlockAsm12B:
 
 matchlen_match1_repeat_extend_encodeSnappyBlockAsm12B:
 	CMPL DI, $0x01
-	JL   repeat_extend_forward_end_encodeSnappyBlockAsm12B
+	JB   repeat_extend_forward_end_encodeSnappyBlockAsm12B
 	MOVB (R8)(R10*1), R9
 	CMPB (BX)(R10*1), R9
 	JNE  repeat_extend_forward_end_encodeSnappyBlockAsm12B
@@ -12224,7 +12290,7 @@ repeat_extend_forward_end_encodeSnappyBlockAsm12B:
 	// emitCopy
 two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm12B:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm12B
+	JBE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm12B
 	MOVB $0xee, (AX)
 	MOVW SI, 1(AX)
 	LEAL -60(BX), BX
@@ -12235,9 +12301,9 @@ two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm12B:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm12B
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm12B
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm12B
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm12B
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -12288,7 +12354,7 @@ candidate_match_encodeSnappyBlockAsm12B:
 
 match_extend_back_loop_encodeSnappyBlockAsm12B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBlockAsm12B
+	JBE  match_extend_back_end_encodeSnappyBlockAsm12B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -12303,7 +12369,7 @@ match_extend_back_end_encodeSnappyBlockAsm12B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBlockAsm12B
+	JB   match_dst_size_check_encodeSnappyBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -12318,9 +12384,12 @@ match_dst_size_check_encodeSnappyBlockAsm12B:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBlockAsm12B
+	JB   one_byte_match_emit_encodeSnappyBlockAsm12B
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBlockAsm12B
+	JB   two_bytes_match_emit_encodeSnappyBlockAsm12B
+	JB   three_bytes_match_emit_encodeSnappyBlockAsm12B
+
+three_bytes_match_emit_encodeSnappyBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW DI, 1(AX)
 	ADDQ $0x03, AX
@@ -12331,7 +12400,7 @@ two_bytes_match_emit_encodeSnappyBlockAsm12B:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeSnappyBlockAsm12B
+	JB   memmove_match_emit_encodeSnappyBlockAsm12B
 	JMP  memmove_long_match_emit_encodeSnappyBlockAsm12B
 
 one_byte_match_emit_encodeSnappyBlockAsm12B:
@@ -12344,7 +12413,7 @@ memmove_match_emit_encodeSnappyBlockAsm12B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm12B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm12B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm12B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -12443,7 +12512,7 @@ match_nolit_loop_encodeSnappyBlockAsm12B:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBlockAsm12B
+	JB   matchlen_match4_match_nolit_encodeSnappyBlockAsm12B
 
 matchlen_loopback_match_nolit_encodeSnappyBlockAsm12B:
 	MOVQ  (DI)(R9*1), R8
@@ -12466,12 +12535,12 @@ matchlen_loop_match_nolit_encodeSnappyBlockAsm12B:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm12B
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm12B
 	JZ   match_nolit_end_encodeSnappyBlockAsm12B
 
 matchlen_match4_match_nolit_encodeSnappyBlockAsm12B:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBlockAsm12B
+	JB   matchlen_match2_match_nolit_encodeSnappyBlockAsm12B
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeSnappyBlockAsm12B
@@ -12480,7 +12549,7 @@ matchlen_match4_match_nolit_encodeSnappyBlockAsm12B:
 
 matchlen_match2_match_nolit_encodeSnappyBlockAsm12B:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBlockAsm12B
+	JB   matchlen_match1_match_nolit_encodeSnappyBlockAsm12B
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeSnappyBlockAsm12B
@@ -12489,7 +12558,7 @@ matchlen_match2_match_nolit_encodeSnappyBlockAsm12B:
 
 matchlen_match1_match_nolit_encodeSnappyBlockAsm12B:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeSnappyBlockAsm12B
+	JB   match_nolit_end_encodeSnappyBlockAsm12B
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeSnappyBlockAsm12B
@@ -12504,7 +12573,7 @@ match_nolit_end_encodeSnappyBlockAsm12B:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBlockAsm12B:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm12B
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm12B
 	MOVB $0xee, (AX)
 	MOVW BX, 1(AX)
 	LEAL -60(R9), R9
@@ -12515,9 +12584,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBlockAsm12B:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm12B
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm12B
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -12535,10 +12604,10 @@ emit_copy_three_match_nolit_encodeSnappyBlockAsm12B:
 
 match_nolit_emitcopy_end_encodeSnappyBlockAsm12B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBlockAsm12B
+	JAE  emit_remainder_encodeSnappyBlockAsm12B
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBlockAsm12B
+	JB   match_nolit_dst_ok_encodeSnappyBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -12568,7 +12637,7 @@ emit_remainder_encodeSnappyBlockAsm12B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBlockAsm12B
+	JB   emit_remainder_ok_encodeSnappyBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -12583,9 +12652,12 @@ emit_remainder_ok_encodeSnappyBlockAsm12B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBlockAsm12B
+	JB   one_byte_emit_remainder_encodeSnappyBlockAsm12B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBlockAsm12B
+	JB   two_bytes_emit_remainder_encodeSnappyBlockAsm12B
+	JB   three_bytes_emit_remainder_encodeSnappyBlockAsm12B
+
+three_bytes_emit_remainder_encodeSnappyBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -12596,7 +12668,7 @@ two_bytes_emit_remainder_encodeSnappyBlockAsm12B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBlockAsm12B
+	JB   memmove_emit_remainder_encodeSnappyBlockAsm12B
 	JMP  memmove_long_emit_remainder_encodeSnappyBlockAsm12B
 
 one_byte_emit_remainder_encodeSnappyBlockAsm12B:
@@ -12759,7 +12831,7 @@ search_loop_encodeSnappyBlockAsm10B:
 	SHRL  $0x05, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBlockAsm10B
+	JAE   emit_remainder_encodeSnappyBlockAsm10B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x9e3779b1, R8
@@ -12797,7 +12869,7 @@ search_loop_encodeSnappyBlockAsm10B:
 
 repeat_extend_back_loop_encodeSnappyBlockAsm10B:
 	CMPL SI, BX
-	JLE  repeat_extend_back_end_encodeSnappyBlockAsm10B
+	JBE  repeat_extend_back_end_encodeSnappyBlockAsm10B
 	MOVB -1(DX)(DI*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -12816,9 +12888,12 @@ repeat_extend_back_end_encodeSnappyBlockAsm10B:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeSnappyBlockAsm10B
+	JB   one_byte_repeat_emit_encodeSnappyBlockAsm10B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeSnappyBlockAsm10B
+	JB   two_bytes_repeat_emit_encodeSnappyBlockAsm10B
+	JB   three_bytes_repeat_emit_encodeSnappyBlockAsm10B
+
+three_bytes_repeat_emit_encodeSnappyBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -12829,7 +12904,7 @@ two_bytes_repeat_emit_encodeSnappyBlockAsm10B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeSnappyBlockAsm10B
+	JB   memmove_repeat_emit_encodeSnappyBlockAsm10B
 	JMP  memmove_long_repeat_emit_encodeSnappyBlockAsm10B
 
 one_byte_repeat_emit_encodeSnappyBlockAsm10B:
@@ -12842,7 +12917,7 @@ memmove_repeat_emit_encodeSnappyBlockAsm10B:
 
 	// genMemMoveShort
 	CMPQ DI, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm10B_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm10B_memmove_move_8
 	CMPQ DI, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm10B_memmove_move_8through16
 	CMPQ DI, $0x20
@@ -12938,7 +13013,7 @@ emit_literal_done_repeat_emit_encodeSnappyBlockAsm10B:
 	// matchLen
 	XORL R10, R10
 	CMPL DI, $0x08
-	JL   matchlen_match4_repeat_extend_encodeSnappyBlockAsm10B
+	JB   matchlen_match4_repeat_extend_encodeSnappyBlockAsm10B
 
 matchlen_loopback_repeat_extend_encodeSnappyBlockAsm10B:
 	MOVQ  (R8)(R10*1), R9
@@ -12961,12 +13036,12 @@ matchlen_loop_repeat_extend_encodeSnappyBlockAsm10B:
 	LEAL -8(DI), DI
 	LEAL 8(R10), R10
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm10B
+	JAE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm10B
 	JZ   repeat_extend_forward_end_encodeSnappyBlockAsm10B
 
 matchlen_match4_repeat_extend_encodeSnappyBlockAsm10B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_repeat_extend_encodeSnappyBlockAsm10B
+	JB   matchlen_match2_repeat_extend_encodeSnappyBlockAsm10B
 	MOVL (R8)(R10*1), R9
 	CMPL (BX)(R10*1), R9
 	JNE  matchlen_match2_repeat_extend_encodeSnappyBlockAsm10B
@@ -12975,7 +13050,7 @@ matchlen_match4_repeat_extend_encodeSnappyBlockAsm10B:
 
 matchlen_match2_repeat_extend_encodeSnappyBlockAsm10B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_repeat_extend_encodeSnappyBlockAsm10B
+	JB   matchlen_match1_repeat_extend_encodeSnappyBlockAsm10B
 	MOVW (R8)(R10*1), R9
 	CMPW (BX)(R10*1), R9
 	JNE  matchlen_match1_repeat_extend_encodeSnappyBlockAsm10B
@@ -12984,7 +13059,7 @@ matchlen_match2_repeat_extend_encodeSnappyBlockAsm10B:
 
 matchlen_match1_repeat_extend_encodeSnappyBlockAsm10B:
 	CMPL DI, $0x01
-	JL   repeat_extend_forward_end_encodeSnappyBlockAsm10B
+	JB   repeat_extend_forward_end_encodeSnappyBlockAsm10B
 	MOVB (R8)(R10*1), R9
 	CMPB (BX)(R10*1), R9
 	JNE  repeat_extend_forward_end_encodeSnappyBlockAsm10B
@@ -12999,7 +13074,7 @@ repeat_extend_forward_end_encodeSnappyBlockAsm10B:
 	// emitCopy
 two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm10B:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm10B
+	JBE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm10B
 	MOVB $0xee, (AX)
 	MOVW SI, 1(AX)
 	LEAL -60(BX), BX
@@ -13010,9 +13085,9 @@ two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm10B:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm10B
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm10B
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm10B
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm10B
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -13063,7 +13138,7 @@ candidate_match_encodeSnappyBlockAsm10B:
 
 match_extend_back_loop_encodeSnappyBlockAsm10B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBlockAsm10B
+	JBE  match_extend_back_end_encodeSnappyBlockAsm10B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -13078,7 +13153,7 @@ match_extend_back_end_encodeSnappyBlockAsm10B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBlockAsm10B
+	JB   match_dst_size_check_encodeSnappyBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -13093,9 +13168,12 @@ match_dst_size_check_encodeSnappyBlockAsm10B:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBlockAsm10B
+	JB   one_byte_match_emit_encodeSnappyBlockAsm10B
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBlockAsm10B
+	JB   two_bytes_match_emit_encodeSnappyBlockAsm10B
+	JB   three_bytes_match_emit_encodeSnappyBlockAsm10B
+
+three_bytes_match_emit_encodeSnappyBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW DI, 1(AX)
 	ADDQ $0x03, AX
@@ -13106,7 +13184,7 @@ two_bytes_match_emit_encodeSnappyBlockAsm10B:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeSnappyBlockAsm10B
+	JB   memmove_match_emit_encodeSnappyBlockAsm10B
 	JMP  memmove_long_match_emit_encodeSnappyBlockAsm10B
 
 one_byte_match_emit_encodeSnappyBlockAsm10B:
@@ -13119,7 +13197,7 @@ memmove_match_emit_encodeSnappyBlockAsm10B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm10B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm10B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm10B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -13218,7 +13296,7 @@ match_nolit_loop_encodeSnappyBlockAsm10B:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBlockAsm10B
+	JB   matchlen_match4_match_nolit_encodeSnappyBlockAsm10B
 
 matchlen_loopback_match_nolit_encodeSnappyBlockAsm10B:
 	MOVQ  (DI)(R9*1), R8
@@ -13241,12 +13319,12 @@ matchlen_loop_match_nolit_encodeSnappyBlockAsm10B:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm10B
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm10B
 	JZ   match_nolit_end_encodeSnappyBlockAsm10B
 
 matchlen_match4_match_nolit_encodeSnappyBlockAsm10B:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBlockAsm10B
+	JB   matchlen_match2_match_nolit_encodeSnappyBlockAsm10B
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeSnappyBlockAsm10B
@@ -13255,7 +13333,7 @@ matchlen_match4_match_nolit_encodeSnappyBlockAsm10B:
 
 matchlen_match2_match_nolit_encodeSnappyBlockAsm10B:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBlockAsm10B
+	JB   matchlen_match1_match_nolit_encodeSnappyBlockAsm10B
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeSnappyBlockAsm10B
@@ -13264,7 +13342,7 @@ matchlen_match2_match_nolit_encodeSnappyBlockAsm10B:
 
 matchlen_match1_match_nolit_encodeSnappyBlockAsm10B:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeSnappyBlockAsm10B
+	JB   match_nolit_end_encodeSnappyBlockAsm10B
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeSnappyBlockAsm10B
@@ -13279,7 +13357,7 @@ match_nolit_end_encodeSnappyBlockAsm10B:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBlockAsm10B:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm10B
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm10B
 	MOVB $0xee, (AX)
 	MOVW BX, 1(AX)
 	LEAL -60(R9), R9
@@ -13290,9 +13368,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBlockAsm10B:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm10B
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm10B
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -13310,10 +13388,10 @@ emit_copy_three_match_nolit_encodeSnappyBlockAsm10B:
 
 match_nolit_emitcopy_end_encodeSnappyBlockAsm10B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBlockAsm10B
+	JAE  emit_remainder_encodeSnappyBlockAsm10B
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBlockAsm10B
+	JB   match_nolit_dst_ok_encodeSnappyBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -13343,7 +13421,7 @@ emit_remainder_encodeSnappyBlockAsm10B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBlockAsm10B
+	JB   emit_remainder_ok_encodeSnappyBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -13358,9 +13436,12 @@ emit_remainder_ok_encodeSnappyBlockAsm10B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBlockAsm10B
+	JB   one_byte_emit_remainder_encodeSnappyBlockAsm10B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBlockAsm10B
+	JB   two_bytes_emit_remainder_encodeSnappyBlockAsm10B
+	JB   three_bytes_emit_remainder_encodeSnappyBlockAsm10B
+
+three_bytes_emit_remainder_encodeSnappyBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -13371,7 +13452,7 @@ two_bytes_emit_remainder_encodeSnappyBlockAsm10B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBlockAsm10B
+	JB   memmove_emit_remainder_encodeSnappyBlockAsm10B
 	JMP  memmove_long_emit_remainder_encodeSnappyBlockAsm10B
 
 one_byte_emit_remainder_encodeSnappyBlockAsm10B:
@@ -13534,7 +13615,7 @@ search_loop_encodeSnappyBlockAsm8B:
 	SHRL  $0x04, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBlockAsm8B
+	JAE   emit_remainder_encodeSnappyBlockAsm8B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x9e3779b1, R8
@@ -13572,7 +13653,7 @@ search_loop_encodeSnappyBlockAsm8B:
 
 repeat_extend_back_loop_encodeSnappyBlockAsm8B:
 	CMPL SI, BX
-	JLE  repeat_extend_back_end_encodeSnappyBlockAsm8B
+	JBE  repeat_extend_back_end_encodeSnappyBlockAsm8B
 	MOVB -1(DX)(DI*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -13591,9 +13672,12 @@ repeat_extend_back_end_encodeSnappyBlockAsm8B:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_encodeSnappyBlockAsm8B
+	JB   one_byte_repeat_emit_encodeSnappyBlockAsm8B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_encodeSnappyBlockAsm8B
+	JB   two_bytes_repeat_emit_encodeSnappyBlockAsm8B
+	JB   three_bytes_repeat_emit_encodeSnappyBlockAsm8B
+
+three_bytes_repeat_emit_encodeSnappyBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -13604,7 +13688,7 @@ two_bytes_repeat_emit_encodeSnappyBlockAsm8B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_encodeSnappyBlockAsm8B
+	JB   memmove_repeat_emit_encodeSnappyBlockAsm8B
 	JMP  memmove_long_repeat_emit_encodeSnappyBlockAsm8B
 
 one_byte_repeat_emit_encodeSnappyBlockAsm8B:
@@ -13617,7 +13701,7 @@ memmove_repeat_emit_encodeSnappyBlockAsm8B:
 
 	// genMemMoveShort
 	CMPQ DI, $0x08
-	JLE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm8B_memmove_move_8
+	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm8B_memmove_move_8
 	CMPQ DI, $0x10
 	JBE  emit_lit_memmove_repeat_emit_encodeSnappyBlockAsm8B_memmove_move_8through16
 	CMPQ DI, $0x20
@@ -13713,7 +13797,7 @@ emit_literal_done_repeat_emit_encodeSnappyBlockAsm8B:
 	// matchLen
 	XORL R10, R10
 	CMPL DI, $0x08
-	JL   matchlen_match4_repeat_extend_encodeSnappyBlockAsm8B
+	JB   matchlen_match4_repeat_extend_encodeSnappyBlockAsm8B
 
 matchlen_loopback_repeat_extend_encodeSnappyBlockAsm8B:
 	MOVQ  (R8)(R10*1), R9
@@ -13736,12 +13820,12 @@ matchlen_loop_repeat_extend_encodeSnappyBlockAsm8B:
 	LEAL -8(DI), DI
 	LEAL 8(R10), R10
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm8B
+	JAE  matchlen_loopback_repeat_extend_encodeSnappyBlockAsm8B
 	JZ   repeat_extend_forward_end_encodeSnappyBlockAsm8B
 
 matchlen_match4_repeat_extend_encodeSnappyBlockAsm8B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_repeat_extend_encodeSnappyBlockAsm8B
+	JB   matchlen_match2_repeat_extend_encodeSnappyBlockAsm8B
 	MOVL (R8)(R10*1), R9
 	CMPL (BX)(R10*1), R9
 	JNE  matchlen_match2_repeat_extend_encodeSnappyBlockAsm8B
@@ -13750,7 +13834,7 @@ matchlen_match4_repeat_extend_encodeSnappyBlockAsm8B:
 
 matchlen_match2_repeat_extend_encodeSnappyBlockAsm8B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_repeat_extend_encodeSnappyBlockAsm8B
+	JB   matchlen_match1_repeat_extend_encodeSnappyBlockAsm8B
 	MOVW (R8)(R10*1), R9
 	CMPW (BX)(R10*1), R9
 	JNE  matchlen_match1_repeat_extend_encodeSnappyBlockAsm8B
@@ -13759,7 +13843,7 @@ matchlen_match2_repeat_extend_encodeSnappyBlockAsm8B:
 
 matchlen_match1_repeat_extend_encodeSnappyBlockAsm8B:
 	CMPL DI, $0x01
-	JL   repeat_extend_forward_end_encodeSnappyBlockAsm8B
+	JB   repeat_extend_forward_end_encodeSnappyBlockAsm8B
 	MOVB (R8)(R10*1), R9
 	CMPB (BX)(R10*1), R9
 	JNE  repeat_extend_forward_end_encodeSnappyBlockAsm8B
@@ -13774,7 +13858,7 @@ repeat_extend_forward_end_encodeSnappyBlockAsm8B:
 	// emitCopy
 two_byte_offset_repeat_as_copy_encodeSnappyBlockAsm8B:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm8B
+	JBE  two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm8B
 	MOVB $0xee, (AX)
 	MOVW SI, 1(AX)
 	LEAL -60(BX), BX
@@ -13785,7 +13869,7 @@ two_byte_offset_short_repeat_as_copy_encodeSnappyBlockAsm8B:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm8B
+	JAE  emit_copy_three_repeat_as_copy_encodeSnappyBlockAsm8B
 	LEAL -15(DI), DI
 	MOVB SI, 1(AX)
 	SHRL $0x08, SI
@@ -13836,7 +13920,7 @@ candidate_match_encodeSnappyBlockAsm8B:
 
 match_extend_back_loop_encodeSnappyBlockAsm8B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBlockAsm8B
+	JBE  match_extend_back_end_encodeSnappyBlockAsm8B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -13851,7 +13935,7 @@ match_extend_back_end_encodeSnappyBlockAsm8B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBlockAsm8B
+	JB   match_dst_size_check_encodeSnappyBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -13866,9 +13950,12 @@ match_dst_size_check_encodeSnappyBlockAsm8B:
 	SUBL DI, R8
 	LEAL -1(R8), DI
 	CMPL DI, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBlockAsm8B
+	JB   one_byte_match_emit_encodeSnappyBlockAsm8B
 	CMPL DI, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBlockAsm8B
+	JB   two_bytes_match_emit_encodeSnappyBlockAsm8B
+	JB   three_bytes_match_emit_encodeSnappyBlockAsm8B
+
+three_bytes_match_emit_encodeSnappyBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW DI, 1(AX)
 	ADDQ $0x03, AX
@@ -13879,7 +13966,7 @@ two_bytes_match_emit_encodeSnappyBlockAsm8B:
 	MOVB DI, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DI, $0x40
-	JL   memmove_match_emit_encodeSnappyBlockAsm8B
+	JB   memmove_match_emit_encodeSnappyBlockAsm8B
 	JMP  memmove_long_match_emit_encodeSnappyBlockAsm8B
 
 one_byte_match_emit_encodeSnappyBlockAsm8B:
@@ -13892,7 +13979,7 @@ memmove_match_emit_encodeSnappyBlockAsm8B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm8B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm8B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBlockAsm8B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -13991,7 +14078,7 @@ match_nolit_loop_encodeSnappyBlockAsm8B:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBlockAsm8B
+	JB   matchlen_match4_match_nolit_encodeSnappyBlockAsm8B
 
 matchlen_loopback_match_nolit_encodeSnappyBlockAsm8B:
 	MOVQ  (DI)(R9*1), R8
@@ -14014,12 +14101,12 @@ matchlen_loop_match_nolit_encodeSnappyBlockAsm8B:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm8B
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBlockAsm8B
 	JZ   match_nolit_end_encodeSnappyBlockAsm8B
 
 matchlen_match4_match_nolit_encodeSnappyBlockAsm8B:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBlockAsm8B
+	JB   matchlen_match2_match_nolit_encodeSnappyBlockAsm8B
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_encodeSnappyBlockAsm8B
@@ -14028,7 +14115,7 @@ matchlen_match4_match_nolit_encodeSnappyBlockAsm8B:
 
 matchlen_match2_match_nolit_encodeSnappyBlockAsm8B:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBlockAsm8B
+	JB   matchlen_match1_match_nolit_encodeSnappyBlockAsm8B
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_encodeSnappyBlockAsm8B
@@ -14037,7 +14124,7 @@ matchlen_match2_match_nolit_encodeSnappyBlockAsm8B:
 
 matchlen_match1_match_nolit_encodeSnappyBlockAsm8B:
 	CMPL SI, $0x01
-	JL   match_nolit_end_encodeSnappyBlockAsm8B
+	JB   match_nolit_end_encodeSnappyBlockAsm8B
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_encodeSnappyBlockAsm8B
@@ -14052,7 +14139,7 @@ match_nolit_end_encodeSnappyBlockAsm8B:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBlockAsm8B:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm8B
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBlockAsm8B
 	MOVB $0xee, (AX)
 	MOVW BX, 1(AX)
 	LEAL -60(R9), R9
@@ -14063,7 +14150,7 @@ two_byte_offset_short_match_nolit_encodeSnappyBlockAsm8B:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBlockAsm8B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBlockAsm8B
 	LEAL -15(SI), SI
 	MOVB BL, 1(AX)
 	SHRL $0x08, BX
@@ -14081,10 +14168,10 @@ emit_copy_three_match_nolit_encodeSnappyBlockAsm8B:
 
 match_nolit_emitcopy_end_encodeSnappyBlockAsm8B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBlockAsm8B
+	JAE  emit_remainder_encodeSnappyBlockAsm8B
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBlockAsm8B
+	JB   match_nolit_dst_ok_encodeSnappyBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -14114,7 +14201,7 @@ emit_remainder_encodeSnappyBlockAsm8B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBlockAsm8B
+	JB   emit_remainder_ok_encodeSnappyBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -14129,9 +14216,12 @@ emit_remainder_ok_encodeSnappyBlockAsm8B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBlockAsm8B
+	JB   one_byte_emit_remainder_encodeSnappyBlockAsm8B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBlockAsm8B
+	JB   two_bytes_emit_remainder_encodeSnappyBlockAsm8B
+	JB   three_bytes_emit_remainder_encodeSnappyBlockAsm8B
+
+three_bytes_emit_remainder_encodeSnappyBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -14142,7 +14232,7 @@ two_bytes_emit_remainder_encodeSnappyBlockAsm8B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBlockAsm8B
+	JB   memmove_emit_remainder_encodeSnappyBlockAsm8B
 	JMP  memmove_long_emit_remainder_encodeSnappyBlockAsm8B
 
 one_byte_emit_remainder_encodeSnappyBlockAsm8B:
@@ -14304,7 +14394,7 @@ search_loop_encodeSnappyBetterBlockAsm:
 	SUBL 12(SP), BX
 	SHRL $0x07, BX
 	CMPL BX, $0x63
-	JLE  check_maxskip_ok_encodeSnappyBetterBlockAsm
+	JBE  check_maxskip_ok_encodeSnappyBetterBlockAsm
 	LEAL 100(CX), BX
 	JMP  check_maxskip_cont_encodeSnappyBetterBlockAsm
 
@@ -14313,7 +14403,7 @@ check_maxskip_ok_encodeSnappyBetterBlockAsm:
 
 check_maxskip_cont_encodeSnappyBetterBlockAsm:
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBetterBlockAsm
+	JAE   emit_remainder_encodeSnappyBetterBlockAsm
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x00cf1bbcdcbfa563, R8
@@ -14368,7 +14458,7 @@ candidate_match_encodeSnappyBetterBlockAsm:
 
 match_extend_back_loop_encodeSnappyBetterBlockAsm:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm
+	JBE  match_extend_back_end_encodeSnappyBetterBlockAsm
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -14383,7 +14473,7 @@ match_extend_back_end_encodeSnappyBetterBlockAsm:
 	SUBL 12(SP), SI
 	LEAQ 5(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBetterBlockAsm
+	JB   match_dst_size_check_encodeSnappyBetterBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -14399,7 +14489,7 @@ match_dst_size_check_encodeSnappyBetterBlockAsm:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm
+	JB   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm
 
 matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm:
 	MOVQ  (R8)(R11*1), R10
@@ -14422,12 +14512,12 @@ matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm
 	JZ   match_nolit_end_encodeSnappyBetterBlockAsm
 
 matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm
+	JB   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm
@@ -14436,7 +14526,7 @@ matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm:
 
 matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm
+	JB   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm
@@ -14445,7 +14535,7 @@ matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm:
 
 matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeSnappyBetterBlockAsm
+	JB   match_nolit_end_encodeSnappyBetterBlockAsm
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeSnappyBetterBlockAsm
@@ -14457,9 +14547,9 @@ match_nolit_end_encodeSnappyBetterBlockAsm:
 
 	// Check if repeat
 	CMPL R11, $0x01
-	JG   match_length_ok_encodeSnappyBetterBlockAsm
+	JA   match_length_ok_encodeSnappyBetterBlockAsm
 	CMPL DI, $0x0000ffff
-	JLE  match_length_ok_encodeSnappyBetterBlockAsm
+	JBE  match_length_ok_encodeSnappyBetterBlockAsm
 	MOVL 20(SP), CX
 	INCL CX
 	JMP  search_loop_encodeSnappyBetterBlockAsm
@@ -14475,13 +14565,13 @@ match_length_ok_encodeSnappyBetterBlockAsm:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm
+	JB   one_byte_match_emit_encodeSnappyBetterBlockAsm
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm
+	JB   two_bytes_match_emit_encodeSnappyBetterBlockAsm
 	CMPL BX, $0x00010000
-	JLT  three_bytes_match_emit_encodeSnappyBetterBlockAsm
+	JB   three_bytes_match_emit_encodeSnappyBetterBlockAsm
 	CMPL BX, $0x01000000
-	JLT  four_bytes_match_emit_encodeSnappyBetterBlockAsm
+	JB   four_bytes_match_emit_encodeSnappyBetterBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL BX, 1(AX)
 	ADDQ $0x05, AX
@@ -14507,7 +14597,7 @@ two_bytes_match_emit_encodeSnappyBetterBlockAsm:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeSnappyBetterBlockAsm
+	JB   memmove_match_emit_encodeSnappyBetterBlockAsm
 	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm
 
 one_byte_match_emit_encodeSnappyBetterBlockAsm:
@@ -14520,7 +14610,7 @@ memmove_match_emit_encodeSnappyBetterBlockAsm:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -14611,17 +14701,17 @@ emit_literal_done_match_emit_encodeSnappyBetterBlockAsm:
 
 	// emitCopy
 	CMPL DI, $0x00010000
-	JL   two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm
+	JB   two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm
 
 four_bytes_loop_back_match_nolit_encodeSnappyBetterBlockAsm:
 	CMPL R11, $0x40
-	JLE  four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm
+	JBE  four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm
 	MOVB $0xff, (AX)
 	MOVL DI, 1(AX)
 	LEAL -64(R11), R11
 	ADDQ $0x05, AX
 	CMPL R11, $0x04
-	JL   four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm
+	JB   four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm
 	JMP  four_bytes_loop_back_match_nolit_encodeSnappyBetterBlockAsm
 
 four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm:
@@ -14636,7 +14726,7 @@ four_bytes_remain_match_nolit_encodeSnappyBetterBlockAsm:
 
 two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm:
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm
 	MOVB $0xee, (AX)
 	MOVW DI, 1(AX)
 	LEAL -60(R11), R11
@@ -14647,9 +14737,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -14667,9 +14757,9 @@ emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm:
 
 match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBetterBlockAsm
+	JAE  emit_remainder_encodeSnappyBetterBlockAsm
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm
+	JB   match_nolit_dst_ok_encodeSnappyBetterBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -14725,7 +14815,7 @@ emit_remainder_encodeSnappyBetterBlockAsm:
 	SUBL 12(SP), CX
 	LEAQ 5(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm
+	JB   emit_remainder_ok_encodeSnappyBetterBlockAsm
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -14740,13 +14830,13 @@ emit_remainder_ok_encodeSnappyBetterBlockAsm:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm
+	JB   one_byte_emit_remainder_encodeSnappyBetterBlockAsm
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm
+	JB   two_bytes_emit_remainder_encodeSnappyBetterBlockAsm
 	CMPL DX, $0x00010000
-	JLT  three_bytes_emit_remainder_encodeSnappyBetterBlockAsm
+	JB   three_bytes_emit_remainder_encodeSnappyBetterBlockAsm
 	CMPL DX, $0x01000000
-	JLT  four_bytes_emit_remainder_encodeSnappyBetterBlockAsm
+	JB   four_bytes_emit_remainder_encodeSnappyBetterBlockAsm
 	MOVB $0xfc, (AX)
 	MOVL DX, 1(AX)
 	ADDQ $0x05, AX
@@ -14772,7 +14862,7 @@ two_bytes_emit_remainder_encodeSnappyBetterBlockAsm:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm
+	JB   memmove_emit_remainder_encodeSnappyBetterBlockAsm
 	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm
 
 one_byte_emit_remainder_encodeSnappyBetterBlockAsm:
@@ -14935,7 +15025,7 @@ search_loop_encodeSnappyBetterBlockAsm64K:
 	SHRL  $0x07, BX
 	LEAL  1(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBetterBlockAsm64K
+	JAE   emit_remainder_encodeSnappyBetterBlockAsm64K
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x00cf1bbcdcbfa563, R8
@@ -14990,7 +15080,7 @@ candidate_match_encodeSnappyBetterBlockAsm64K:
 
 match_extend_back_loop_encodeSnappyBetterBlockAsm64K:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm64K
+	JBE  match_extend_back_end_encodeSnappyBetterBlockAsm64K
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -15005,7 +15095,7 @@ match_extend_back_end_encodeSnappyBetterBlockAsm64K:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBetterBlockAsm64K
+	JB   match_dst_size_check_encodeSnappyBetterBlockAsm64K
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -15021,7 +15111,7 @@ match_dst_size_check_encodeSnappyBetterBlockAsm64K:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm64K
+	JB   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm64K
 
 matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm64K:
 	MOVQ  (R8)(R11*1), R10
@@ -15044,12 +15134,12 @@ matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm64K:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm64K
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm64K
 	JZ   match_nolit_end_encodeSnappyBetterBlockAsm64K
 
 matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm64K:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm64K
+	JB   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm64K
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm64K
@@ -15058,7 +15148,7 @@ matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm64K:
 
 matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm64K:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm64K
+	JB   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm64K
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm64K
@@ -15067,7 +15157,7 @@ matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm64K:
 
 matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm64K:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeSnappyBetterBlockAsm64K
+	JB   match_nolit_end_encodeSnappyBetterBlockAsm64K
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeSnappyBetterBlockAsm64K
@@ -15088,9 +15178,12 @@ match_nolit_end_encodeSnappyBetterBlockAsm64K:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm64K
+	JB   one_byte_match_emit_encodeSnappyBetterBlockAsm64K
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm64K
+	JB   two_bytes_match_emit_encodeSnappyBetterBlockAsm64K
+	JB   three_bytes_match_emit_encodeSnappyBetterBlockAsm64K
+
+three_bytes_match_emit_encodeSnappyBetterBlockAsm64K:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -15101,7 +15194,7 @@ two_bytes_match_emit_encodeSnappyBetterBlockAsm64K:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeSnappyBetterBlockAsm64K
+	JB   memmove_match_emit_encodeSnappyBetterBlockAsm64K
 	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm64K
 
 one_byte_match_emit_encodeSnappyBetterBlockAsm64K:
@@ -15114,7 +15207,7 @@ memmove_match_emit_encodeSnappyBetterBlockAsm64K:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm64K_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -15206,7 +15299,7 @@ emit_literal_done_match_emit_encodeSnappyBetterBlockAsm64K:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm64K:
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm64K
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm64K
 	MOVB $0xee, (AX)
 	MOVW DI, 1(AX)
 	LEAL -60(R11), R11
@@ -15217,9 +15310,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm64K:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -15237,9 +15330,9 @@ emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm64K:
 
 match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm64K:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBetterBlockAsm64K
+	JAE  emit_remainder_encodeSnappyBetterBlockAsm64K
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm64K
+	JB   match_nolit_dst_ok_encodeSnappyBetterBlockAsm64K
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -15295,7 +15388,7 @@ emit_remainder_encodeSnappyBetterBlockAsm64K:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm64K
+	JB   emit_remainder_ok_encodeSnappyBetterBlockAsm64K
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -15310,9 +15403,12 @@ emit_remainder_ok_encodeSnappyBetterBlockAsm64K:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm64K
+	JB   one_byte_emit_remainder_encodeSnappyBetterBlockAsm64K
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm64K
+	JB   two_bytes_emit_remainder_encodeSnappyBetterBlockAsm64K
+	JB   three_bytes_emit_remainder_encodeSnappyBetterBlockAsm64K
+
+three_bytes_emit_remainder_encodeSnappyBetterBlockAsm64K:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -15323,7 +15419,7 @@ two_bytes_emit_remainder_encodeSnappyBetterBlockAsm64K:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm64K
+	JB   memmove_emit_remainder_encodeSnappyBetterBlockAsm64K
 	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm64K
 
 one_byte_emit_remainder_encodeSnappyBetterBlockAsm64K:
@@ -15486,7 +15582,7 @@ search_loop_encodeSnappyBetterBlockAsm12B:
 	SHRL  $0x06, BX
 	LEAL  1(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBetterBlockAsm12B
+	JAE   emit_remainder_encodeSnappyBetterBlockAsm12B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -15541,7 +15637,7 @@ candidate_match_encodeSnappyBetterBlockAsm12B:
 
 match_extend_back_loop_encodeSnappyBetterBlockAsm12B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm12B
+	JBE  match_extend_back_end_encodeSnappyBetterBlockAsm12B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -15556,7 +15652,7 @@ match_extend_back_end_encodeSnappyBetterBlockAsm12B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBetterBlockAsm12B
+	JB   match_dst_size_check_encodeSnappyBetterBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -15572,7 +15668,7 @@ match_dst_size_check_encodeSnappyBetterBlockAsm12B:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm12B
+	JB   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm12B
 
 matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm12B:
 	MOVQ  (R8)(R11*1), R10
@@ -15595,12 +15691,12 @@ matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm12B:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm12B
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm12B
 	JZ   match_nolit_end_encodeSnappyBetterBlockAsm12B
 
 matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm12B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm12B
+	JB   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm12B
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm12B
@@ -15609,7 +15705,7 @@ matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm12B:
 
 matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm12B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm12B
+	JB   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm12B
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm12B
@@ -15618,7 +15714,7 @@ matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm12B:
 
 matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm12B:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeSnappyBetterBlockAsm12B
+	JB   match_nolit_end_encodeSnappyBetterBlockAsm12B
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeSnappyBetterBlockAsm12B
@@ -15639,9 +15735,12 @@ match_nolit_end_encodeSnappyBetterBlockAsm12B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm12B
+	JB   one_byte_match_emit_encodeSnappyBetterBlockAsm12B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm12B
+	JB   two_bytes_match_emit_encodeSnappyBetterBlockAsm12B
+	JB   three_bytes_match_emit_encodeSnappyBetterBlockAsm12B
+
+three_bytes_match_emit_encodeSnappyBetterBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -15652,7 +15751,7 @@ two_bytes_match_emit_encodeSnappyBetterBlockAsm12B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeSnappyBetterBlockAsm12B
+	JB   memmove_match_emit_encodeSnappyBetterBlockAsm12B
 	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm12B
 
 one_byte_match_emit_encodeSnappyBetterBlockAsm12B:
@@ -15665,7 +15764,7 @@ memmove_match_emit_encodeSnappyBetterBlockAsm12B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm12B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -15757,7 +15856,7 @@ emit_literal_done_match_emit_encodeSnappyBetterBlockAsm12B:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm12B:
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm12B
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm12B
 	MOVB $0xee, (AX)
 	MOVW DI, 1(AX)
 	LEAL -60(R11), R11
@@ -15768,9 +15867,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm12B:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -15788,9 +15887,9 @@ emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm12B:
 
 match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm12B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBetterBlockAsm12B
+	JAE  emit_remainder_encodeSnappyBetterBlockAsm12B
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm12B
+	JB   match_nolit_dst_ok_encodeSnappyBetterBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -15846,7 +15945,7 @@ emit_remainder_encodeSnappyBetterBlockAsm12B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm12B
+	JB   emit_remainder_ok_encodeSnappyBetterBlockAsm12B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -15861,9 +15960,12 @@ emit_remainder_ok_encodeSnappyBetterBlockAsm12B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm12B
+	JB   one_byte_emit_remainder_encodeSnappyBetterBlockAsm12B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm12B
+	JB   two_bytes_emit_remainder_encodeSnappyBetterBlockAsm12B
+	JB   three_bytes_emit_remainder_encodeSnappyBetterBlockAsm12B
+
+three_bytes_emit_remainder_encodeSnappyBetterBlockAsm12B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -15874,7 +15976,7 @@ two_bytes_emit_remainder_encodeSnappyBetterBlockAsm12B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm12B
+	JB   memmove_emit_remainder_encodeSnappyBetterBlockAsm12B
 	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm12B
 
 one_byte_emit_remainder_encodeSnappyBetterBlockAsm12B:
@@ -16037,7 +16139,7 @@ search_loop_encodeSnappyBetterBlockAsm10B:
 	SHRL  $0x05, BX
 	LEAL  1(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBetterBlockAsm10B
+	JAE   emit_remainder_encodeSnappyBetterBlockAsm10B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -16092,7 +16194,7 @@ candidate_match_encodeSnappyBetterBlockAsm10B:
 
 match_extend_back_loop_encodeSnappyBetterBlockAsm10B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm10B
+	JBE  match_extend_back_end_encodeSnappyBetterBlockAsm10B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -16107,7 +16209,7 @@ match_extend_back_end_encodeSnappyBetterBlockAsm10B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBetterBlockAsm10B
+	JB   match_dst_size_check_encodeSnappyBetterBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -16123,7 +16225,7 @@ match_dst_size_check_encodeSnappyBetterBlockAsm10B:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm10B
+	JB   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm10B
 
 matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm10B:
 	MOVQ  (R8)(R11*1), R10
@@ -16146,12 +16248,12 @@ matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm10B:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm10B
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm10B
 	JZ   match_nolit_end_encodeSnappyBetterBlockAsm10B
 
 matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm10B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm10B
+	JB   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm10B
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm10B
@@ -16160,7 +16262,7 @@ matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm10B:
 
 matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm10B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm10B
+	JB   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm10B
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm10B
@@ -16169,7 +16271,7 @@ matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm10B:
 
 matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm10B:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeSnappyBetterBlockAsm10B
+	JB   match_nolit_end_encodeSnappyBetterBlockAsm10B
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeSnappyBetterBlockAsm10B
@@ -16190,9 +16292,12 @@ match_nolit_end_encodeSnappyBetterBlockAsm10B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm10B
+	JB   one_byte_match_emit_encodeSnappyBetterBlockAsm10B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm10B
+	JB   two_bytes_match_emit_encodeSnappyBetterBlockAsm10B
+	JB   three_bytes_match_emit_encodeSnappyBetterBlockAsm10B
+
+three_bytes_match_emit_encodeSnappyBetterBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -16203,7 +16308,7 @@ two_bytes_match_emit_encodeSnappyBetterBlockAsm10B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeSnappyBetterBlockAsm10B
+	JB   memmove_match_emit_encodeSnappyBetterBlockAsm10B
 	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm10B
 
 one_byte_match_emit_encodeSnappyBetterBlockAsm10B:
@@ -16216,7 +16321,7 @@ memmove_match_emit_encodeSnappyBetterBlockAsm10B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm10B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -16308,7 +16413,7 @@ emit_literal_done_match_emit_encodeSnappyBetterBlockAsm10B:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm10B:
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm10B
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm10B
 	MOVB $0xee, (AX)
 	MOVW DI, 1(AX)
 	LEAL -60(R11), R11
@@ -16319,9 +16424,9 @@ two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm10B:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B
 	CMPL DI, $0x00000800
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -16339,9 +16444,9 @@ emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm10B:
 
 match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm10B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBetterBlockAsm10B
+	JAE  emit_remainder_encodeSnappyBetterBlockAsm10B
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm10B
+	JB   match_nolit_dst_ok_encodeSnappyBetterBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -16397,7 +16502,7 @@ emit_remainder_encodeSnappyBetterBlockAsm10B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm10B
+	JB   emit_remainder_ok_encodeSnappyBetterBlockAsm10B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -16412,9 +16517,12 @@ emit_remainder_ok_encodeSnappyBetterBlockAsm10B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm10B
+	JB   one_byte_emit_remainder_encodeSnappyBetterBlockAsm10B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm10B
+	JB   two_bytes_emit_remainder_encodeSnappyBetterBlockAsm10B
+	JB   three_bytes_emit_remainder_encodeSnappyBetterBlockAsm10B
+
+three_bytes_emit_remainder_encodeSnappyBetterBlockAsm10B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -16425,7 +16533,7 @@ two_bytes_emit_remainder_encodeSnappyBetterBlockAsm10B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm10B
+	JB   memmove_emit_remainder_encodeSnappyBetterBlockAsm10B
 	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm10B
 
 one_byte_emit_remainder_encodeSnappyBetterBlockAsm10B:
@@ -16588,7 +16696,7 @@ search_loop_encodeSnappyBetterBlockAsm8B:
 	SHRL  $0x04, BX
 	LEAL  1(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_encodeSnappyBetterBlockAsm8B
+	JAE   emit_remainder_encodeSnappyBetterBlockAsm8B
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -16643,7 +16751,7 @@ candidate_match_encodeSnappyBetterBlockAsm8B:
 
 match_extend_back_loop_encodeSnappyBetterBlockAsm8B:
 	CMPL CX, SI
-	JLE  match_extend_back_end_encodeSnappyBetterBlockAsm8B
+	JBE  match_extend_back_end_encodeSnappyBetterBlockAsm8B
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -16658,7 +16766,7 @@ match_extend_back_end_encodeSnappyBetterBlockAsm8B:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_encodeSnappyBetterBlockAsm8B
+	JB   match_dst_size_check_encodeSnappyBetterBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -16674,7 +16782,7 @@ match_dst_size_check_encodeSnappyBetterBlockAsm8B:
 	// matchLen
 	XORL R11, R11
 	CMPL DI, $0x08
-	JL   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm8B
+	JB   matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm8B
 
 matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm8B:
 	MOVQ  (R8)(R11*1), R10
@@ -16697,12 +16805,12 @@ matchlen_loop_match_nolit_encodeSnappyBetterBlockAsm8B:
 	LEAL -8(DI), DI
 	LEAL 8(R11), R11
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm8B
+	JAE  matchlen_loopback_match_nolit_encodeSnappyBetterBlockAsm8B
 	JZ   match_nolit_end_encodeSnappyBetterBlockAsm8B
 
 matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm8B:
 	CMPL DI, $0x04
-	JL   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm8B
+	JB   matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm8B
 	MOVL (R8)(R11*1), R10
 	CMPL (R9)(R11*1), R10
 	JNE  matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm8B
@@ -16711,7 +16819,7 @@ matchlen_match4_match_nolit_encodeSnappyBetterBlockAsm8B:
 
 matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm8B:
 	CMPL DI, $0x02
-	JL   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm8B
+	JB   matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm8B
 	MOVW (R8)(R11*1), R10
 	CMPW (R9)(R11*1), R10
 	JNE  matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm8B
@@ -16720,7 +16828,7 @@ matchlen_match2_match_nolit_encodeSnappyBetterBlockAsm8B:
 
 matchlen_match1_match_nolit_encodeSnappyBetterBlockAsm8B:
 	CMPL DI, $0x01
-	JL   match_nolit_end_encodeSnappyBetterBlockAsm8B
+	JB   match_nolit_end_encodeSnappyBetterBlockAsm8B
 	MOVB (R8)(R11*1), R10
 	CMPB (R9)(R11*1), R10
 	JNE  match_nolit_end_encodeSnappyBetterBlockAsm8B
@@ -16741,9 +16849,12 @@ match_nolit_end_encodeSnappyBetterBlockAsm8B:
 	SUBL BX, R8
 	LEAL -1(R8), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_match_emit_encodeSnappyBetterBlockAsm8B
+	JB   one_byte_match_emit_encodeSnappyBetterBlockAsm8B
 	CMPL BX, $0x00000100
-	JLT  two_bytes_match_emit_encodeSnappyBetterBlockAsm8B
+	JB   two_bytes_match_emit_encodeSnappyBetterBlockAsm8B
+	JB   three_bytes_match_emit_encodeSnappyBetterBlockAsm8B
+
+three_bytes_match_emit_encodeSnappyBetterBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW BX, 1(AX)
 	ADDQ $0x03, AX
@@ -16754,7 +16865,7 @@ two_bytes_match_emit_encodeSnappyBetterBlockAsm8B:
 	MOVB BL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_match_emit_encodeSnappyBetterBlockAsm8B
+	JB   memmove_match_emit_encodeSnappyBetterBlockAsm8B
 	JMP  memmove_long_match_emit_encodeSnappyBetterBlockAsm8B
 
 one_byte_match_emit_encodeSnappyBetterBlockAsm8B:
@@ -16767,7 +16878,7 @@ memmove_match_emit_encodeSnappyBetterBlockAsm8B:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_8
+	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_match_emit_encodeSnappyBetterBlockAsm8B_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -16859,7 +16970,7 @@ emit_literal_done_match_emit_encodeSnappyBetterBlockAsm8B:
 	// emitCopy
 two_byte_offset_match_nolit_encodeSnappyBetterBlockAsm8B:
 	CMPL R11, $0x40
-	JLE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm8B
+	JBE  two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm8B
 	MOVB $0xee, (AX)
 	MOVW DI, 1(AX)
 	LEAL -60(R11), R11
@@ -16870,7 +16981,7 @@ two_byte_offset_short_match_nolit_encodeSnappyBetterBlockAsm8B:
 	MOVL R11, BX
 	SHLL $0x02, BX
 	CMPL R11, $0x0c
-	JGE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm8B
+	JAE  emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm8B
 	LEAL -15(BX), BX
 	MOVB DI, 1(AX)
 	SHRL $0x08, DI
@@ -16888,9 +16999,9 @@ emit_copy_three_match_nolit_encodeSnappyBetterBlockAsm8B:
 
 match_nolit_emitcopy_end_encodeSnappyBetterBlockAsm8B:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_encodeSnappyBetterBlockAsm8B
+	JAE  emit_remainder_encodeSnappyBetterBlockAsm8B
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_encodeSnappyBetterBlockAsm8B
+	JB   match_nolit_dst_ok_encodeSnappyBetterBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -16946,7 +17057,7 @@ emit_remainder_encodeSnappyBetterBlockAsm8B:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_encodeSnappyBetterBlockAsm8B
+	JB   emit_remainder_ok_encodeSnappyBetterBlockAsm8B
 	MOVQ $0x00000000, ret+48(FP)
 	RET
 
@@ -16961,9 +17072,12 @@ emit_remainder_ok_encodeSnappyBetterBlockAsm8B:
 	SUBL BX, SI
 	LEAL -1(SI), DX
 	CMPL DX, $0x3c
-	JLT  one_byte_emit_remainder_encodeSnappyBetterBlockAsm8B
+	JB   one_byte_emit_remainder_encodeSnappyBetterBlockAsm8B
 	CMPL DX, $0x00000100
-	JLT  two_bytes_emit_remainder_encodeSnappyBetterBlockAsm8B
+	JB   two_bytes_emit_remainder_encodeSnappyBetterBlockAsm8B
+	JB   three_bytes_emit_remainder_encodeSnappyBetterBlockAsm8B
+
+three_bytes_emit_remainder_encodeSnappyBetterBlockAsm8B:
 	MOVB $0xf4, (AX)
 	MOVW DX, 1(AX)
 	ADDQ $0x03, AX
@@ -16974,7 +17088,7 @@ two_bytes_emit_remainder_encodeSnappyBetterBlockAsm8B:
 	MOVB DL, 1(AX)
 	ADDQ $0x02, AX
 	CMPL DX, $0x40
-	JL   memmove_emit_remainder_encodeSnappyBetterBlockAsm8B
+	JB   memmove_emit_remainder_encodeSnappyBetterBlockAsm8B
 	JMP  memmove_long_emit_remainder_encodeSnappyBetterBlockAsm8B
 
 one_byte_emit_remainder_encodeSnappyBetterBlockAsm8B:
@@ -17137,7 +17251,7 @@ search_loop_calcBlockSize:
 	SHRL  $0x05, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_calcBlockSize
+	JAE   emit_remainder_calcBlockSize
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x0000cf1bbcdcbf9b, R8
@@ -17175,7 +17289,7 @@ search_loop_calcBlockSize:
 
 repeat_extend_back_loop_calcBlockSize:
 	CMPL SI, BX
-	JLE  repeat_extend_back_end_calcBlockSize
+	JBE  repeat_extend_back_end_calcBlockSize
 	MOVB -1(DX)(DI*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -17194,13 +17308,13 @@ repeat_extend_back_end_calcBlockSize:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_calcBlockSize
+	JB   one_byte_repeat_emit_calcBlockSize
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_calcBlockSize
+	JB   two_bytes_repeat_emit_calcBlockSize
 	CMPL BX, $0x00010000
-	JLT  three_bytes_repeat_emit_calcBlockSize
+	JB   three_bytes_repeat_emit_calcBlockSize
 	CMPL BX, $0x01000000
-	JLT  four_bytes_repeat_emit_calcBlockSize
+	JB   four_bytes_repeat_emit_calcBlockSize
 	ADDQ $0x05, AX
 	JMP  memmove_long_repeat_emit_calcBlockSize
 
@@ -17215,7 +17329,7 @@ three_bytes_repeat_emit_calcBlockSize:
 two_bytes_repeat_emit_calcBlockSize:
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_calcBlockSize
+	JB   memmove_repeat_emit_calcBlockSize
 	JMP  memmove_long_repeat_emit_calcBlockSize
 
 one_byte_repeat_emit_calcBlockSize:
@@ -17240,7 +17354,7 @@ emit_literal_done_repeat_emit_calcBlockSize:
 	// matchLen
 	XORL R10, R10
 	CMPL DI, $0x08
-	JL   matchlen_match4_repeat_extend_calcBlockSize
+	JB   matchlen_match4_repeat_extend_calcBlockSize
 
 matchlen_loopback_repeat_extend_calcBlockSize:
 	MOVQ  (R8)(R10*1), R9
@@ -17263,12 +17377,12 @@ matchlen_loop_repeat_extend_calcBlockSize:
 	LEAL -8(DI), DI
 	LEAL 8(R10), R10
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_repeat_extend_calcBlockSize
+	JAE  matchlen_loopback_repeat_extend_calcBlockSize
 	JZ   repeat_extend_forward_end_calcBlockSize
 
 matchlen_match4_repeat_extend_calcBlockSize:
 	CMPL DI, $0x04
-	JL   matchlen_match2_repeat_extend_calcBlockSize
+	JB   matchlen_match2_repeat_extend_calcBlockSize
 	MOVL (R8)(R10*1), R9
 	CMPL (BX)(R10*1), R9
 	JNE  matchlen_match2_repeat_extend_calcBlockSize
@@ -17277,7 +17391,7 @@ matchlen_match4_repeat_extend_calcBlockSize:
 
 matchlen_match2_repeat_extend_calcBlockSize:
 	CMPL DI, $0x02
-	JL   matchlen_match1_repeat_extend_calcBlockSize
+	JB   matchlen_match1_repeat_extend_calcBlockSize
 	MOVW (R8)(R10*1), R9
 	CMPW (BX)(R10*1), R9
 	JNE  matchlen_match1_repeat_extend_calcBlockSize
@@ -17286,7 +17400,7 @@ matchlen_match2_repeat_extend_calcBlockSize:
 
 matchlen_match1_repeat_extend_calcBlockSize:
 	CMPL DI, $0x01
-	JL   repeat_extend_forward_end_calcBlockSize
+	JB   repeat_extend_forward_end_calcBlockSize
 	MOVB (R8)(R10*1), R9
 	CMPB (BX)(R10*1), R9
 	JNE  repeat_extend_forward_end_calcBlockSize
@@ -17300,15 +17414,15 @@ repeat_extend_forward_end_calcBlockSize:
 
 	// emitCopy
 	CMPL SI, $0x00010000
-	JL   two_byte_offset_repeat_as_copy_calcBlockSize
+	JB   two_byte_offset_repeat_as_copy_calcBlockSize
 
 four_bytes_loop_back_repeat_as_copy_calcBlockSize:
 	CMPL BX, $0x40
-	JLE  four_bytes_remain_repeat_as_copy_calcBlockSize
+	JBE  four_bytes_remain_repeat_as_copy_calcBlockSize
 	LEAL -64(BX), BX
 	ADDQ $0x05, AX
 	CMPL BX, $0x04
-	JL   four_bytes_remain_repeat_as_copy_calcBlockSize
+	JB   four_bytes_remain_repeat_as_copy_calcBlockSize
 	JMP  four_bytes_loop_back_repeat_as_copy_calcBlockSize
 
 four_bytes_remain_repeat_as_copy_calcBlockSize:
@@ -17320,7 +17434,7 @@ four_bytes_remain_repeat_as_copy_calcBlockSize:
 
 two_byte_offset_repeat_as_copy_calcBlockSize:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_calcBlockSize
+	JBE  two_byte_offset_short_repeat_as_copy_calcBlockSize
 	LEAL -60(BX), BX
 	ADDQ $0x03, AX
 	JMP  two_byte_offset_repeat_as_copy_calcBlockSize
@@ -17329,9 +17443,9 @@ two_byte_offset_short_repeat_as_copy_calcBlockSize:
 	MOVL BX, DI
 	SHLL $0x02, DI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_calcBlockSize
+	JAE  emit_copy_three_repeat_as_copy_calcBlockSize
 	CMPL SI, $0x00000800
-	JGE  emit_copy_three_repeat_as_copy_calcBlockSize
+	JAE  emit_copy_three_repeat_as_copy_calcBlockSize
 	ADDQ $0x02, AX
 	JMP  repeat_end_emit_calcBlockSize
 
@@ -17373,7 +17487,7 @@ candidate_match_calcBlockSize:
 
 match_extend_back_loop_calcBlockSize:
 	CMPL CX, SI
-	JLE  match_extend_back_end_calcBlockSize
+	JBE  match_extend_back_end_calcBlockSize
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -17388,7 +17502,7 @@ match_extend_back_end_calcBlockSize:
 	SUBL 12(SP), SI
 	LEAQ 5(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_calcBlockSize
+	JB   match_dst_size_check_calcBlockSize
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
@@ -17403,13 +17517,13 @@ match_dst_size_check_calcBlockSize:
 	SUBL DI, R8
 	LEAL -1(R8), SI
 	CMPL SI, $0x3c
-	JLT  one_byte_match_emit_calcBlockSize
+	JB   one_byte_match_emit_calcBlockSize
 	CMPL SI, $0x00000100
-	JLT  two_bytes_match_emit_calcBlockSize
+	JB   two_bytes_match_emit_calcBlockSize
 	CMPL SI, $0x00010000
-	JLT  three_bytes_match_emit_calcBlockSize
+	JB   three_bytes_match_emit_calcBlockSize
 	CMPL SI, $0x01000000
-	JLT  four_bytes_match_emit_calcBlockSize
+	JB   four_bytes_match_emit_calcBlockSize
 	ADDQ $0x05, AX
 	JMP  memmove_long_match_emit_calcBlockSize
 
@@ -17424,7 +17538,7 @@ three_bytes_match_emit_calcBlockSize:
 two_bytes_match_emit_calcBlockSize:
 	ADDQ $0x02, AX
 	CMPL SI, $0x40
-	JL   memmove_match_emit_calcBlockSize
+	JB   memmove_match_emit_calcBlockSize
 	JMP  memmove_long_match_emit_calcBlockSize
 
 one_byte_match_emit_calcBlockSize:
@@ -17452,7 +17566,7 @@ match_nolit_loop_calcBlockSize:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_calcBlockSize
+	JB   matchlen_match4_match_nolit_calcBlockSize
 
 matchlen_loopback_match_nolit_calcBlockSize:
 	MOVQ  (DI)(R9*1), R8
@@ -17475,12 +17589,12 @@ matchlen_loop_match_nolit_calcBlockSize:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_calcBlockSize
+	JAE  matchlen_loopback_match_nolit_calcBlockSize
 	JZ   match_nolit_end_calcBlockSize
 
 matchlen_match4_match_nolit_calcBlockSize:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_calcBlockSize
+	JB   matchlen_match2_match_nolit_calcBlockSize
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_calcBlockSize
@@ -17489,7 +17603,7 @@ matchlen_match4_match_nolit_calcBlockSize:
 
 matchlen_match2_match_nolit_calcBlockSize:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_calcBlockSize
+	JB   matchlen_match1_match_nolit_calcBlockSize
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_calcBlockSize
@@ -17498,7 +17612,7 @@ matchlen_match2_match_nolit_calcBlockSize:
 
 matchlen_match1_match_nolit_calcBlockSize:
 	CMPL SI, $0x01
-	JL   match_nolit_end_calcBlockSize
+	JB   match_nolit_end_calcBlockSize
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_calcBlockSize
@@ -17512,15 +17626,15 @@ match_nolit_end_calcBlockSize:
 
 	// emitCopy
 	CMPL BX, $0x00010000
-	JL   two_byte_offset_match_nolit_calcBlockSize
+	JB   two_byte_offset_match_nolit_calcBlockSize
 
 four_bytes_loop_back_match_nolit_calcBlockSize:
 	CMPL R9, $0x40
-	JLE  four_bytes_remain_match_nolit_calcBlockSize
+	JBE  four_bytes_remain_match_nolit_calcBlockSize
 	LEAL -64(R9), R9
 	ADDQ $0x05, AX
 	CMPL R9, $0x04
-	JL   four_bytes_remain_match_nolit_calcBlockSize
+	JB   four_bytes_remain_match_nolit_calcBlockSize
 	JMP  four_bytes_loop_back_match_nolit_calcBlockSize
 
 four_bytes_remain_match_nolit_calcBlockSize:
@@ -17532,7 +17646,7 @@ four_bytes_remain_match_nolit_calcBlockSize:
 
 two_byte_offset_match_nolit_calcBlockSize:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_calcBlockSize
+	JBE  two_byte_offset_short_match_nolit_calcBlockSize
 	LEAL -60(R9), R9
 	ADDQ $0x03, AX
 	JMP  two_byte_offset_match_nolit_calcBlockSize
@@ -17541,9 +17655,9 @@ two_byte_offset_short_match_nolit_calcBlockSize:
 	MOVL R9, SI
 	SHLL $0x02, SI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_calcBlockSize
+	JAE  emit_copy_three_match_nolit_calcBlockSize
 	CMPL BX, $0x00000800
-	JGE  emit_copy_three_match_nolit_calcBlockSize
+	JAE  emit_copy_three_match_nolit_calcBlockSize
 	ADDQ $0x02, AX
 	JMP  match_nolit_emitcopy_end_calcBlockSize
 
@@ -17552,10 +17666,10 @@ emit_copy_three_match_nolit_calcBlockSize:
 
 match_nolit_emitcopy_end_calcBlockSize:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_calcBlockSize
+	JAE  emit_remainder_calcBlockSize
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_calcBlockSize
+	JB   match_nolit_dst_ok_calcBlockSize
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
@@ -17585,7 +17699,7 @@ emit_remainder_calcBlockSize:
 	SUBL 12(SP), CX
 	LEAQ 5(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_calcBlockSize
+	JB   emit_remainder_ok_calcBlockSize
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
@@ -17600,13 +17714,13 @@ emit_remainder_ok_calcBlockSize:
 	SUBL BX, SI
 	LEAL -1(SI), CX
 	CMPL CX, $0x3c
-	JLT  one_byte_emit_remainder_calcBlockSize
+	JB   one_byte_emit_remainder_calcBlockSize
 	CMPL CX, $0x00000100
-	JLT  two_bytes_emit_remainder_calcBlockSize
+	JB   two_bytes_emit_remainder_calcBlockSize
 	CMPL CX, $0x00010000
-	JLT  three_bytes_emit_remainder_calcBlockSize
+	JB   three_bytes_emit_remainder_calcBlockSize
 	CMPL CX, $0x01000000
-	JLT  four_bytes_emit_remainder_calcBlockSize
+	JB   four_bytes_emit_remainder_calcBlockSize
 	ADDQ $0x05, AX
 	JMP  memmove_long_emit_remainder_calcBlockSize
 
@@ -17621,7 +17735,7 @@ three_bytes_emit_remainder_calcBlockSize:
 two_bytes_emit_remainder_calcBlockSize:
 	ADDQ $0x02, AX
 	CMPL CX, $0x40
-	JL   memmove_emit_remainder_calcBlockSize
+	JB   memmove_emit_remainder_calcBlockSize
 	JMP  memmove_long_emit_remainder_calcBlockSize
 
 one_byte_emit_remainder_calcBlockSize:
@@ -17677,7 +17791,7 @@ search_loop_calcBlockSizeSmall:
 	SHRL  $0x04, BX
 	LEAL  4(CX)(BX*1), BX
 	CMPL  BX, 8(SP)
-	JGE   emit_remainder_calcBlockSizeSmall
+	JAE   emit_remainder_calcBlockSizeSmall
 	MOVQ  (DX)(CX*1), SI
 	MOVL  BX, 20(SP)
 	MOVQ  $0x9e3779b1, R8
@@ -17715,7 +17829,7 @@ search_loop_calcBlockSizeSmall:
 
 repeat_extend_back_loop_calcBlockSizeSmall:
 	CMPL SI, BX
-	JLE  repeat_extend_back_end_calcBlockSizeSmall
+	JBE  repeat_extend_back_end_calcBlockSizeSmall
 	MOVB -1(DX)(DI*1), R8
 	MOVB -1(DX)(SI*1), R9
 	CMPB R8, R9
@@ -17734,16 +17848,19 @@ repeat_extend_back_end_calcBlockSizeSmall:
 	SUBL BX, DI
 	LEAL -1(DI), BX
 	CMPL BX, $0x3c
-	JLT  one_byte_repeat_emit_calcBlockSizeSmall
+	JB   one_byte_repeat_emit_calcBlockSizeSmall
 	CMPL BX, $0x00000100
-	JLT  two_bytes_repeat_emit_calcBlockSizeSmall
+	JB   two_bytes_repeat_emit_calcBlockSizeSmall
+	JB   three_bytes_repeat_emit_calcBlockSizeSmall
+
+three_bytes_repeat_emit_calcBlockSizeSmall:
 	ADDQ $0x03, AX
 	JMP  memmove_long_repeat_emit_calcBlockSizeSmall
 
 two_bytes_repeat_emit_calcBlockSizeSmall:
 	ADDQ $0x02, AX
 	CMPL BX, $0x40
-	JL   memmove_repeat_emit_calcBlockSizeSmall
+	JB   memmove_repeat_emit_calcBlockSizeSmall
 	JMP  memmove_long_repeat_emit_calcBlockSizeSmall
 
 one_byte_repeat_emit_calcBlockSizeSmall:
@@ -17768,7 +17885,7 @@ emit_literal_done_repeat_emit_calcBlockSizeSmall:
 	// matchLen
 	XORL R10, R10
 	CMPL DI, $0x08
-	JL   matchlen_match4_repeat_extend_calcBlockSizeSmall
+	JB   matchlen_match4_repeat_extend_calcBlockSizeSmall
 
 matchlen_loopback_repeat_extend_calcBlockSizeSmall:
 	MOVQ  (R8)(R10*1), R9
@@ -17791,12 +17908,12 @@ matchlen_loop_repeat_extend_calcBlockSizeSmall:
 	LEAL -8(DI), DI
 	LEAL 8(R10), R10
 	CMPL DI, $0x08
-	JGE  matchlen_loopback_repeat_extend_calcBlockSizeSmall
+	JAE  matchlen_loopback_repeat_extend_calcBlockSizeSmall
 	JZ   repeat_extend_forward_end_calcBlockSizeSmall
 
 matchlen_match4_repeat_extend_calcBlockSizeSmall:
 	CMPL DI, $0x04
-	JL   matchlen_match2_repeat_extend_calcBlockSizeSmall
+	JB   matchlen_match2_repeat_extend_calcBlockSizeSmall
 	MOVL (R8)(R10*1), R9
 	CMPL (BX)(R10*1), R9
 	JNE  matchlen_match2_repeat_extend_calcBlockSizeSmall
@@ -17805,7 +17922,7 @@ matchlen_match4_repeat_extend_calcBlockSizeSmall:
 
 matchlen_match2_repeat_extend_calcBlockSizeSmall:
 	CMPL DI, $0x02
-	JL   matchlen_match1_repeat_extend_calcBlockSizeSmall
+	JB   matchlen_match1_repeat_extend_calcBlockSizeSmall
 	MOVW (R8)(R10*1), R9
 	CMPW (BX)(R10*1), R9
 	JNE  matchlen_match1_repeat_extend_calcBlockSizeSmall
@@ -17814,7 +17931,7 @@ matchlen_match2_repeat_extend_calcBlockSizeSmall:
 
 matchlen_match1_repeat_extend_calcBlockSizeSmall:
 	CMPL DI, $0x01
-	JL   repeat_extend_forward_end_calcBlockSizeSmall
+	JB   repeat_extend_forward_end_calcBlockSizeSmall
 	MOVB (R8)(R10*1), R9
 	CMPB (BX)(R10*1), R9
 	JNE  repeat_extend_forward_end_calcBlockSizeSmall
@@ -17829,7 +17946,7 @@ repeat_extend_forward_end_calcBlockSizeSmall:
 	// emitCopy
 two_byte_offset_repeat_as_copy_calcBlockSizeSmall:
 	CMPL BX, $0x40
-	JLE  two_byte_offset_short_repeat_as_copy_calcBlockSizeSmall
+	JBE  two_byte_offset_short_repeat_as_copy_calcBlockSizeSmall
 	LEAL -60(BX), BX
 	ADDQ $0x03, AX
 	JMP  two_byte_offset_repeat_as_copy_calcBlockSizeSmall
@@ -17838,7 +17955,7 @@ two_byte_offset_short_repeat_as_copy_calcBlockSizeSmall:
 	MOVL BX, SI
 	SHLL $0x02, SI
 	CMPL BX, $0x0c
-	JGE  emit_copy_three_repeat_as_copy_calcBlockSizeSmall
+	JAE  emit_copy_three_repeat_as_copy_calcBlockSizeSmall
 	ADDQ $0x02, AX
 	JMP  repeat_end_emit_calcBlockSizeSmall
 
@@ -17880,7 +17997,7 @@ candidate_match_calcBlockSizeSmall:
 
 match_extend_back_loop_calcBlockSizeSmall:
 	CMPL CX, SI
-	JLE  match_extend_back_end_calcBlockSizeSmall
+	JBE  match_extend_back_end_calcBlockSizeSmall
 	MOVB -1(DX)(BX*1), DI
 	MOVB -1(DX)(CX*1), R8
 	CMPB DI, R8
@@ -17895,7 +18012,7 @@ match_extend_back_end_calcBlockSizeSmall:
 	SUBL 12(SP), SI
 	LEAQ 3(AX)(SI*1), SI
 	CMPQ SI, (SP)
-	JL   match_dst_size_check_calcBlockSizeSmall
+	JB   match_dst_size_check_calcBlockSizeSmall
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
@@ -17910,16 +18027,19 @@ match_dst_size_check_calcBlockSizeSmall:
 	SUBL DI, R8
 	LEAL -1(R8), SI
 	CMPL SI, $0x3c
-	JLT  one_byte_match_emit_calcBlockSizeSmall
+	JB   one_byte_match_emit_calcBlockSizeSmall
 	CMPL SI, $0x00000100
-	JLT  two_bytes_match_emit_calcBlockSizeSmall
+	JB   two_bytes_match_emit_calcBlockSizeSmall
+	JB   three_bytes_match_emit_calcBlockSizeSmall
+
+three_bytes_match_emit_calcBlockSizeSmall:
 	ADDQ $0x03, AX
 	JMP  memmove_long_match_emit_calcBlockSizeSmall
 
 two_bytes_match_emit_calcBlockSizeSmall:
 	ADDQ $0x02, AX
 	CMPL SI, $0x40
-	JL   memmove_match_emit_calcBlockSizeSmall
+	JB   memmove_match_emit_calcBlockSizeSmall
 	JMP  memmove_long_match_emit_calcBlockSizeSmall
 
 one_byte_match_emit_calcBlockSizeSmall:
@@ -17947,7 +18067,7 @@ match_nolit_loop_calcBlockSizeSmall:
 	// matchLen
 	XORL R9, R9
 	CMPL SI, $0x08
-	JL   matchlen_match4_match_nolit_calcBlockSizeSmall
+	JB   matchlen_match4_match_nolit_calcBlockSizeSmall
 
 matchlen_loopback_match_nolit_calcBlockSizeSmall:
 	MOVQ  (DI)(R9*1), R8
@@ -17970,12 +18090,12 @@ matchlen_loop_match_nolit_calcBlockSizeSmall:
 	LEAL -8(SI), SI
 	LEAL 8(R9), R9
 	CMPL SI, $0x08
-	JGE  matchlen_loopback_match_nolit_calcBlockSizeSmall
+	JAE  matchlen_loopback_match_nolit_calcBlockSizeSmall
 	JZ   match_nolit_end_calcBlockSizeSmall
 
 matchlen_match4_match_nolit_calcBlockSizeSmall:
 	CMPL SI, $0x04
-	JL   matchlen_match2_match_nolit_calcBlockSizeSmall
+	JB   matchlen_match2_match_nolit_calcBlockSizeSmall
 	MOVL (DI)(R9*1), R8
 	CMPL (BX)(R9*1), R8
 	JNE  matchlen_match2_match_nolit_calcBlockSizeSmall
@@ -17984,7 +18104,7 @@ matchlen_match4_match_nolit_calcBlockSizeSmall:
 
 matchlen_match2_match_nolit_calcBlockSizeSmall:
 	CMPL SI, $0x02
-	JL   matchlen_match1_match_nolit_calcBlockSizeSmall
+	JB   matchlen_match1_match_nolit_calcBlockSizeSmall
 	MOVW (DI)(R9*1), R8
 	CMPW (BX)(R9*1), R8
 	JNE  matchlen_match1_match_nolit_calcBlockSizeSmall
@@ -17993,7 +18113,7 @@ matchlen_match2_match_nolit_calcBlockSizeSmall:
 
 matchlen_match1_match_nolit_calcBlockSizeSmall:
 	CMPL SI, $0x01
-	JL   match_nolit_end_calcBlockSizeSmall
+	JB   match_nolit_end_calcBlockSizeSmall
 	MOVB (DI)(R9*1), R8
 	CMPB (BX)(R9*1), R8
 	JNE  match_nolit_end_calcBlockSizeSmall
@@ -18008,7 +18128,7 @@ match_nolit_end_calcBlockSizeSmall:
 	// emitCopy
 two_byte_offset_match_nolit_calcBlockSizeSmall:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_match_nolit_calcBlockSizeSmall
+	JBE  two_byte_offset_short_match_nolit_calcBlockSizeSmall
 	LEAL -60(R9), R9
 	ADDQ $0x03, AX
 	JMP  two_byte_offset_match_nolit_calcBlockSizeSmall
@@ -18017,7 +18137,7 @@ two_byte_offset_short_match_nolit_calcBlockSizeSmall:
 	MOVL R9, BX
 	SHLL $0x02, BX
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_match_nolit_calcBlockSizeSmall
+	JAE  emit_copy_three_match_nolit_calcBlockSizeSmall
 	ADDQ $0x02, AX
 	JMP  match_nolit_emitcopy_end_calcBlockSizeSmall
 
@@ -18026,10 +18146,10 @@ emit_copy_three_match_nolit_calcBlockSizeSmall:
 
 match_nolit_emitcopy_end_calcBlockSizeSmall:
 	CMPL CX, 8(SP)
-	JGE  emit_remainder_calcBlockSizeSmall
+	JAE  emit_remainder_calcBlockSizeSmall
 	MOVQ -2(DX)(CX*1), SI
 	CMPQ AX, (SP)
-	JL   match_nolit_dst_ok_calcBlockSizeSmall
+	JB   match_nolit_dst_ok_calcBlockSizeSmall
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
@@ -18059,7 +18179,7 @@ emit_remainder_calcBlockSizeSmall:
 	SUBL 12(SP), CX
 	LEAQ 3(AX)(CX*1), CX
 	CMPQ CX, (SP)
-	JL   emit_remainder_ok_calcBlockSizeSmall
+	JB   emit_remainder_ok_calcBlockSizeSmall
 	MOVQ $0x00000000, ret+24(FP)
 	RET
 
@@ -18074,16 +18194,19 @@ emit_remainder_ok_calcBlockSizeSmall:
 	SUBL BX, SI
 	LEAL -1(SI), CX
 	CMPL CX, $0x3c
-	JLT  one_byte_emit_remainder_calcBlockSizeSmall
+	JB   one_byte_emit_remainder_calcBlockSizeSmall
 	CMPL CX, $0x00000100
-	JLT  two_bytes_emit_remainder_calcBlockSizeSmall
+	JB   two_bytes_emit_remainder_calcBlockSizeSmall
+	JB   three_bytes_emit_remainder_calcBlockSizeSmall
+
+three_bytes_emit_remainder_calcBlockSizeSmall:
 	ADDQ $0x03, AX
 	JMP  memmove_long_emit_remainder_calcBlockSizeSmall
 
 two_bytes_emit_remainder_calcBlockSizeSmall:
 	ADDQ $0x02, AX
 	CMPL CX, $0x40
-	JL   memmove_emit_remainder_calcBlockSizeSmall
+	JB   memmove_emit_remainder_calcBlockSizeSmall
 	JMP  memmove_long_emit_remainder_calcBlockSizeSmall
 
 one_byte_emit_remainder_calcBlockSizeSmall:
@@ -18111,13 +18234,13 @@ TEXT ·emitLiteral(SB), NOSPLIT, $0-56
 	MOVL  DX, BX
 	LEAL  -1(DX), SI
 	CMPL  SI, $0x3c
-	JLT   one_byte_standalone
+	JB    one_byte_standalone
 	CMPL  SI, $0x00000100
-	JLT   two_bytes_standalone
+	JB    two_bytes_standalone
 	CMPL  SI, $0x00010000
-	JLT   three_bytes_standalone
+	JB    three_bytes_standalone
 	CMPL  SI, $0x01000000
-	JLT   four_bytes_standalone
+	JB    four_bytes_standalone
 	MOVB  $0xfc, (AX)
 	MOVL  SI, 1(AX)
 	ADDQ  $0x05, BX
@@ -18147,7 +18270,7 @@ two_bytes_standalone:
 	ADDQ $0x02, BX
 	ADDQ $0x02, AX
 	CMPL SI, $0x40
-	JL   memmove_standalone
+	JB   memmove_standalone
 	JMP  memmove_long_standalone
 
 one_byte_standalone:
@@ -18278,19 +18401,19 @@ emit_repeat_again_standalone:
 	MOVL DX, SI
 	LEAL -4(DX), DX
 	CMPL SI, $0x08
-	JLE  repeat_two_standalone
+	JBE  repeat_two_standalone
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_standalone
+	JAE  cant_repeat_two_offset_standalone
 	CMPL CX, $0x00000800
-	JLT  repeat_two_offset_standalone
+	JB   repeat_two_offset_standalone
 
 cant_repeat_two_offset_standalone:
 	CMPL DX, $0x00000104
-	JLT  repeat_three_standalone
+	JB   repeat_three_standalone
 	CMPL DX, $0x00010100
-	JLT  repeat_four_standalone
+	JB   repeat_four_standalone
 	CMPL DX, $0x0100ffff
-	JLT  repeat_five_standalone
+	JB   repeat_five_standalone
 	LEAL -16842747(DX), DX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -18357,35 +18480,35 @@ TEXT ·emitCopy(SB), NOSPLIT, $0-48
 
 	// emitCopy
 	CMPL CX, $0x00010000
-	JL   two_byte_offset_standalone
+	JB   two_byte_offset_standalone
 	CMPL DX, $0x40
-	JLE  four_bytes_remain_standalone
+	JBE  four_bytes_remain_standalone
 	MOVB $0xff, (AX)
 	MOVL CX, 1(AX)
 	LEAL -64(DX), DX
 	ADDQ $0x05, BX
 	ADDQ $0x05, AX
 	CMPL DX, $0x04
-	JL   four_bytes_remain_standalone
+	JB   four_bytes_remain_standalone
 
 	// emitRepeat
 emit_repeat_again_standalone_emit_copy:
 	MOVL DX, SI
 	LEAL -4(DX), DX
 	CMPL SI, $0x08
-	JLE  repeat_two_standalone_emit_copy
+	JBE  repeat_two_standalone_emit_copy
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_standalone_emit_copy
+	JAE  cant_repeat_two_offset_standalone_emit_copy
 	CMPL CX, $0x00000800
-	JLT  repeat_two_offset_standalone_emit_copy
+	JB   repeat_two_offset_standalone_emit_copy
 
 cant_repeat_two_offset_standalone_emit_copy:
 	CMPL DX, $0x00000104
-	JLT  repeat_three_standalone_emit_copy
+	JB   repeat_three_standalone_emit_copy
 	CMPL DX, $0x00010100
-	JLT  repeat_four_standalone_emit_copy
+	JB   repeat_four_standalone_emit_copy
 	CMPL DX, $0x0100ffff
-	JLT  repeat_five_standalone_emit_copy
+	JB   repeat_five_standalone_emit_copy
 	LEAL -16842747(DX), DX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -18453,7 +18576,7 @@ four_bytes_remain_standalone:
 
 two_byte_offset_standalone:
 	CMPL DX, $0x40
-	JLE  two_byte_offset_short_standalone
+	JBE  two_byte_offset_short_standalone
 	CMPL CX, $0x00000800
 	JAE  long_offset_short_standalone
 	MOVL $0x00000001, SI
@@ -18476,19 +18599,19 @@ emit_repeat_again_standalone_emit_copy_short_2b:
 	MOVL DX, SI
 	LEAL -4(DX), DX
 	CMPL SI, $0x08
-	JLE  repeat_two_standalone_emit_copy_short_2b
+	JBE  repeat_two_standalone_emit_copy_short_2b
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_standalone_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_standalone_emit_copy_short_2b
 	CMPL CX, $0x00000800
-	JLT  repeat_two_offset_standalone_emit_copy_short_2b
+	JB   repeat_two_offset_standalone_emit_copy_short_2b
 
 cant_repeat_two_offset_standalone_emit_copy_short_2b:
 	CMPL DX, $0x00000104
-	JLT  repeat_three_standalone_emit_copy_short_2b
+	JB   repeat_three_standalone_emit_copy_short_2b
 	CMPL DX, $0x00010100
-	JLT  repeat_four_standalone_emit_copy_short_2b
+	JB   repeat_four_standalone_emit_copy_short_2b
 	CMPL DX, $0x0100ffff
-	JLT  repeat_five_standalone_emit_copy_short_2b
+	JB   repeat_five_standalone_emit_copy_short_2b
 	LEAL -16842747(DX), DX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -18555,19 +18678,19 @@ emit_repeat_again_standalone_emit_copy_short:
 	MOVL DX, SI
 	LEAL -4(DX), DX
 	CMPL SI, $0x08
-	JLE  repeat_two_standalone_emit_copy_short
+	JBE  repeat_two_standalone_emit_copy_short
 	CMPL SI, $0x0c
-	JGE  cant_repeat_two_offset_standalone_emit_copy_short
+	JAE  cant_repeat_two_offset_standalone_emit_copy_short
 	CMPL CX, $0x00000800
-	JLT  repeat_two_offset_standalone_emit_copy_short
+	JB   repeat_two_offset_standalone_emit_copy_short
 
 cant_repeat_two_offset_standalone_emit_copy_short:
 	CMPL DX, $0x00000104
-	JLT  repeat_three_standalone_emit_copy_short
+	JB   repeat_three_standalone_emit_copy_short
 	CMPL DX, $0x00010100
-	JLT  repeat_four_standalone_emit_copy_short
+	JB   repeat_four_standalone_emit_copy_short
 	CMPL DX, $0x0100ffff
-	JLT  repeat_five_standalone_emit_copy_short
+	JB   repeat_five_standalone_emit_copy_short
 	LEAL -16842747(DX), DX
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -18626,9 +18749,9 @@ two_byte_offset_short_standalone:
 	MOVL DX, SI
 	SHLL $0x02, SI
 	CMPL DX, $0x0c
-	JGE  emit_copy_three_standalone
+	JAE  emit_copy_three_standalone
 	CMPL CX, $0x00000800
-	JGE  emit_copy_three_standalone
+	JAE  emit_copy_three_standalone
 	LEAL -15(SI), SI
 	MOVB CL, 1(AX)
 	SHRL $0x08, CX
@@ -18659,18 +18782,18 @@ TEXT ·emitCopyNoRepeat(SB), NOSPLIT, $0-48
 
 	// emitCopy
 	CMPL CX, $0x00010000
-	JL   two_byte_offset_standalone_snappy
+	JB   two_byte_offset_standalone_snappy
 
 four_bytes_loop_back_standalone_snappy:
 	CMPL DX, $0x40
-	JLE  four_bytes_remain_standalone_snappy
+	JBE  four_bytes_remain_standalone_snappy
 	MOVB $0xff, (AX)
 	MOVL CX, 1(AX)
 	LEAL -64(DX), DX
 	ADDQ $0x05, BX
 	ADDQ $0x05, AX
 	CMPL DX, $0x04
-	JL   four_bytes_remain_standalone_snappy
+	JB   four_bytes_remain_standalone_snappy
 	JMP  four_bytes_loop_back_standalone_snappy
 
 four_bytes_remain_standalone_snappy:
@@ -18686,7 +18809,7 @@ four_bytes_remain_standalone_snappy:
 
 two_byte_offset_standalone_snappy:
 	CMPL DX, $0x40
-	JLE  two_byte_offset_short_standalone_snappy
+	JBE  two_byte_offset_short_standalone_snappy
 	MOVB $0xee, (AX)
 	MOVW CX, 1(AX)
 	LEAL -60(DX), DX
@@ -18698,9 +18821,9 @@ two_byte_offset_short_standalone_snappy:
 	MOVL DX, SI
 	SHLL $0x02, SI
 	CMPL DX, $0x0c
-	JGE  emit_copy_three_standalone_snappy
+	JAE  emit_copy_three_standalone_snappy
 	CMPL CX, $0x00000800
-	JGE  emit_copy_three_standalone_snappy
+	JAE  emit_copy_three_standalone_snappy
 	LEAL -15(SI), SI
 	MOVB CL, 1(AX)
 	SHRL $0x08, CX
@@ -18732,7 +18855,7 @@ TEXT ·matchLen(SB), NOSPLIT, $0-56
 	// matchLen
 	XORL SI, SI
 	CMPL DX, $0x08
-	JL   matchlen_match4_standalone
+	JB   matchlen_match4_standalone
 
 matchlen_loopback_standalone:
 	MOVQ  (AX)(SI*1), BX
@@ -18755,12 +18878,12 @@ matchlen_loop_standalone:
 	LEAL -8(DX), DX
 	LEAL 8(SI), SI
 	CMPL DX, $0x08
-	JGE  matchlen_loopback_standalone
+	JAE  matchlen_loopback_standalone
 	JZ   gen_match_len_end
 
 matchlen_match4_standalone:
 	CMPL DX, $0x04
-	JL   matchlen_match2_standalone
+	JB   matchlen_match2_standalone
 	MOVL (AX)(SI*1), BX
 	CMPL (CX)(SI*1), BX
 	JNE  matchlen_match2_standalone
@@ -18769,7 +18892,7 @@ matchlen_match4_standalone:
 
 matchlen_match2_standalone:
 	CMPL DX, $0x02
-	JL   matchlen_match1_standalone
+	JB   matchlen_match1_standalone
 	MOVW (AX)(SI*1), BX
 	CMPW (CX)(SI*1), BX
 	JNE  matchlen_match1_standalone
@@ -18778,7 +18901,7 @@ matchlen_match2_standalone:
 
 matchlen_match1_standalone:
 	CMPL DX, $0x01
-	JL   gen_match_len_end
+	JB   gen_match_len_end
 	MOVB (AX)(SI*1), BL
 	CMPB (CX)(SI*1), BL
 	JNE  gen_match_len_end
@@ -18837,13 +18960,13 @@ lz4_s2_ll_end:
 	ADDQ  R9, SI
 	LEAL  -1(R9), R11
 	CMPL  R11, $0x3c
-	JLT   one_byte_lz4_s2
+	JB    one_byte_lz4_s2
 	CMPL  R11, $0x00000100
-	JLT   two_bytes_lz4_s2
+	JB    two_bytes_lz4_s2
 	CMPL  R11, $0x00010000
-	JLT   three_bytes_lz4_s2
+	JB    three_bytes_lz4_s2
 	CMPL  R11, $0x01000000
-	JLT   four_bytes_lz4_s2
+	JB    four_bytes_lz4_s2
 	MOVB  $0xfc, (AX)
 	MOVL  R11, 1(AX)
 	ADDQ  $0x05, AX
@@ -18869,7 +18992,7 @@ two_bytes_lz4_s2:
 	MOVB R11, 1(AX)
 	ADDQ $0x02, AX
 	CMPL R11, $0x40
-	JL   memmove_lz4_s2
+	JB   memmove_lz4_s2
 	JMP  memmove_long_lz4_s2
 
 one_byte_lz4_s2:
@@ -18882,7 +19005,7 @@ memmove_lz4_s2:
 
 	// genMemMoveShort
 	CMPQ R9, $0x08
-	JLE  emit_lit_memmove_lz4_s2_memmove_move_8
+	JBE  emit_lit_memmove_lz4_s2_memmove_move_8
 	CMPQ R9, $0x10
 	JBE  emit_lit_memmove_lz4_s2_memmove_move_8through16
 	CMPQ R9, $0x20
@@ -19008,19 +19131,19 @@ emit_repeat_again_lz4_s2:
 	MOVL R10, R8
 	LEAL -4(R10), R10
 	CMPL R8, $0x08
-	JLE  repeat_two_lz4_s2
+	JBE  repeat_two_lz4_s2
 	CMPL R8, $0x0c
-	JGE  cant_repeat_two_offset_lz4_s2
+	JAE  cant_repeat_two_offset_lz4_s2
 	CMPL R9, $0x00000800
-	JLT  repeat_two_offset_lz4_s2
+	JB   repeat_two_offset_lz4_s2
 
 cant_repeat_two_offset_lz4_s2:
 	CMPL R10, $0x00000104
-	JLT  repeat_three_lz4_s2
+	JB   repeat_three_lz4_s2
 	CMPL R10, $0x00010100
-	JLT  repeat_four_lz4_s2
+	JB   repeat_four_lz4_s2
 	CMPL R10, $0x0100ffff
-	JLT  repeat_five_lz4_s2
+	JB   repeat_five_lz4_s2
 	LEAL -16842747(R10), R10
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -19074,7 +19197,7 @@ lz4_s2_docopy:
 
 	// emitCopy
 	CMPL R10, $0x40
-	JLE  two_byte_offset_short_lz4_s2
+	JBE  two_byte_offset_short_lz4_s2
 	CMPL R9, $0x00000800
 	JAE  long_offset_short_lz4_s2
 	MOVL $0x00000001, R8
@@ -19096,19 +19219,19 @@ emit_repeat_again_lz4_s2_emit_copy_short_2b:
 	MOVL R10, R8
 	LEAL -4(R10), R10
 	CMPL R8, $0x08
-	JLE  repeat_two_lz4_s2_emit_copy_short_2b
+	JBE  repeat_two_lz4_s2_emit_copy_short_2b
 	CMPL R8, $0x0c
-	JGE  cant_repeat_two_offset_lz4_s2_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_lz4_s2_emit_copy_short_2b
 	CMPL R9, $0x00000800
-	JLT  repeat_two_offset_lz4_s2_emit_copy_short_2b
+	JB   repeat_two_offset_lz4_s2_emit_copy_short_2b
 
 cant_repeat_two_offset_lz4_s2_emit_copy_short_2b:
 	CMPL R10, $0x00000104
-	JLT  repeat_three_lz4_s2_emit_copy_short_2b
+	JB   repeat_three_lz4_s2_emit_copy_short_2b
 	CMPL R10, $0x00010100
-	JLT  repeat_four_lz4_s2_emit_copy_short_2b
+	JB   repeat_four_lz4_s2_emit_copy_short_2b
 	CMPL R10, $0x0100ffff
-	JLT  repeat_five_lz4_s2_emit_copy_short_2b
+	JB   repeat_five_lz4_s2_emit_copy_short_2b
 	LEAL -16842747(R10), R10
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -19168,19 +19291,19 @@ emit_repeat_again_lz4_s2_emit_copy_short:
 	MOVL R10, R8
 	LEAL -4(R10), R10
 	CMPL R8, $0x08
-	JLE  repeat_two_lz4_s2_emit_copy_short
+	JBE  repeat_two_lz4_s2_emit_copy_short
 	CMPL R8, $0x0c
-	JGE  cant_repeat_two_offset_lz4_s2_emit_copy_short
+	JAE  cant_repeat_two_offset_lz4_s2_emit_copy_short
 	CMPL R9, $0x00000800
-	JLT  repeat_two_offset_lz4_s2_emit_copy_short
+	JB   repeat_two_offset_lz4_s2_emit_copy_short
 
 cant_repeat_two_offset_lz4_s2_emit_copy_short:
 	CMPL R10, $0x00000104
-	JLT  repeat_three_lz4_s2_emit_copy_short
+	JB   repeat_three_lz4_s2_emit_copy_short
 	CMPL R10, $0x00010100
-	JLT  repeat_four_lz4_s2_emit_copy_short
+	JB   repeat_four_lz4_s2_emit_copy_short
 	CMPL R10, $0x0100ffff
-	JLT  repeat_five_lz4_s2_emit_copy_short
+	JB   repeat_five_lz4_s2_emit_copy_short
 	LEAL -16842747(R10), R10
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -19233,9 +19356,9 @@ two_byte_offset_short_lz4_s2:
 	MOVL R10, R8
 	SHLL $0x02, R8
 	CMPL R10, $0x0c
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	CMPL R9, $0x00000800
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	LEAL -15(R8), R8
 	MOVB R9, 1(AX)
 	SHRL $0x08, R9
@@ -19320,13 +19443,13 @@ lz4s_s2_ll_end:
 	ADDQ  R9, SI
 	LEAL  -1(R9), R11
 	CMPL  R11, $0x3c
-	JLT   one_byte_lz4s_s2
+	JB    one_byte_lz4s_s2
 	CMPL  R11, $0x00000100
-	JLT   two_bytes_lz4s_s2
+	JB    two_bytes_lz4s_s2
 	CMPL  R11, $0x00010000
-	JLT   three_bytes_lz4s_s2
+	JB    three_bytes_lz4s_s2
 	CMPL  R11, $0x01000000
-	JLT   four_bytes_lz4s_s2
+	JB    four_bytes_lz4s_s2
 	MOVB  $0xfc, (AX)
 	MOVL  R11, 1(AX)
 	ADDQ  $0x05, AX
@@ -19352,7 +19475,7 @@ two_bytes_lz4s_s2:
 	MOVB R11, 1(AX)
 	ADDQ $0x02, AX
 	CMPL R11, $0x40
-	JL   memmove_lz4s_s2
+	JB   memmove_lz4s_s2
 	JMP  memmove_long_lz4s_s2
 
 one_byte_lz4s_s2:
@@ -19365,7 +19488,7 @@ memmove_lz4s_s2:
 
 	// genMemMoveShort
 	CMPQ R9, $0x08
-	JLE  emit_lit_memmove_lz4s_s2_memmove_move_8
+	JBE  emit_lit_memmove_lz4s_s2_memmove_move_8
 	CMPQ R9, $0x10
 	JBE  emit_lit_memmove_lz4s_s2_memmove_move_8through16
 	CMPQ R9, $0x20
@@ -19493,19 +19616,19 @@ emit_repeat_again_lz4_s2:
 	MOVL R10, R8
 	LEAL -4(R10), R10
 	CMPL R8, $0x08
-	JLE  repeat_two_lz4_s2
+	JBE  repeat_two_lz4_s2
 	CMPL R8, $0x0c
-	JGE  cant_repeat_two_offset_lz4_s2
+	JAE  cant_repeat_two_offset_lz4_s2
 	CMPL R9, $0x00000800
-	JLT  repeat_two_offset_lz4_s2
+	JB   repeat_two_offset_lz4_s2
 
 cant_repeat_two_offset_lz4_s2:
 	CMPL R10, $0x00000104
-	JLT  repeat_three_lz4_s2
+	JB   repeat_three_lz4_s2
 	CMPL R10, $0x00010100
-	JLT  repeat_four_lz4_s2
+	JB   repeat_four_lz4_s2
 	CMPL R10, $0x0100ffff
-	JLT  repeat_five_lz4_s2
+	JB   repeat_five_lz4_s2
 	LEAL -16842747(R10), R10
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -19559,7 +19682,7 @@ lz4s_s2_docopy:
 
 	// emitCopy
 	CMPL R10, $0x40
-	JLE  two_byte_offset_short_lz4_s2
+	JBE  two_byte_offset_short_lz4_s2
 	CMPL R9, $0x00000800
 	JAE  long_offset_short_lz4_s2
 	MOVL $0x00000001, R8
@@ -19581,19 +19704,19 @@ emit_repeat_again_lz4_s2_emit_copy_short_2b:
 	MOVL R10, R8
 	LEAL -4(R10), R10
 	CMPL R8, $0x08
-	JLE  repeat_two_lz4_s2_emit_copy_short_2b
+	JBE  repeat_two_lz4_s2_emit_copy_short_2b
 	CMPL R8, $0x0c
-	JGE  cant_repeat_two_offset_lz4_s2_emit_copy_short_2b
+	JAE  cant_repeat_two_offset_lz4_s2_emit_copy_short_2b
 	CMPL R9, $0x00000800
-	JLT  repeat_two_offset_lz4_s2_emit_copy_short_2b
+	JB   repeat_two_offset_lz4_s2_emit_copy_short_2b
 
 cant_repeat_two_offset_lz4_s2_emit_copy_short_2b:
 	CMPL R10, $0x00000104
-	JLT  repeat_three_lz4_s2_emit_copy_short_2b
+	JB   repeat_three_lz4_s2_emit_copy_short_2b
 	CMPL R10, $0x00010100
-	JLT  repeat_four_lz4_s2_emit_copy_short_2b
+	JB   repeat_four_lz4_s2_emit_copy_short_2b
 	CMPL R10, $0x0100ffff
-	JLT  repeat_five_lz4_s2_emit_copy_short_2b
+	JB   repeat_five_lz4_s2_emit_copy_short_2b
 	LEAL -16842747(R10), R10
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -19653,19 +19776,19 @@ emit_repeat_again_lz4_s2_emit_copy_short:
 	MOVL R10, R8
 	LEAL -4(R10), R10
 	CMPL R8, $0x08
-	JLE  repeat_two_lz4_s2_emit_copy_short
+	JBE  repeat_two_lz4_s2_emit_copy_short
 	CMPL R8, $0x0c
-	JGE  cant_repeat_two_offset_lz4_s2_emit_copy_short
+	JAE  cant_repeat_two_offset_lz4_s2_emit_copy_short
 	CMPL R9, $0x00000800
-	JLT  repeat_two_offset_lz4_s2_emit_copy_short
+	JB   repeat_two_offset_lz4_s2_emit_copy_short
 
 cant_repeat_two_offset_lz4_s2_emit_copy_short:
 	CMPL R10, $0x00000104
-	JLT  repeat_three_lz4_s2_emit_copy_short
+	JB   repeat_three_lz4_s2_emit_copy_short
 	CMPL R10, $0x00010100
-	JLT  repeat_four_lz4_s2_emit_copy_short
+	JB   repeat_four_lz4_s2_emit_copy_short
 	CMPL R10, $0x0100ffff
-	JLT  repeat_five_lz4_s2_emit_copy_short
+	JB   repeat_five_lz4_s2_emit_copy_short
 	LEAL -16842747(R10), R10
 	MOVL $0xfffb001d, (AX)
 	MOVB $0xff, 4(AX)
@@ -19718,9 +19841,9 @@ two_byte_offset_short_lz4_s2:
 	MOVL R10, R8
 	SHLL $0x02, R8
 	CMPL R10, $0x0c
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	CMPL R9, $0x00000800
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	LEAL -15(R8), R8
 	MOVB R9, 1(AX)
 	SHRL $0x08, R9
@@ -19804,13 +19927,13 @@ lz4_snappy_ll_end:
 	ADDQ  R8, SI
 	LEAL  -1(R8), R10
 	CMPL  R10, $0x3c
-	JLT   one_byte_lz4_snappy
+	JB    one_byte_lz4_snappy
 	CMPL  R10, $0x00000100
-	JLT   two_bytes_lz4_snappy
+	JB    two_bytes_lz4_snappy
 	CMPL  R10, $0x00010000
-	JLT   three_bytes_lz4_snappy
+	JB    three_bytes_lz4_snappy
 	CMPL  R10, $0x01000000
-	JLT   four_bytes_lz4_snappy
+	JB    four_bytes_lz4_snappy
 	MOVB  $0xfc, (AX)
 	MOVL  R10, 1(AX)
 	ADDQ  $0x05, AX
@@ -19836,7 +19959,7 @@ two_bytes_lz4_snappy:
 	MOVB R10, 1(AX)
 	ADDQ $0x02, AX
 	CMPL R10, $0x40
-	JL   memmove_lz4_snappy
+	JB   memmove_lz4_snappy
 	JMP  memmove_long_lz4_snappy
 
 one_byte_lz4_snappy:
@@ -19849,7 +19972,7 @@ memmove_lz4_snappy:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_lz4_snappy_memmove_move_8
+	JBE  emit_lit_memmove_lz4_snappy_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_lz4_snappy_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -19971,7 +20094,7 @@ lz4_snappy_ml_done:
 	// emitCopy
 two_byte_offset_lz4_s2:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_lz4_s2
+	JBE  two_byte_offset_short_lz4_s2
 	MOVB $0xee, (AX)
 	MOVW R8, 1(AX)
 	LEAL -60(R9), R9
@@ -19984,9 +20107,9 @@ two_byte_offset_short_lz4_s2:
 	MOVL R9, DI
 	SHLL $0x02, DI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	CMPL R8, $0x00000800
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	LEAL -15(DI), DI
 	MOVB R8, 1(AX)
 	SHRL $0x08, R8
@@ -20070,13 +20193,13 @@ lz4s_snappy_ll_end:
 	ADDQ  R8, SI
 	LEAL  -1(R8), R10
 	CMPL  R10, $0x3c
-	JLT   one_byte_lz4s_snappy
+	JB    one_byte_lz4s_snappy
 	CMPL  R10, $0x00000100
-	JLT   two_bytes_lz4s_snappy
+	JB    two_bytes_lz4s_snappy
 	CMPL  R10, $0x00010000
-	JLT   three_bytes_lz4s_snappy
+	JB    three_bytes_lz4s_snappy
 	CMPL  R10, $0x01000000
-	JLT   four_bytes_lz4s_snappy
+	JB    four_bytes_lz4s_snappy
 	MOVB  $0xfc, (AX)
 	MOVL  R10, 1(AX)
 	ADDQ  $0x05, AX
@@ -20102,7 +20225,7 @@ two_bytes_lz4s_snappy:
 	MOVB R10, 1(AX)
 	ADDQ $0x02, AX
 	CMPL R10, $0x40
-	JL   memmove_lz4s_snappy
+	JB   memmove_lz4s_snappy
 	JMP  memmove_long_lz4s_snappy
 
 one_byte_lz4s_snappy:
@@ -20115,7 +20238,7 @@ memmove_lz4s_snappy:
 
 	// genMemMoveShort
 	CMPQ R8, $0x08
-	JLE  emit_lit_memmove_lz4s_snappy_memmove_move_8
+	JBE  emit_lit_memmove_lz4s_snappy_memmove_move_8
 	CMPQ R8, $0x10
 	JBE  emit_lit_memmove_lz4s_snappy_memmove_move_8through16
 	CMPQ R8, $0x20
@@ -20239,7 +20362,7 @@ lz4s_snappy_ml_done:
 	// emitCopy
 two_byte_offset_lz4_s2:
 	CMPL R9, $0x40
-	JLE  two_byte_offset_short_lz4_s2
+	JBE  two_byte_offset_short_lz4_s2
 	MOVB $0xee, (AX)
 	MOVW R8, 1(AX)
 	LEAL -60(R9), R9
@@ -20252,9 +20375,9 @@ two_byte_offset_short_lz4_s2:
 	MOVL R9, DI
 	SHLL $0x02, DI
 	CMPL R9, $0x0c
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	CMPL R8, $0x00000800
-	JGE  emit_copy_three_lz4_s2
+	JAE  emit_copy_three_lz4_s2
 	LEAL -15(DI), DI
 	MOVB R8, 1(AX)
 	SHRL $0x08, R8

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -38,28 +38,29 @@ func TestMaxEncodedLen(t *testing.T) {
 	testSet := []struct {
 		in, out int64
 	}{
-		{in: 0, out: 1},
-		{in: 1 << 24, out: 1<<24 + int64(binary.PutVarint([]byte{binary.MaxVarintLen32: 0}, int64(1<<24))) + literalExtraSize(1<<24)},
-		{in: MaxBlockSize, out: math.MaxUint32},
-		{in: math.MaxUint32 - binary.MaxVarintLen32 - literalExtraSize(math.MaxUint32), out: math.MaxUint32},
-		{in: math.MaxUint32 - 9, out: -1},
-		{in: math.MaxUint32 - 8, out: -1},
-		{in: math.MaxUint32 - 7, out: -1},
-		{in: math.MaxUint32 - 6, out: -1},
-		{in: math.MaxUint32 - 5, out: -1},
-		{in: math.MaxUint32 - 4, out: -1},
-		{in: math.MaxUint32 - 3, out: -1},
-		{in: math.MaxUint32 - 2, out: -1},
-		{in: math.MaxUint32 - 1, out: -1},
-		{in: math.MaxUint32, out: -1},
-		{in: -1, out: -1},
-		{in: -2, out: -1},
+		0:  {in: 0, out: 1},
+		1:  {in: 1 << 24, out: 1<<24 + int64(binary.PutVarint([]byte{binary.MaxVarintLen32: 0}, int64(1<<24))) + literalExtraSize(1<<24)},
+		2:  {in: MaxBlockSize, out: math.MaxUint32},
+		3:  {in: math.MaxUint32 - binary.MaxVarintLen32 - literalExtraSize(math.MaxUint32), out: math.MaxUint32},
+		4:  {in: math.MaxUint32 - 9, out: -1},
+		5:  {in: math.MaxUint32 - 8, out: -1},
+		6:  {in: math.MaxUint32 - 7, out: -1},
+		7:  {in: math.MaxUint32 - 6, out: -1},
+		8:  {in: math.MaxUint32 - 5, out: -1},
+		9:  {in: math.MaxUint32 - 4, out: -1},
+		10: {in: math.MaxUint32 - 3, out: -1},
+		11: {in: math.MaxUint32 - 2, out: -1},
+		12: {in: math.MaxUint32 - 1, out: -1},
+		13: {in: math.MaxUint32, out: -1},
+		14: {in: -1, out: -1},
+		15: {in: -2, out: -1},
 	}
 	// 32 bit platforms have a different threshold.
 	if maxInt == math.MaxInt32 {
-		testSet[2].out = -1
+		testSet[2].out = math.MaxInt32
 		testSet[3].out = -1
 	}
+	t.Log("Maxblock:", MaxBlockSize, "reduction:", intReduction)
 	// Test all sizes up to maxBlockSize.
 	for i := int64(0); i < maxBlockSize; i++ {
 		testSet = append(testSet, struct{ in, out int64 }{in: i, out: i + int64(binary.PutVarint([]byte{binary.MaxVarintLen32: 0}, i)) + literalExtraSize(i)})
@@ -69,7 +70,7 @@ func TestMaxEncodedLen(t *testing.T) {
 		want := tt.out
 		got := int64(MaxEncodedLen(int(tt.in)))
 		if got != want {
-			t.Fatalf("input: %d, want: %d, got: %d", tt.in, want, got)
+			t.Errorf("test %d: input: %d, want: %d, got: %d", i, tt.in, want, got)
 		}
 	}
 }


### PR DESCRIPTION
Fixes crash on encoding single blocks close to or above 2147483647 bytes on amd64.

Fixes #778

Use unsigned compares in assembly.

Lowers the maximum block size on 32 bit platforms. Realistically you wouldn't be able to get close to it anyway.