### PR TITLE
zstd: Less branching in asm version of adjustOffset

### DIFF
--- a/zstd/seqdec_amd64.s
+++ b/zstd/seqdec_amd64.s
@@ -223,51 +223,28 @@ sequenceDecs_decode_amd64_skip_update:
 	JMP  sequenceDecs_decode_amd64_after_adjust
 
 sequenceDecs_decode_amd64_adjust_offsetB_1_or_0:
-	CMPQ (R10), $0x00000000
-	JNE  sequenceDecs_decode_amd64_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_amd64_adjust_offset_nonzero
-
-sequenceDecs_decode_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_amd64_adjust_offset_nonzero
-	MOVQ  R11, CX
-	JMP   sequenceDecs_decode_amd64_after_adjust
+	LEAQ    1(CX), AX
+	CMPQ    (R10), $0x00000000
+	CMOVQEQ AX, CX
+	TESTQ   CX, CX
+	JNZ     sequenceDecs_decode_amd64_adjust_offset_nonzero
+	MOVQ    R11, CX
+	JMP     sequenceDecs_decode_amd64_after_adjust
 
 sequenceDecs_decode_amd64_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_amd64_adjust_zero
-	JEQ  sequenceDecs_decode_amd64_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_amd64_adjust_three
-	JMP  sequenceDecs_decode_amd64_adjust_two
-
-sequenceDecs_decode_amd64_adjust_zero:
-	MOVQ R11, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_one:
-	MOVQ R12, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_two:
-	MOVQ R13, AX
-	JMP  sequenceDecs_decode_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_amd64_adjust_three:
-	LEAQ -1(R11), AX
-
-sequenceDecs_decode_amd64_adjust_test_temp_valid:
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_amd64_adjust_temp_valid
-	MOVQ  $0x00000001, AX
+	LEAQ    -1(R11), AX
+	CMPQ    CX, $0x02
+	CMOVQEQ R13, AX
+	CMOVQCS R12, AX
+	CMOVQCC R12, R13
+	TESTQ   AX, AX
+	JNZ     sequenceDecs_decode_amd64_adjust_temp_valid
+	INCL    AX
 
 sequenceDecs_decode_amd64_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R12, R13
-	MOVQ    R11, R12
-	MOVQ    AX, R11
-	MOVQ    AX, CX
+	MOVQ R11, R12
+	MOVQ AX, R11
+	MOVQ AX, CX
 
 sequenceDecs_decode_amd64_after_adjust:
 	MOVQ CX, 16(R10)
@@ -522,51 +499,28 @@ sequenceDecs_decode_56_amd64_skip_update:
 	JMP  sequenceDecs_decode_56_amd64_after_adjust
 
 sequenceDecs_decode_56_amd64_adjust_offsetB_1_or_0:
-	CMPQ (R10), $0x00000000
-	JNE  sequenceDecs_decode_56_amd64_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_amd64_adjust_offset_nonzero
-
-sequenceDecs_decode_56_amd64_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_amd64_adjust_offset_nonzero
-	MOVQ  R11, CX
-	JMP   sequenceDecs_decode_56_amd64_after_adjust
+	LEAQ    1(CX), AX
+	CMPQ    (R10), $0x00000000
+	CMOVQEQ AX, CX
+	TESTQ   CX, CX
+	JNZ     sequenceDecs_decode_56_amd64_adjust_offset_nonzero
+	MOVQ    R11, CX
+	JMP     sequenceDecs_decode_56_amd64_after_adjust
 
 sequenceDecs_decode_56_amd64_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_56_amd64_adjust_zero
-	JEQ  sequenceDecs_decode_56_amd64_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_56_amd64_adjust_three
-	JMP  sequenceDecs_decode_56_amd64_adjust_two
-
-sequenceDecs_decode_56_amd64_adjust_zero:
-	MOVQ R11, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_one:
-	MOVQ R12, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_two:
-	MOVQ R13, AX
-	JMP  sequenceDecs_decode_56_amd64_adjust_test_temp_valid
-
-sequenceDecs_decode_56_amd64_adjust_three:
-	LEAQ -1(R11), AX
-
-sequenceDecs_decode_56_amd64_adjust_test_temp_valid:
-	TESTQ AX, AX
-	JNZ   sequenceDecs_decode_56_amd64_adjust_temp_valid
-	MOVQ  $0x00000001, AX
+	LEAQ    -1(R11), AX
+	CMPQ    CX, $0x02
+	CMOVQEQ R13, AX
+	CMOVQCS R12, AX
+	CMOVQCC R12, R13
+	TESTQ   AX, AX
+	JNZ     sequenceDecs_decode_56_amd64_adjust_temp_valid
+	INCL    AX
 
 sequenceDecs_decode_56_amd64_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R12, R13
