### PR TITLE
zstd: Make load(32|64)32 safer and smaller

### DIFF
--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -128,11 +128,11 @@ func matchLen(a, b []byte) (n int) {
 }
 
 func load3232(b []byte, i int32) uint32 {
-	return binary.LittleEndian.Uint32(b[i:])
+	return binary.LittleEndian.Uint32(b[:len(b):len(b)][i:])
 }
 
 func load6432(b []byte, i int32) uint64 {
-	return binary.LittleEndian.Uint64(b[i:])
+	return binary.LittleEndian.Uint64(b[:len(b):len(b)][i:])
 }
 
 type byter interface {


### PR DESCRIPTION
load3232 and load6432 now limit their slice to its length. This improves safety, since encoders can no longer look at the part beyond the length. It also produces several dozen fewer instructions for bounds checks.