### PR TITLE
Do not set the content-type when response has no body

### DIFF
--- a/gzhttp/compress_test.go
+++ b/gzhttp/compress_test.go
@@ -1617,6 +1617,25 @@ func TestNoContentTypeWhenNoContent(t *testing.T) {
 
 }
 
+func TestNoContentTypeWhenNoBody(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapper, err := NewWrapper()
+	assertNil(t, err)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp := httptest.NewRecorder()
+	wrapper(handler).ServeHTTP(resp, req)
+	res := resp.Result()
+
+	assertEqual(t, http.StatusOK, res.StatusCode)
+	assertEqual(t, "", res.Header.Get("Content-Type"))
+
+}
+
 func TestContentTypeDetect(t *testing.T) {
 	for _, tt := range sniffTests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/klauspost/compress/pull/1011 which addresses an additional issue where the Content-Type was set for responses that have no body.

Co-authored-by: Romain <rtribotte@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for detecting `Content-Type` when not specified.
	- Adjusted conditions for applying gzip compression based on response content.

- **Bug Fixes**
	- Improved error handling to prevent silent failures during write operations.

- **Tests**
	- Introduced a new test to verify `Content-Type` behavior when no body is written.
	- Retained existing tests to ensure consistent handling of `Content-Type` in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->