### PR TITLE
gzip: Error out if reserved bits are set

### DIFF
--- a/gzip/gunzip.go
+++ b/gzip/gunzip.go
@@ -238,6 +238,11 @@ func (z *Reader) readHeader() (hdr Header, err error) {
 		}
 	}
 
+	// Reserved FLG bits must be zero.
+	if flg>>5 != 0 {
+		return hdr, ErrHeader
+	}
+
 	z.digest = 0
 	if z.decompressor == nil {
 		z.decompressor = flate.NewReader(z.r)


### PR DESCRIPTION
RFC 1952 states: Reserved FLG bits must be zero.