### PR TITLE
zstd: Load source value at start of loop

### DIFF
--- a/zstd/enc_best.go
+++ b/zstd/enc_best.go
@@ -159,7 +159,6 @@ func (e *bestFastEncoder) Encode(blk *blockEnc, src []byte) {
 
 	// nextEmit is where in src the next emitLiteral should start from.
 	nextEmit := s
-	cv := load6432(src, s)
 
 	// Relative offsets
 	offset1 := int32(blk.recentOffsets[0])
@@ -173,7 +172,6 @@ func (e *bestFastEncoder) Encode(blk *blockEnc, src []byte) {
 		blk.literals = append(blk.literals, src[nextEmit:until]...)
 		s.litLen = uint32(until - nextEmit)
 	}
-	_ = addLiterals
 
 	if debugEncoder {
 		println("recent offsets:", blk.recentOffsets)
@@ -189,6 +187,8 @@ encodeLoop:
 		}
 
 		const goodEnough = 250
+
+		cv := load6432(src, s)
 
 		nextHashL := hashLen(cv, bestLongTableBits, bestLongLen)
 		nextHashS := hashLen(cv, bestShortTableBits, bestShortLen)
@@ -290,7 +290,6 @@ encodeLoop:
 				if s >= sLimit {
 					break encodeLoop
 				}
-				cv = load6432(src, s)
 				continue
 			}
 
@@ -364,7 +363,6 @@ encodeLoop:
 			if s >= sLimit {
 				if debugEncoder {
 					println("repeat ended", s, best.length)
-
 				}
 				break encodeLoop
 			}
@@ -387,7 +385,6 @@ encodeLoop:
 			case 4 | 3:
 				offset1, offset2, offset3 = offset1-1, offset1, offset2
 			}
-			cv = load6432(src, s)
 			continue
 		}
 
@@ -435,7 +432,6 @@ encodeLoop:
 			e.table[h1] = prevEntry{offset: off, prev: e.table[h1].offset}
 			index0++
 		}
-		cv = load6432(src, s)
 	}
 
 	if int(nextEmit) < len(src) {


### PR DESCRIPTION
There were four places were this value was loaded: before the loop, at the end, and before two continues. Doing it at the start reduces the code size. It also seems to give a tiny speedup:

```
name                              old speed      new speed      delta
Encoder_EncodeAllSimple/best-8    16.8MB/s ± 2%  16.9MB/s ± 1%  +0.47%  (p=0.025 n=8+10)
Encoder_EncodeAllSimple4K/best-8  16.0MB/s ± 2%  16.2MB/s ± 1%  +1.67%  (p=0.000 n=10+10)

name                              old alloc/op   new alloc/op   delta
Encoder_EncodeAllSimple/best-8       19.0B ± 5%     18.0B ± 0%  -5.26%  (p=0.002 n=9+9)
Encoder_EncodeAllSimple4K/best-8     1.00B ± 0%     1.00B ± 0%    ~     (all equal)
```