-	MOVQ    R11, R12
-	MOVQ    AX, R11
-	MOVQ    AX, CX
+	MOVQ R11, R12
+	MOVQ AX, R11
+	MOVQ AX, CX
 
 sequenceDecs_decode_56_amd64_after_adjust:
 	MOVQ CX, 16(R10)
@@ -808,51 +762,28 @@ sequenceDecs_decode_bmi2_skip_update:
 	JMP  sequenceDecs_decode_bmi2_after_adjust
 
 sequenceDecs_decode_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_bmi2_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decode_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_bmi2_adjust_offset_nonzero
-	MOVQ  R10, CX
-	JMP   sequenceDecs_decode_bmi2_after_adjust
+	LEAQ    1(CX), R13
+	CMPQ    (R9), $0x00000000
+	CMOVQEQ R13, CX
+	TESTQ   CX, CX
+	JNZ     sequenceDecs_decode_bmi2_adjust_offset_nonzero
+	MOVQ    R10, CX
+	JMP     sequenceDecs_decode_bmi2_after_adjust
 
 sequenceDecs_decode_bmi2_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_bmi2_adjust_zero
-	JEQ  sequenceDecs_decode_bmi2_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_bmi2_adjust_three
-	JMP  sequenceDecs_decode_bmi2_adjust_two
-
-sequenceDecs_decode_bmi2_adjust_zero:
-	MOVQ R10, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_one:
-	MOVQ R11, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_two:
-	MOVQ R12, R13
-	JMP  sequenceDecs_decode_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_bmi2_adjust_three:
-	LEAQ -1(R10), R13
-
-sequenceDecs_decode_bmi2_adjust_test_temp_valid:
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_bmi2_adjust_temp_valid
-	MOVQ  $0x00000001, R13
+	LEAQ    -1(R10), R13
+	CMPQ    CX, $0x02
+	CMOVQEQ R12, R13
+	CMOVQCS R11, R13
+	CMOVQCC R11, R12
+	TESTQ   R13, R13
+	JNZ     sequenceDecs_decode_bmi2_adjust_temp_valid
+	INCL    R13
 
 sequenceDecs_decode_bmi2_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R11, R12
-	MOVQ    R10, R11
-	MOVQ    R13, R10
-	MOVQ    R13, CX
+	MOVQ R10, R11
+	MOVQ R13, R10
+	MOVQ R13, CX
 
 sequenceDecs_decode_bmi2_after_adjust:
 	MOVQ CX, 16(R9)
@@ -1065,51 +996,28 @@ sequenceDecs_decode_56_bmi2_skip_update:
 	JMP  sequenceDecs_decode_56_bmi2_after_adjust
 
 sequenceDecs_decode_56_bmi2_adjust_offsetB_1_or_0:
-	CMPQ (R9), $0x00000000
-	JNE  sequenceDecs_decode_56_bmi2_adjust_offset_maybezero
-	INCQ CX
-	JMP  sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
-
-sequenceDecs_decode_56_bmi2_adjust_offset_maybezero:
-	TESTQ CX, CX
-	JNZ   sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
-	MOVQ  R10, CX
-	JMP   sequenceDecs_decode_56_bmi2_after_adjust
+	LEAQ    1(CX), R13
+	CMPQ    (R9), $0x00000000
+	CMOVQEQ R13, CX
+	TESTQ   CX, CX
+	JNZ     sequenceDecs_decode_56_bmi2_adjust_offset_nonzero
+	MOVQ    R10, CX
+	JMP     sequenceDecs_decode_56_bmi2_after_adjust
 
 sequenceDecs_decode_56_bmi2_adjust_offset_nonzero:
