### PR TITLE
No content-type on no body response code

### DIFF
--- a/gzhttp/compress.go
+++ b/gzhttp/compress.go
@@ -349,12 +349,12 @@ func (w *GzipResponseWriter) Close() error {
 			ce = w.Header().Get(contentEncoding)
 			cr = w.Header().Get(contentRange)
 		)
-		if ct == "" && bodyAllowedForStatus(w.code) {
+		if ct == "" {
 			ct = http.DetectContentType(w.buf)
 
 			// Handles the intended case of setting a nil Content-Type (as for http/server or http/fs)
 			// Set the header only if the key does not exist
-			if _, ok := w.Header()[contentType]; w.setContentType && !ok {
+			if _, ok := w.Header()[contentType]; bodyAllowedForStatus(w.code) && w.setContentType && !ok {
 				w.Header().Set(contentType, ct)
 			}
 		}

--- a/gzhttp/compress_test.go
+++ b/gzhttp/compress_test.go
@@ -662,7 +662,7 @@ func TestFlushAfterWrite3(t *testing.T) {
 	}
 	handler := gz(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
-		//rw.Write(nil)
+		// rw.Write(nil)
 		rw.(http.Flusher).Flush()
 	}))
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -1596,6 +1596,25 @@ var sniffTests = []struct {
 	{"RAR v5+", []byte("Rar!\x1A\x07\x01\x00"), "application/x-rar-compressed"},
 	{"Incorrect RAR v1.5-v4.0", []byte("Rar \x1A\x07\x00"), "application/octet-stream"},
 	{"Incorrect RAR v5+", []byte("Rar \x1A\x07\x01\x00"), "application/octet-stream"},
+}
+
+func TestNoContentTypeWhenNoContent(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	wrapper, err := NewWrapper()
+	assertNil(t, err)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp := httptest.NewRecorder()
+	wrapper(handler).ServeHTTP(resp, req)
+	res := resp.Result()
+
+	assertEqual(t, http.StatusNoContent, res.StatusCode)
+	assertEqual(t, "", res.Header.Get("Content-Type"))
+
 }
 
 func TestContentTypeDetect(t *testing.T) {


### PR DESCRIPTION
This PR addresses an issue where the Content-Type was being automatically detected and set, even for responses that are not allowed to have a body (e.g., status codes 204 No Content, 304 Not Modified, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a function to determine if a response status code allows for a body, enhancing response handling based on HTTP standards.
  
- **Bug Fixes**
	- Updated response handling to ensure the `Content-Type` header is absent for `204 No Content` status responses.

- **Tests**
	- Added a test to verify that no `Content-Type` header is sent for `204 No Content` responses, ensuring compliance with HTTP specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->