### PR TITLE
gzip: Copy bufio.Reader on Reset

### DIFF
--- a/gzip/gunzip.go
+++ b/gzip/gunzip.go
@@ -106,6 +106,7 @@ func (z *Reader) Reset(r io.Reader) error {
 	*z = Reader{
 		decompressor: z.decompressor,
 		multistream:  true,
+		br:           z.br,
 	}
 	if rr, ok := r.(flate.Reader); ok {
 		z.r = rr


### PR DESCRIPTION
The code already checks to see if the buffer can be reused, but since it's not copied in the overwrite, a new buffer is allocated each time.