### PR TITLE
s2: add GetBufferCapacity() method

### DIFF
--- a/s2/reader.go
+++ b/s2/reader.go
@@ -147,6 +147,13 @@ type Reader struct {
 	ignoreCRC      bool
 }
 
+// GetBufferCapacity returns the capacity of the internal buffer.
+// This might be useful to know when reusing the same reader in combination
+// with the lazy buffer option.
+func (r *Reader) GetBufferCapacity() int {
+	return cap(r.buf)
+}
+
 // ensureBufferSize will ensure that the buffer can take at least n bytes.
 // If false is returned the buffer exceeds maximum allowed size.
 func (r *Reader) ensureBufferSize(n int) bool {


### PR DESCRIPTION
Add GetBufferCapacity() method. We are reusing readers with sync.Pool and we'd like to avoid allocating memory for the default block size since most of the inputs are smaller. To have a better estimate of how big the lazy buffer should be, we are thinking about keeping in mind a running average of the internal buffer capacities. This method would allow us to implement that.