### PR TITLE
readerWrapper: readByte needs to use io.ReadFull

### DIFF
--- a/zstd/bytebuf.go
+++ b/zstd/bytebuf.go
@@ -109,7 +109,7 @@ func (r *readerWrapper) readBig(n int, dst []byte) ([]byte, error) {
 }
 
 func (r *readerWrapper) readByte() (byte, error) {
-	n2, err := r.r.Read(r.tmp[:1])
+	n2, err := io.ReadFull(r.r, r.tmp[:1])
 	if err != nil {
 		if err == io.EOF {
 			err = io.ErrUnexpectedEOF


### PR DESCRIPTION
This fixes an "unexpected EOF" error that can occur when streaming from a network source into the zstd decompressor. I maintain a production system which streams zstd-compressed data from AWS S3 that hits this bug regularly when under heavy load.

Even when asking for one byte of data, it's necessary to use io.ReadFull. It's valid to return 0 bytes without EOF on a read, and this behavior is seen on network sources rather frequently.

I wrote up a test that reproduces the bug here:

https://github.com/jnoxon/zstd-zero-length-read-bug