-	CMPQ CX, $0x01
-	JB   sequenceDecs_decode_56_bmi2_adjust_zero
-	JEQ  sequenceDecs_decode_56_bmi2_adjust_one
-	CMPQ CX, $0x02
-	JA   sequenceDecs_decode_56_bmi2_adjust_three
-	JMP  sequenceDecs_decode_56_bmi2_adjust_two
-
-sequenceDecs_decode_56_bmi2_adjust_zero:
-	MOVQ R10, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_56_bmi2_adjust_one:
-	MOVQ R11, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_56_bmi2_adjust_two:
-	MOVQ R12, R13
-	JMP  sequenceDecs_decode_56_bmi2_adjust_test_temp_valid
-
-sequenceDecs_decode_56_bmi2_adjust_three:
-	LEAQ -1(R10), R13
-
-sequenceDecs_decode_56_bmi2_adjust_test_temp_valid:
-	TESTQ R13, R13
-	JNZ   sequenceDecs_decode_56_bmi2_adjust_temp_valid
-	MOVQ  $0x00000001, R13
+	LEAQ    -1(R10), R13
+	CMPQ    CX, $0x02
+	CMOVQEQ R12, R13
+	CMOVQCS R11, R13
+	CMOVQCC R11, R12
+	TESTQ   R13, R13
+	JNZ     sequenceDecs_decode_56_bmi2_adjust_temp_valid
+	INCL    R13
 
 sequenceDecs_decode_56_bmi2_adjust_temp_valid:
-	CMPQ    CX, $0x01
-	CMOVQNE R11, R12
-	MOVQ    R10, R11
-	MOVQ    R13, R10
-	MOVQ    R13, CX
+	MOVQ R10, R11
+	MOVQ R13, R10
+	MOVQ R13, CX
 
 sequenceDecs_decode_56_bmi2_after_adjust:
 	MOVQ CX, 16(R9)
@@ -2036,10 +1944,9 @@ sequenceDecs_decodeSync_amd64_adjust_offset_maybezero:
 sequenceDecs_decodeSync_amd64_adjust_offset_nonzero:
 	MOVQ    R13, AX
 	XORQ    R14, R14
-	MOVQ    $-1, R15
 	CMPQ    R13, $0x03
 	CMOVQEQ R14, AX
-	CMOVQEQ R15, R14
+	ADCQ    $-1, R14
 	ADDQ    144(CX)(AX*8), R14
 	JNZ     sequenceDecs_decodeSync_amd64_adjust_temp_valid
 	MOVQ    $0x00000001, R14
@@ -2556,10 +2463,9 @@ sequenceDecs_decodeSync_bmi2_adjust_offset_maybezero:
 sequenceDecs_decodeSync_bmi2_adjust_offset_nonzero:
 	MOVQ    R13, R12
 	XORQ    R14, R14
-	MOVQ    $-1, R15
 	CMPQ    R13, $0x03
 	CMOVQEQ R14, R12
-	CMOVQEQ R15, R14
+	ADCQ    $-1, R14
 	ADDQ    144(CX)(R12*8), R14
 	JNZ     sequenceDecs_decodeSync_bmi2_adjust_temp_valid
 	MOVQ    $0x00000001, R14
@@ -3118,10 +3024,9 @@ sequenceDecs_decodeSync_safe_amd64_adjust_offset_maybezero:
 sequenceDecs_decodeSync_safe_amd64_adjust_offset_nonzero:
 	MOVQ    R13, AX
 	XORQ    R14, R14
-	MOVQ    $-1, R15
 	CMPQ    R13, $0x03
 	CMOVQEQ R14, AX
-	CMOVQEQ R15, R14
+	ADCQ    $-1, R14
 	ADDQ    144(CX)(AX*8), R14
 	JNZ     sequenceDecs_decodeSync_safe_amd64_adjust_temp_valid
 	MOVQ    $0x00000001, R14
@@ -3740,10 +3645,9 @@ sequenceDecs_decodeSync_safe_bmi2_adjust_offset_maybezero:
 sequenceDecs_decodeSync_safe_bmi2_adjust_offset_nonzero:
 	MOVQ    R13, R12
 	XORQ    R14, R14
-	MOVQ    $-1, R15
 	CMPQ    R13, $0x03
 	CMOVQEQ R14, R12
-	CMOVQEQ R15, R14
+	ADCQ    $-1, R14
 	ADDQ    144(CX)(R12*8), R14
 	JNZ     sequenceDecs_decodeSync_safe_bmi2_adjust_temp_valid
 	MOVQ    $0x00000001, R14


### PR DESCRIPTION
We can do most of the work with conditional moves and we can handle the case offset != 0 with a single comparison against 2.

