### PR TITLE
gzhttp: Add TransportAlwaysDecompress option.

### DIFF
--- a/gzhttp/compress.go
+++ b/gzhttp/compress.go
@@ -306,7 +306,7 @@ func (w *GzipResponseWriter) startPlain() error {
 func (w *GzipResponseWriter) WriteHeader(code int) {
 	// Handle informational headers
 	// This is gated to not forward 1xx responses on builds prior to go1.20.
-	if shouldWrite1xxResponses() && code >= 100 && code <= 199 {
+	if code >= 100 && code <= 199 {
 		w.ResponseWriter.WriteHeader(code)
 		return
 	}

--- a/gzhttp/compress_go119.go
+++ b/gzhttp/compress_go119.go
@@ -1,9 +1,0 @@
-//go:build !go1.20
-// +build !go1.20
-
-package gzhttp
-
-// shouldWrite1xxResponses indicates whether the current build supports writes of 1xx status codes.
-func shouldWrite1xxResponses() bool {
-	return false
-}

--- a/gzhttp/compress_go120.go
+++ b/gzhttp/compress_go120.go
@@ -1,9 +1,0 @@
-//go:build go1.20
-// +build go1.20
-
-package gzhttp
-
-// shouldWrite1xxResponses indicates whether the current build supports writes of 1xx status codes.
-func shouldWrite1xxResponses() bool {
-	return true
-}

--- a/gzhttp/transport.go
+++ b/gzhttp/transport.go
@@ -5,7 +5,6 @@
 package gzhttp
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -125,7 +124,6 @@ func (g *gzRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		resp.Uncompressed = true
 	}
 	if (decompress || g.withZstd) && asciiEqualFold(resp.Header.Get("Content-Encoding"), "zstd") {
-		fmt.Println("Decompressing zstd")
 		resp.Body = &zstdReader{body: resp.Body}
 		resp.Header.Del("Content-Encoding")
 		resp.Header.Del("Content-Length")

--- a/gzhttp/transport_test.go
+++ b/gzhttp/transport_test.go
@@ -251,6 +251,71 @@ func TestTransportCustomEval(t *testing.T) {
 	}
 }
 
+func TestTransportTransportAlwaysDecompress(t *testing.T) {
+	bin, err := os.ReadFile("testdata/benchmark.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We will serve the data as zstd+gzip, but the client will not request it.
+	server := httptest.NewServer(newTestHandler(bin))
+	c := http.Client{Transport: Transport(http.DefaultTransport, TransportEnableZstd(false), TransportEnableGzip(false), TransportAlwaysDecompress(true))}
+	resp, err := c.Get(server.URL + "/zstd/do")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, bin) {
+		t.Errorf("data mismatch")
+	}
+	resp.Body.Close()
+
+	resp, err = c.Get(server.URL + "/gzip/do")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, bin) {
+		t.Errorf("data mismatch")
+	}
+	resp.Body.Close()
+
+	// We will serve the data as zstd+gzip, but the client will not request it.
+	// With TransportAlwaysDecompress(false) it should not be decompressed.
+	c = http.Client{Transport: Transport(http.DefaultTransport, TransportEnableZstd(false), TransportEnableGzip(false), TransportAlwaysDecompress(false))}
+	resp, err = c.Get(server.URL + "/zstd/do")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(got, bin) {
+		t.Errorf("data matches")
+	}
+	resp.Body.Close()
+
+	resp, err = c.Get(server.URL + "/gzip/do")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, bin) {
+		t.Errorf("data matches")
+	}
+	resp.Body.Close()
+}
+
 func BenchmarkTransport(b *testing.B) {
 	raw, err := os.ReadFile("testdata/benchmark.json")
 	if err != nil {


### PR DESCRIPTION
TransportAlwaysDecompress will always decompress the response, regardless of whether we requested it or not.

Default is false, which will pass compressed data through if we did not request compression.

Replaces #977

Bonus: Remove code for Go 1.19 and older.