### PR TITLE
internal/race,s2: add some race instrumentation

### DIFF
--- a/internal/race/norace.go
+++ b/internal/race/norace.go
@@ -1,0 +1,13 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !race
+
+package race
+
+func ReadSlice[T any](s []T) {
+}
+
+func WriteSlice[T any](s []T) {
+}

--- a/internal/race/race.go
+++ b/internal/race/race.go
@@ -1,0 +1,26 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build race
+
+package race
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+func ReadSlice[T any](s []T) {
+	if len(s) == 0 {
+		return
+	}
+	runtime.RaceReadRange(unsafe.Pointer(&s[0]), len(s)*int(unsafe.Sizeof(s[0])))
+}
+
+func WriteSlice[T any](s []T) {
+	if len(s) == 0 {
+		return
+	}
+	runtime.RaceWriteRange(unsafe.Pointer(&s[0]), len(s)*int(unsafe.Sizeof(s[0])))
+}

--- a/s2/decode.go
+++ b/s2/decode.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+
+	"github.com/klauspost/compress/internal/race"
 )
 
 var (
@@ -63,6 +65,10 @@ func Decode(dst, src []byte) ([]byte, error) {
 	} else {
 		dst = make([]byte, dLen)
 	}
+
+	race.WriteSlice(dst)
+	race.ReadSlice(src[s:])
+
 	if s2Decode(dst, src[s:]) != 0 {
 		return nil, ErrCorrupt
 	}

--- a/s2/encode_amd64.go
+++ b/s2/encode_amd64.go
@@ -3,6 +3,8 @@
 
 package s2
 
+import "github.com/klauspost/compress/internal/race"
+
 const hasAmd64Asm = true
 
 // encodeBlock encodes a non-empty src to a guaranteed-large-enough dst. It
@@ -14,6 +16,9 @@ const hasAmd64Asm = true
 //	len(dst) >= MaxEncodedLen(len(src)) &&
 //	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlock(dst, src []byte) (d int) {
+	race.ReadSlice(src)
+	race.WriteSlice(dst)
+
 	const (
 		// Use 12 bit table when less than...
 		limit12B = 16 << 10
@@ -50,6 +55,9 @@ func encodeBlock(dst, src []byte) (d int) {
 //	len(dst) >= MaxEncodedLen(len(src)) &&
 //	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlockBetter(dst, src []byte) (d int) {
+	race.ReadSlice(src)
+	race.WriteSlice(dst)
+
 	const (
 		// Use 12 bit table when less than...
 		limit12B = 16 << 10
@@ -86,6 +94,9 @@ func encodeBlockBetter(dst, src []byte) (d int) {
 //	len(dst) >= MaxEncodedLen(len(src)) &&
 //	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlockSnappy(dst, src []byte) (d int) {
+	race.ReadSlice(src)
+	race.WriteSlice(dst)
+
 	const (
 		// Use 12 bit table when less than...
 		limit12B = 16 << 10
@@ -121,6 +132,9 @@ func encodeBlockSnappy(dst, src []byte) (d int) {
 //	len(dst) >= MaxEncodedLen(len(src)) &&
 //	minNonLiteralBlockSize <= len(src) && len(src) <= maxBlockSize
 func encodeBlockBetterSnappy(dst, src []byte) (d int) {
+	race.ReadSlice(src)
+	race.WriteSlice(dst)
+
 	const (
 		// Use 12 bit table when less than...
 		limit12B = 16 << 10

--- a/s2/s2.go
+++ b/s2/s2.go
@@ -37,6 +37,8 @@ package s2
 import (
 	"bytes"
 	"hash/crc32"
+
+	"github.com/klauspost/compress/internal/race"
 )
 
 /*
@@ -112,6 +114,8 @@ var crcTable = crc32.MakeTable(crc32.Castagnoli)
 // crc implements the checksum specified in section 3 of
 // https://github.com/google/snappy/blob/master/framing_format.txt
 func crc(b []byte) uint32 {
+	race.ReadSlice(b)
+
 	c := crc32.Update(0, crcTable, b)
 	return c>>15 | c<<17 + 0xa282ead8
 }


### PR DESCRIPTION
Assembly code isn't instrumented with race detector. This adds few annotations for race detector.