### PR TITLE
flate: Fix reset with dictionary on custom window encodes

### DIFF
--- a/flate/deflate.go
+++ b/flate/deflate.go
@@ -212,7 +212,7 @@ func (d *compressor) writeBlockSkip(tok *tokens, index int, eof bool) error {
 // Should only be used after a start/reset.
 func (d *compressor) fillWindow(b []byte) {
 	// Do not fill window if we are in store-only or huffman mode.
-	if d.level <= 0 {
+	if d.level <= 0 && d.level > -MinCustomWindowSize {
 		return
 	}
 	if d.fast != nil {

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -538,6 +538,14 @@ func TestWriterReset(t *testing.T) {
 			return w2, nil
 		})
 	}
+	testResetOutput(t, fmt.Sprint("dict-reset-window"), func(w io.Writer) (*Writer, error) {
+		w2, err := NewWriterWindow(nil, 1024)
+		if err != nil {
+			return w2, err
+		}
+		w2.ResetDict(w, dict)
+		return w2, nil
+	})
 }
 
 func testResetOutput(t *testing.T, name string, newWriter func(w io.Writer) (*Writer, error)) {


### PR DESCRIPTION
Dictionary was being ignored when compressing with a custom window size.

Fixes #911