### PR TITLE
tests: Fix OSS fuzzer t.Run

### DIFF
--- a/flate/fuzz_test.go
+++ b/flate/fuzz_test.go
@@ -54,130 +54,125 @@ func FuzzEncoding(f *testing.F) {
 		}
 		for level := startFuzz; level <= endFuzz; level++ {
 			msg := "level " + strconv.Itoa(level) + ":"
-			t.Run(msg, func(t *testing.T) {
-				buf.Reset()
-				fw := encs[level-startFuzz]
-				fw.Reset(buf)
-				n, err := fw.Write(data)
-				if n != len(data) {
-					t.Fatal(msg + "short write")
-				}
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				err = fw.Close()
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				decoder.(Resetter).Reset(buf, nil)
-				data2, err := io.ReadAll(decoder)
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				if !bytes.Equal(data, data2) {
-					t.Fatal(msg + "not equal")
-				}
-				// Do it again...
-				msg = "level " + strconv.Itoa(level) + " (reset):"
-				buf.Reset()
-				fw.Reset(buf)
-				n, err = fw.Write(data)
-				if n != len(data) {
-					t.Fatal(msg + "short write")
-				}
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				err = fw.Close()
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				decoder.(Resetter).Reset(buf, nil)
-				data2, err = io.ReadAll(decoder)
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				if !bytes.Equal(data, data2) {
-					t.Fatal(msg + "not equal")
-				}
-			})
+			buf.Reset()
+			fw := encs[level-startFuzz]
+			fw.Reset(buf)
+			n, err := fw.Write(data)
+			if n != len(data) {
+				t.Fatal(msg + "short write")
+			}
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			err = fw.Close()
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			decoder.(Resetter).Reset(buf, nil)
+			data2, err := io.ReadAll(decoder)
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			if !bytes.Equal(data, data2) {
+				t.Fatal(msg + "not equal")
+			}
+			// Do it again...
+			msg = "level " + strconv.Itoa(level) + " (reset):"
+			buf.Reset()
+			fw.Reset(buf)
+			n, err = fw.Write(data)
+			if n != len(data) {
+				t.Fatal(msg + "short write")
+			}
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			err = fw.Close()
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			decoder.(Resetter).Reset(buf, nil)
+			data2, err = io.ReadAll(decoder)
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			if !bytes.Equal(data, data2) {
+				t.Fatal(msg + "not equal")
+			}
 		}
 		if stateless {
-			t.Run("stateless", func(t *testing.T) {
-				// Split into two and use history...
-				buf.Reset()
-				err := StatelessDeflate(buf, data[:len(data)/2], false, nil)
-				if err != nil {
-					t.Error(err)
-				}
+			// Split into two and use history...
+			msg := "stateless:"
+			buf.Reset()
+			err := StatelessDeflate(buf, data[:len(data)/2], false, nil)
+			if err != nil {
+				t.Error(err)
+			}
 
-				// Use top half as dictionary...
-				dict := data[:len(data)/2]
-				err = StatelessDeflate(buf, data[len(data)/2:], true, dict)
-				if err != nil {
-					t.Error(err)
-				}
+			// Use top half as dictionary...
+			dict := data[:len(data)/2]
+			err = StatelessDeflate(buf, data[len(data)/2:], true, dict)
+			if err != nil {
+				t.Error(err)
+			}
 
-				decoder.(Resetter).Reset(buf, nil)
-				data2, err := io.ReadAll(decoder)
-				if err != nil {
-					t.Error(err)
-				}
-				if !bytes.Equal(data, data2) {
-					//fmt.Printf("want:%x\ngot: %x\n", data1, data2)
-					t.Error("not equal")
-				}
-			})
+			decoder.(Resetter).Reset(buf, nil)
+			data2, err := io.ReadAll(decoder)
+			if err != nil {
+				t.Error(err)
+			}
+			if !bytes.Equal(data, data2) {
+				//fmt.Printf("want:%x\ngot: %x\n", data1, data2)
+				t.Error(msg + "not equal")
+			}
 		}
 		if fuzzWindow {
-			t.Run("window", func(t *testing.T) {
-				msg := "windowed"
-				buf.Reset()
-				fw, err := NewWriterWindow(buf, 1000)
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				fw.Reset(buf)
-				n, err := fw.Write(data)
-				if n != len(data) {
-					t.Fatal(msg + "short write")
-				}
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				err = fw.Close()
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				decoder.(Resetter).Reset(buf, nil)
-				data2, err := io.ReadAll(decoder)
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				if !bytes.Equal(data, data2) {
-					t.Fatal(msg + "not equal")
-				}
-				// Do it again...
-				msg = msg + " (reset):"
-				buf.Reset()
-				fw.Reset(buf)
-				n, err = fw.Write(data)
-				if n != len(data) {
-					t.Fatal(msg + "short write")
-				}
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				err = fw.Close()
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-				decoder.(Resetter).Reset(buf, nil)
-				data2, err = io.ReadAll(decoder)
-				if err != nil {
-					t.Fatal(msg + err.Error())
-				}
-			})
+			msg := "windowed:"
+			buf.Reset()
+			fw, err := NewWriterWindow(buf, 1000)
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			fw.Reset(buf)
+			n, err := fw.Write(data)
+			if n != len(data) {
+				t.Fatal(msg + "short write")
+			}
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			err = fw.Close()
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			decoder.(Resetter).Reset(buf, nil)
+			data2, err := io.ReadAll(decoder)
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			if !bytes.Equal(data, data2) {
+				t.Fatal(msg + "not equal")
+			}
+			// Do it again...
+			msg = msg + " (reset):"
+			buf.Reset()
+			fw.Reset(buf)
+			n, err = fw.Write(data)
+			if n != len(data) {
+				t.Fatal(msg + "short write")
+			}
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			err = fw.Close()
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
+			decoder.(Resetter).Reset(buf, nil)
+			data2, err = io.ReadAll(decoder)
+			if err != nil {
+				t.Fatal(msg + err.Error())
+			}
 		}
 	})
 }


### PR DESCRIPTION
```
  t.Run() is not supported when fuzzing in libFuzzer mode
  testing.(*T).Run
```

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61356