### PR TITLE
flate, zstd: Shave some bytes off amd64 matchLen

### DIFF
--- a/flate/matchlen_amd64.s
+++ b/flate/matchlen_amd64.s
@@ -5,7 +5,6 @@
 #include "textflag.h"
 
 // func matchLen(a []byte, b []byte) int
-// Requires: BMI
 TEXT ·matchLen(SB), NOSPLIT, $0-56
 	MOVQ a_base+0(FP), AX
 	MOVQ b_base+24(FP), CX
@@ -17,17 +16,16 @@ TEXT ·matchLen(SB), NOSPLIT, $0-56
 	JB   matchlen_match4_standalone
 
 matchlen_loopback_standalone:
-	MOVQ  (AX)(SI*1), BX
-	XORQ  (CX)(SI*1), BX
-	TESTQ BX, BX
-	JZ    matchlen_loop_standalone
+	MOVQ (AX)(SI*1), BX
+	XORQ (CX)(SI*1), BX
+	JZ   matchlen_loop_standalone
 
 #ifdef GOAMD64_v3
 	TZCNTQ BX, BX
 #else
 	BSFQ BX, BX
 #endif
-	SARQ $0x03, BX
+	SHRL $0x03, BX
 	LEAL (SI)(BX*1), SI
 	JMP  gen_match_len_end
 

--- a/zstd/matchlen_amd64.s
+++ b/zstd/matchlen_amd64.s
@@ -5,7 +5,6 @@
 #include "textflag.h"
 
 // func matchLen(a []byte, b []byte) int
-// Requires: BMI
 TEXT ·matchLen(SB), NOSPLIT, $0-56
 	MOVQ a_base+0(FP), AX
 	MOVQ b_base+24(FP), CX
@@ -17,17 +16,16 @@ TEXT ·matchLen(SB), NOSPLIT, $0-56
 	JB   matchlen_match4_standalone
 
 matchlen_loopback_standalone:
-	MOVQ  (AX)(SI*1), BX
-	XORQ  (CX)(SI*1), BX
-	TESTQ BX, BX
-	JZ    matchlen_loop_standalone
+	MOVQ (AX)(SI*1), BX
+	XORQ (CX)(SI*1), BX
+	JZ   matchlen_loop_standalone
 
 #ifdef GOAMD64_v3
 	TZCNTQ BX, BX
 #else
 	BSFQ BX, BX
 #endif
-	SARQ $0x03, BX
+	SHRL $0x03, BX
 	LEAL (SI)(BX*1), SI
 	JMP  gen_match_len_end
 


### PR DESCRIPTION
I only ran a few benchmarks and did not see a speedup, but the code is a bit shorter.