Also, shorten a conditional move in adjustOffsetInMemory from a MOVQ+CMOVQEQ to an ADCQ.

Benchmark results, Ivy Bridge:

```
                                       │     old      │                cmov              │
                                       │     B/s      │     B/s       vs base               │
Decoder_DecodeAll/kppkn.gtb.zst-8        447.7Mi ± 2%   445.0Mi ± 0%       ~ (p=0.355 n=20)
Decoder_DecodeAll/geo.protodata.zst-8    1.147Gi ± 0%   1.152Gi ± 1%  +0.39% (p=0.012 n=20)
Decoder_DecodeAll/plrabn12.txt.zst-8     354.0Mi ± 1%   351.6Mi ± 1%       ~ (p=0.076 n=20)
Decoder_DecodeAll/lcet10.txt.zst-8       424.9Mi ± 1%   420.2Mi ± 0%  -1.10% (p=0.000 n=20)
Decoder_DecodeAll/asyoulik.txt.zst-8     351.4Mi ± 1%   350.5Mi ± 0%       ~ (p=1.000 n=20)
Decoder_DecodeAll/alice29.txt.zst-8      350.5Mi ± 1%   349.5Mi ± 1%       ~ (p=0.525 n=20)
Decoder_DecodeAll/html_x_4.zst-8         1.437Gi ± 1%   1.440Gi ± 0%       ~ (p=0.607 n=20)
Decoder_DecodeAll/paper-100k.pdf.zst-8   4.193Gi ± 1%   4.219Gi ± 1%  +0.60% (p=0.007 n=20)
Decoder_DecodeAll/fireworks.jpeg.zst-8   8.878Gi ± 0%   8.798Gi ± 0%  -0.89% (p=0.000 n=20)
Decoder_DecodeAll/urls.10K.zst-8         596.6Mi ± 1%   596.0Mi ± 1%       ~ (p=0.337 n=20)
Decoder_DecodeAll/html.zst-8             933.2Mi ± 0%   936.1Mi ± 1%       ~ (p=0.659 n=20)
Decoder_DecodeAll/comp-data.bin.zst-8    394.0Mi ± 1%   390.9Mi ± 1%       ~ (p=0.149 n=20)
geomean                                  839.6Mi        837.4Mi       -0.26%

```

Tiger Lake (laptop):

	                                        │     old      │                 cmov                 │
	                                        │     B/s      │      B/s       vs base               │
	Decoder_DecodeAll/kppkn.gtb.zst-16        408.2Mi ± 1%    416.9Mi ± 2%  +2.13% (p=0.000 n=20)
	Decoder_DecodeAll/geo.protodata.zst-16    1.291Gi ± 1%    1.306Gi ± 2%       ~ (p=0.277 n=20)
	Decoder_DecodeAll/plrabn12.txt.zst-16     332.9Mi ± 2%    339.3Mi ± 2%  +1.95% (p=0.030 n=20)
	Decoder_DecodeAll/lcet10.txt.zst-16       394.1Mi ± 1%    398.6Mi ± 1%  +1.16% (p=0.006 n=20)
	Decoder_DecodeAll/asyoulik.txt.zst-16     348.2Mi ± 1%    350.0Mi ± 0%       ~ (p=0.101 n=20)
	Decoder_DecodeAll/alice29.txt.zst-16      320.1Mi ± 2%    319.5Mi ± 1%       ~ (p=0.265 n=20)
	Decoder_DecodeAll/html_x_4.zst-16         2.109Gi ± 1%    2.138Gi ± 2%       ~ (p=0.068 n=20)
	Decoder_DecodeAll/paper-100k.pdf.zst-16   5.258Gi ± 1%    5.291Gi ± 1%       ~ (p=0.121 n=20)
	Decoder_DecodeAll/fireworks.jpeg.zst-16   12.40Gi ± 1%    12.54Gi ± 1%  +1.08% (p=0.004 n=20)
	Decoder_DecodeAll/urls.10K.zst-16         553.6Mi ± 1%    563.5Mi ± 2%  +1.80% (p=0.000 n=20)
	Decoder_DecodeAll/html.zst-16             987.2Mi ± 1%   1004.3Mi ± 2%       ~ (p=0.068 n=20)
	Decoder_DecodeAll/comp-data.bin.zst-16    492.3Mi ± 2%    496.1Mi ± 1%       ~ (p=0.417 n=20)
	geomean                                   907.9Mi         918.5Mi       +1.17%