### PR TITLE
ci: Remove sed for internal/fuzz/helpers.go

### DIFF
--- a/internal/fuzz/helpers.go
+++ b/internal/fuzz/helpers.go
@@ -38,6 +38,10 @@ func AddFromZip(f *testing.F, filename string, t InputType, short bool) {
 		f.Fatal(err)
 	}
 	fi, err := file.Stat()
+	if fi == nil {
+		return
+	}
+
 	if err != nil {
 		f.Fatal(err)
 	}
@@ -99,6 +103,9 @@ func ReturnFromZip(tb testing.TB, filename string, t InputType, fn func([]byte))
 		tb.Fatal(err)
 	}
 	fi, err := file.Stat()
+	if fi == nil {
+		return
+	}
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/ossfuzz/ossfuzz.sh
+++ b/ossfuzz/ossfuzz.sh
@@ -34,8 +34,6 @@ cp $SRC/compress/zstd/fuzzDicts.go $OUT/
 cd $SRC/compress
 
 # Modify some files. This would be better done upstream.
-sed -i '38 a\
-	if fi == nil { return }' $SRC/compress/internal/fuzz/helpers.go
 printf "package compress\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > registerfuzzdependency.go
 sed -i 's/zr := testCreateZipReader/\/\/zr := testCreateZipReader/g' "${SRC}"/compress/zstd/fuzz_test.go
 sed -i 's/dicts = readDicts(f, zr)/dicts = fuzzDicts/g' "${SRC}"/compress/zstd/fuzz_test.go


### PR DESCRIPTION
No idea if this is supposed to go before or after the error check.