### PR TITLE
flate: Add amd64 assembly matchlen

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -198,6 +198,9 @@ jobs:
       - name: flate/FuzzEncoding
         run: go test -run=none -fuzz=FuzzEncoding -fuzztime=100000x -test.fuzzminimizetime=10ms ./flate/.
 
+      - name: flate/FuzzEncoding/noasm
+        run: go test -run=none -tags=noasm -fuzz=FuzzEncoding -fuzztime=100000x -test.fuzzminimizetime=10ms ./flate/.
+
       - name: zip/FuzzReader
         run: go test -run=none -fuzz=FuzzReader -fuzztime=500000x -test.fuzzminimizetime=10ms ./zip/.
 

--- a/flate/fast_encoder.go
+++ b/flate/fast_encoder.go
@@ -8,7 +8,6 @@ package flate
 import (
 	"encoding/binary"
 	"fmt"
-	"math/bits"
 )
 
 type fastEnc interface {
@@ -191,26 +190,4 @@ func (e *fastGen) Reset() {
 		e.cur += maxMatchOffset + int32(len(e.hist))
 	}
 	e.hist = e.hist[:0]
-}
-
-// matchLen returns the maximum length.
-// 'a' must be the shortest of the two.
-func matchLen(a, b []byte) int {
-	var checked int
-
-	for len(a) >= 8 {
-		if diff := binary.LittleEndian.Uint64(a) ^ binary.LittleEndian.Uint64(b); diff != 0 {
-			return checked + (bits.TrailingZeros64(diff) >> 3)
-		}
-		checked += 8
-		a = a[8:]
-		b = b[8:]
-	}
-	b = b[:len(a)]
-	for i := range a {
-		if a[i] != b[i] {
-			return i + checked
-		}
-	}
-	return len(a) + checked
 }

--- a/flate/matchlen_amd64.go
+++ b/flate/matchlen_amd64.go
@@ -1,0 +1,16 @@
+//go:build amd64 && !appengine && !noasm && gc
+// +build amd64,!appengine,!noasm,gc
+
+// Copyright 2019+ Klaus Post. All rights reserved.
+// License information can be found in the LICENSE file.
+
+package flate
+
+// matchLen returns how many bytes match in a and b
+//
+// It assumes that:
+//
+//	len(a) <= len(b) and len(a) > 0
+//
+//go:noescape
+func matchLen(a []byte, b []byte) int

--- a/flate/matchlen_amd64.s
+++ b/flate/matchlen_amd64.s
@@ -1,0 +1,68 @@
+// Copied from S2 implementation.
+
+//go:build !appengine && !noasm && gc && !noasm
+
+#include "textflag.h"
+
+// func matchLen(a []byte, b []byte) int
+// Requires: BMI
+TEXT ·matchLen(SB), NOSPLIT, $0-56
+	MOVQ a_base+0(FP), AX
+	MOVQ b_base+24(FP), CX
+	MOVQ a_len+8(FP), DX
+
+	// matchLen
+	XORL SI, SI
+	CMPL DX, $0x08
+	JB   matchlen_match4_standalone
+
+matchlen_loopback_standalone:
+	MOVQ  (AX)(SI*1), BX
+	XORQ  (CX)(SI*1), BX
+	TESTQ BX, BX
+	JZ    matchlen_loop_standalone
+
+#ifdef GOAMD64_v3
+	TZCNTQ BX, BX
+#else
+	BSFQ BX, BX
+#endif
+	SARQ $0x03, BX
+	LEAL (SI)(BX*1), SI
+	JMP  gen_match_len_end
+
+matchlen_loop_standalone:
+	LEAL -8(DX), DX
+	LEAL 8(SI), SI
+	CMPL DX, $0x08
+	JAE  matchlen_loopback_standalone
+
+matchlen_match4_standalone:
+	CMPL DX, $0x04
+	JB   matchlen_match2_standalone
+	MOVL (AX)(SI*1), BX
+	CMPL (CX)(SI*1), BX
+	JNE  matchlen_match2_standalone
+	LEAL -4(DX), DX
+	LEAL 4(SI), SI
+
+matchlen_match2_standalone:
+	CMPL DX, $0x02
+	JB   matchlen_match1_standalone
+	MOVW (AX)(SI*1), BX
+	CMPW (CX)(SI*1), BX
+	JNE  matchlen_match1_standalone
+	LEAL -2(DX), DX
+	LEAL 2(SI), SI
+
+matchlen_match1_standalone:
+	CMPL DX, $0x01
+	JB   gen_match_len_end
+	MOVB (AX)(SI*1), BL
+	CMPB (CX)(SI*1), BL
+	JNE  gen_match_len_end
+	INCL SI
+
+gen_match_len_end:
+	MOVQ SI, ret+48(FP)
+	RET

--- a/flate/matchlen_generic.go
+++ b/flate/matchlen_generic.go
@@ -1,0 +1,33 @@
+//go:build !amd64 || appengine || !gc || noasm
+// +build !amd64 appengine !gc noasm
+
+// Copyright 2019+ Klaus Post. All rights reserved.
+// License information can be found in the LICENSE file.
+
+package flate
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+// matchLen returns the maximum common prefix length of a and b.
+// a must be the shortest of the two.
+func matchLen(a, b []byte) (n int) {
+	for ; len(a) >= 8 && len(b) >= 8; a, b = a[8:], b[8:] {
+		diff := binary.LittleEndian.Uint64(a) ^ binary.LittleEndian.Uint64(b)
+		if diff != 0 {
+			return n + bits.TrailingZeros64(diff)>>3
+		}
+		n += 8
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			break
+		}
+		n++
+	}
+	return n
+
+}


### PR DESCRIPTION
A few percent faster.

```
before:
github-june-2days-2019.json	gzkp	1	6273951764	1073607045	17271	346.43
github-june-2days-2019.json	gzkp	2	6273951764	1045461954	20016	298.92
github-june-2days-2019.json	gzkp	3	6273951764	1030139729	21372	279.95
github-june-2days-2019.json	gzkp	4	6273951764	992526317	26354	227.03
github-june-2days-2019.json	gzkp	5	6273951764	938015731	28919	206.89
github-june-2days-2019.json	gzkp	6	6273951764	918717756	32473	184.25
github-june-2days-2019.json	gzkp	7	6273951764	924473679	41597	143.84
github-june-2days-2019.json	gzkp	8	6273951764	905294390	52419	114.14
github-june-2days-2019.json	gzkp	9	6273951764	895561157	103132	58.02

after:
github-june-2days-2019.json	gzkp	1	6273951764	1073607045	16978	352.40
github-june-2days-2019.json	gzkp	2	6273951764	1045461954	19362	309.01
github-june-2days-2019.json	gzkp	3	6273951764	1030139729	20882	286.53
github-june-2days-2019.json	gzkp	4	6273951764	992526317	25009	239.24
github-june-2days-2019.json	gzkp	5	6273951764	938015731	28934	206.79
github-june-2days-2019.json	gzkp	6	6273951764	918717756	32698	182.98
github-june-2days-2019.json	gzkp	7	6273951764	924473679	42734	140.01
github-june-2days-2019.json	gzkp	8	6273951764	905294390	53639	111.55
github-june-2days-2019.json	gzkp	9	6273951764	895561157	97701	61.24
```