### PR TITLE
Dict ROLZ 2 byte context experiment 

### DIFF
--- a/s2/dict.go
+++ b/s2/dict.go
@@ -72,7 +72,8 @@ func (d *Dict) initROLZ() {
 	for c := range d.rolzTab {
 		filled := 0
 	nextEntry:
-		for i := range d.dict[:len(d.dict)-4] {
+		for i := len(d.dict) - 4; i >= 0; i-- {
+			//for i := range d.dict[:len(d.dict)-4] {
 			if binary.LittleEndian.Uint16(d.dict[i:]) == uint16(c) {
 				// Don't fill the same 2 bytes several times.
 				const matchMask = (1 << (4 * 8)) - 1

--- a/s2/dict_test.go
+++ b/s2/dict_test.go
@@ -311,9 +311,9 @@ func TestDictBest2(t *testing.T) {
 func TestDictSize(t *testing.T) {
 	//f, err := os.Open("testdata/xlmeta.tar.s2")
 	//f, err := os.Open("testdata/broken.tar.s2")
-	f, err := os.Open("testdata/github_users_sample_set.tar.s2")
+	//f, err := os.Open("testdata/github_users_sample_set.tar.s2")
 	//f, err := os.Open("testdata/gofiles2.tar.s2")
-	//f, err := os.Open("testdata/gosrc.tar.s2")
+	f, err := os.Open("testdata/gosrc.tar.s2")
 	if err != nil {
 		t.Skip(err)
 	}
@@ -389,6 +389,9 @@ func TestDictSize(t *testing.T) {
 			}
 			totalOut += res
 			encoded = encoded[:res]
+			if true {
+				return
+			}
 			//t.Log("encoded", len(data), "->", res, "saved", len(data)-res, "bytes")
 			decoded := make([]byte, len(data))
 			res = s2DecodeDict(decoded, encoded, d)
@@ -402,7 +405,7 @@ func TestDictSize(t *testing.T) {
 			}
 		})
 	}
-	t.Logf("%d files, %d -> %d (%.2f%%) - %.02f bytes saved/file\n", totalCount, totalIn, totalOut, float64(totalOut*100)/float64(totalIn), float64(totalIn-totalOut)/float64(totalCount))
+	fmt.Printf("%d files, %d -> %d (%.2f%%) - %.02f bytes saved/file\n", totalCount, totalIn, totalOut, float64(totalOut*100)/float64(totalIn), float64(totalIn-totalOut)/float64(totalCount))
 }
 
 func FuzzDictBlocks(f *testing.F) {


### PR DESCRIPTION
Testing on go source files:

```
8912 files, 51253563 -> 15870944 (30.97%) - 3970.22 bytes saved/file

--->> (ROLZ after COPY&LIT)

8912 files, 51253563 -> 15840596 (30.91%) - 3973.63 bytes saved/file
```

Nothing too crazy here, but better than 1 byte.