### PR TITLE
Reduce allocations in flate decompressor and minor code improvements

### DIFF
--- a/flate/_gen/gen_inflate.go
+++ b/flate/_gen/gen_inflate.go
@@ -109,7 +109,7 @@ readLiteral:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
 				f.toRead = dict.readFlush()
-				f.step = (*decompressor).$FUNCNAME$
+				f.step = $FUNCNAME$
 				f.stepState = stateInit
 				f.b, f.nb = fb, fnb
 				return
@@ -275,7 +275,7 @@ copyHistory:
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
 			f.toRead = dict.readFlush()
-			f.step = (*decompressor).$FUNCNAME$ // We need to continue this work
+			f.step = $FUNCNAME$ // We need to continue this work
 			f.stepState = stateDict
 			f.b, f.nb = fb, fnb
 			return

--- a/flate/_gen/gen_inflate.go
+++ b/flate/_gen/gen_inflate.go
@@ -291,13 +291,13 @@ copyHistory:
 		s = strings.Replace(s, "$TYPE$", t, -1)
 		f.WriteString(s)
 	}
-	f.WriteString("func (f *decompressor) huffmanBlockDecoder() func() {\n")
+	f.WriteString("func (f *decompressor) huffmanBlockDecoder() {\n")
 	f.WriteString("\tswitch f.r.(type) {\n")
 	for i, t := range types {
 		f.WriteString("\t\tcase " + t + ":\n")
-		f.WriteString("\t\t\treturn f.huffman" + names[i] + "\n")
+		f.WriteString("\t\t\tf.huffman" + names[i] + "()\n")
 	}
 	f.WriteString("\t\tdefault:\n")
