### PR TITLE
s2: Fix callbacks for skippable blocks and disallow 0xfe (Padding) for custom use

### DIFF
--- a/s2/reader.go
+++ b/s2/reader.go
@@ -109,7 +109,7 @@ func ReaderSkippableCB(id uint8, fn func(r io.Reader) error) ReaderOption {
 		if id < 0x80 || id > 0xfd {
 			return fmt.Errorf("ReaderSkippableCB: Invalid id provided, must be 0x80-0xfd (inclusive)")
 		}
-		r.skippableCB[id] = fn
+		r.skippableCB[id-0x80] = fn
 		return nil
 	}
 }
@@ -128,7 +128,7 @@ type Reader struct {
 	err         error
 	decoded     []byte
 	buf         []byte
-	skippableCB [0x80]func(r io.Reader) error
+	skippableCB [0xff - 0x80]func(r io.Reader) error
 	blockStart  int64 // Uncompressed offset at start of current.
 	index       *Index
 
@@ -201,7 +201,7 @@ func (r *Reader) readFull(p []byte, allowEOF bool) (ok bool) {
 // The supplied slice does not need to be the size of the read.
 func (r *Reader) skippable(tmp []byte, n int, allowEOF bool, id uint8) (ok bool) {
 	if id < 0x80 {
-		r.err = fmt.Errorf("interbal error: skippable id < 0x80")
+		r.err = fmt.Errorf("internal error: skippable id < 0x80")
 		return false
 	}
 	if fn := r.skippableCB[id-0x80]; fn != nil {
@@ -1048,15 +1048,15 @@ func (r *Reader) ReadByte() (byte, error) {
 }
 
 // SkippableCB will register a callback for chunks with the specified ID.
-// ID must be a Reserved skippable chunks ID, 0x80-0xfe (inclusive).
+// ID must be a Reserved skippable chunks ID, 0x80-0xfd (inclusive).
 // For each chunk with the ID, the callback is called with the content.
 // Any returned non-nil error will abort decompression.
 // Only one callback per ID is supported, latest sent will be used.
 // Sending a nil function will disable previous callbacks.
 func (r *Reader) SkippableCB(id uint8, fn func(r io.Reader) error) error {
-	if id < 0x80 || id > chunkTypePadding {
+	if id < 0x80 || id >= chunkTypePadding {
 		return fmt.Errorf("ReaderSkippableCB: Invalid id provided, must be 0x80-0xfe (inclusive)")
 	}
-	r.skippableCB[id] = fn
+	r.skippableCB[id-0x80] = fn
 	return nil
 }


### PR DESCRIPTION
The spec writes that 0xfe must not be interpreted by decompressors, so setting up a callback should be denied.

I left 0xfe open for use by the Writer, as it could maybe be valid for a user to handle padding manually.