-	f.WriteString("\t\t\treturn f.huffmanGenericReader\n")
+	f.WriteString("\t\t\tf.huffmanGenericReader()\n")
 	f.WriteString("\t}\n}\n")
 }

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -120,8 +120,9 @@ func (h *huffmanDecoder) init(lengths []int) bool {
 	const sanity = false
 
 	if h.chunks == nil {
-		h.chunks = &[huffmanNumChunks]uint16{}
+		h.chunks = new([huffmanNumChunks]uint16)
 	}
+
 	if h.maxRead != 0 {
 		*h = huffmanDecoder{chunks: h.chunks, links: h.links}
 	}
@@ -352,7 +353,7 @@ func (f *decompressor) nextBlock() {
 		// compressed, fixed Huffman tables
 		f.hl = &fixedHuffmanDecoder
 		f.hd = nil
-		f.huffmanBlockDecoder()()
+		f.huffmanBlockDecoder()
 		if debugDecode {
 			fmt.Println("predefinied huffman block")
 		}
@@ -363,7 +364,7 @@ func (f *decompressor) nextBlock() {
 		}
 		f.hl = &f.h1
 		f.hd = &f.h2
-		f.huffmanBlockDecoder()()
+		f.huffmanBlockDecoder()
 		if debugDecode {
 			fmt.Println("dynamic huffman block")
 		}

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -675,7 +675,6 @@ func (f *decompressor) copyData() {
 	if f.dict.availWrite() == 0 || f.copyLen > 0 {
 		f.toRead = f.dict.readFlush()
 		f.step = copyData
-		//f.step = (*decompressor).copyData
 		return
 	}
 	f.finishBlock()
@@ -689,7 +688,6 @@ func (f *decompressor) finishBlock() {
 		f.err = io.EOF
 	}
 	f.step = nextBlock
-	//f.step = (*decompressor).nextBlock
 }
 
 // noEOF returns err, unless err == io.EOF, in which case it returns io.ErrUnexpectedEOF.

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -201,8 +201,7 @@ func (h *huffmanDecoder) init(lengths []int) bool {
 			if cap(h.links[off]) < numLinks {
 				h.links[off] = make([]uint16, numLinks)
 			} else {
-				links := h.links[off][:0]
-				h.links[off] = links[:numLinks]
+				h.links[off] = h.links[off][:numLinks]
 			}
 		}
 	} else {

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -43,6 +43,9 @@ var bitMask32 = [32]uint32{
 	0x1ffFFFF, 0x3ffFFFF, 0x7ffFFFF, 0xfffFFFF, 0x1fffFFFF, 0x3fffFFFF, 0x7fffFFFF,
 } // up to 32 bits
 
+// zeroChunks is used to nullify decompressor.chunks array
+var zeroChunks = make([]uint16, huffmanNumChunks)
+
 // Initialize the fixedHuffmanDecoder only once upon first use.
 var fixedOnce sync.Once
 var fixedHuffmanDecoder huffmanDecoder
@@ -176,9 +179,10 @@ func (h *huffmanDecoder) init(lengths []int) bool {
 	}
 
 	h.maxRead = min
-	for i := range h.chunks {
-		h.chunks[i] = 0
-	}
+
+	// instead of iterating over the whole array, just copy already null-filled
+	// slice in it.
+	copy(h.chunks[:], zeroChunks)
 
 	if max > huffmanChunkBits {
 		numLinks := 1 << (uint(max) - huffmanChunkBits)
@@ -276,7 +280,7 @@ func (h *huffmanDecoder) init(lengths []int) bool {
 	return true
 }
 
-// The actual read interface needed by NewReader.
+// Reader is the actual read interface needed by NewReader.
 // If the passed in io.Reader does not also have ReadByte,
 // the NewReader will introduce its own buffering.
 type Reader interface {

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -175,9 +175,8 @@ func (h *huffmanDecoder) init(lengths []int) bool {
 	}
 
 	h.maxRead = min
-	chunks := h.chunks[:]
-	for i := range chunks {
-		chunks[i] = 0
+	for i := range h.chunks {
+		h.chunks[i] = 0
 	}
 
 	if max > huffmanChunkBits {

--- a/flate/inflate_gen.go
+++ b/flate/inflate_gen.go
@@ -85,7 +85,7 @@ readLiteral:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
 				f.toRead = dict.readFlush()
-				f.step = (*decompressor).huffmanBytesBuffer
+				f.step = huffmanBytesBuffer
 				f.stepState = stateInit
 				f.b, f.nb = fb, fnb
 				return
@@ -251,7 +251,7 @@ copyHistory:
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
 			f.toRead = dict.readFlush()
-			f.step = (*decompressor).huffmanBytesBuffer // We need to continue this work
+			f.step = huffmanBytesBuffer // We need to continue this work
 			f.stepState = stateDict
 			f.b, f.nb = fb, fnb
 			return
@@ -336,7 +336,7 @@ readLiteral:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
 				f.toRead = dict.readFlush()
-				f.step = (*decompressor).huffmanBytesReader
+				f.step = huffmanBytesReader
 				f.stepState = stateInit
 				f.b, f.nb = fb, fnb
 				return
@@ -502,7 +502,7 @@ copyHistory:
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
 			f.toRead = dict.readFlush()
-			f.step = (*decompressor).huffmanBytesReader // We need to continue this work
+			f.step = huffmanBytesReader // We need to continue this work
 			f.stepState = stateDict
 			f.b, f.nb = fb, fnb
 			return
@@ -587,7 +587,7 @@ readLiteral:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
 				f.toRead = dict.readFlush()
-				f.step = (*decompressor).huffmanBufioReader
+				f.step = huffmanBufioReader
 				f.stepState = stateInit
 				f.b, f.nb = fb, fnb
 				return
@@ -753,7 +753,7 @@ copyHistory:
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
 			f.toRead = dict.readFlush()
-			f.step = (*decompressor).huffmanBufioReader // We need to continue this work
+			f.step = huffmanBufioReader // We need to continue this work
 			f.stepState = stateDict
 			f.b, f.nb = fb, fnb
 			return
@@ -838,7 +838,7 @@ readLiteral:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
 				f.toRead = dict.readFlush()
-				f.step = (*decompressor).huffmanStringsReader
+				f.step = huffmanStringsReader
 				f.stepState = stateInit
 				f.b, f.nb = fb, fnb
 				return
@@ -1004,7 +1004,7 @@ copyHistory:
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
 			f.toRead = dict.readFlush()
-			f.step = (*decompressor).huffmanStringsReader // We need to continue this work
+			f.step = huffmanStringsReader // We need to continue this work
 			f.stepState = stateDict
 			f.b, f.nb = fb, fnb
 			return
@@ -1089,7 +1089,7 @@ readLiteral:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
 				f.toRead = dict.readFlush()
-				f.step = (*decompressor).huffmanGenericReader
+				f.step = huffmanGenericReader
 				f.stepState = stateInit
 				f.b, f.nb = fb, fnb
 				return
@@ -1255,7 +1255,7 @@ copyHistory:
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
 			f.toRead = dict.readFlush()
-			f.step = (*decompressor).huffmanGenericReader // We need to continue this work
+			f.step = huffmanGenericReader // We need to continue this work
 			f.stepState = stateDict
 			f.b, f.nb = fb, fnb
 			return

--- a/flate/inflate_gen.go
+++ b/flate/inflate_gen.go
@@ -1265,19 +1265,19 @@ copyHistory:
 	// Not reached
 }
 
-func (f *decompressor) huffmanBlockDecoder() func() {
+func (f *decompressor) huffmanBlockDecoder() {
 	switch f.r.(type) {
 	case *bytes.Buffer:
-		return f.huffmanBytesBuffer
+		f.huffmanBytesBuffer()
 	case *bytes.Reader:
-		return f.huffmanBytesReader
+		f.huffmanBytesReader()
 	case *bufio.Reader:
-		return f.huffmanBufioReader
+		f.huffmanBufioReader()
 	case *strings.Reader:
-		return f.huffmanStringsReader
+		f.huffmanStringsReader()
 	case Reader:
-		return f.huffmanGenericReader
+		f.huffmanGenericReader()
 	default:
-		return f.huffmanGenericReader
+		f.huffmanGenericReader()
 	}
 }

--- a/flate/reader_test.go
+++ b/flate/reader_test.go
@@ -64,8 +64,6 @@ func benchmarkDecode(b *testing.B, testfile, level, n int) {
 	w.Close()
 	buf1 := compressed.Bytes()
 	buf0, compressed, w = nil, nil, nil
-	const ioCopyBuffSize = 32 * 1024 // taken from io.copyBuffer, in case passed buf==nil
-	ioCopyBuff := make([]byte, ioCopyBuffSize)
 	r := NewReader(bytes.NewReader(buf1))
 	res := r.(Resetter)
 	runtime.GC()
@@ -73,7 +71,7 @@ func benchmarkDecode(b *testing.B, testfile, level, n int) {
 
 	for i := 0; i < b.N; i++ {
 		_ = res.Reset(bytes.NewReader(buf1), nil)
-		_, _ = io.CopyBuffer(io.Discard, r, ioCopyBuff)
+		_, _ = io.Copy(io.Discard, r)
 	}
 }
 

--- a/flate/reader_test.go
+++ b/flate/reader_test.go
@@ -64,13 +64,15 @@ func benchmarkDecode(b *testing.B, testfile, level, n int) {
 	w.Close()
 	buf1 := compressed.Bytes()
 	buf0, compressed, w = nil, nil, nil
+	const ioCopyBuffSize = 32 * 1024 // taken from io.copyBuffer, in case passed buf==nil
+	ioCopyBuff := make([]byte, ioCopyBuffSize)
 	runtime.GC()
 	b.StartTimer()
 	r := NewReader(bytes.NewReader(buf1))
 	res := r.(Resetter)
 	for i := 0; i < b.N; i++ {
 		res.Reset(bytes.NewReader(buf1), nil)
-		io.Copy(io.Discard, r)
+		io.CopyBuffer(io.Discard, r, ioCopyBuff)
 	}
 }
 

--- a/flate/reader_test.go
+++ b/flate/reader_test.go
@@ -66,13 +66,14 @@ func benchmarkDecode(b *testing.B, testfile, level, n int) {
 	buf0, compressed, w = nil, nil, nil
 	const ioCopyBuffSize = 32 * 1024 // taken from io.copyBuffer, in case passed buf==nil
 	ioCopyBuff := make([]byte, ioCopyBuffSize)
-	runtime.GC()
-	b.StartTimer()
 	r := NewReader(bytes.NewReader(buf1))
 	res := r.(Resetter)
+	runtime.GC()
+	b.StartTimer()
+
 	for i := 0; i < b.N; i++ {
-		res.Reset(bytes.NewReader(buf1), nil)
-		io.CopyBuffer(io.Discard, r, ioCopyBuff)
+		_ = res.Reset(bytes.NewReader(buf1), nil)
+		_, _ = io.CopyBuffer(io.Discard, r, ioCopyBuff)
 	}
 }
 


### PR DESCRIPTION
- `decompressor.step` is now enumeric instead of function pointer. This reduces ALL allocations in decompressor benchmarks to constant 1 (previously this number differed for each case). However, it doesn't bring much gains in terms of throughtput.
- `huffmanBlockDecoder()`, generated by _gen/gen_inflate.go, also used to return a function pointer. Now calling the method directly inside of it. Also doesn't bring much gains, but in microbenchmarks may be visible
- Improved decompressor benchmarks by replacing io.Copy() with io.CopyBuffer(), because io.Copy() allocates internally a buffer for reading
- Removed some expressions, that are useless