### PR TITLE
zstd: Fix extra CRC written with multiple Close calls

### DIFF
--- a/zstd/encoder.go
+++ b/zstd/encoder.go
@@ -6,6 +6,7 @@ package zstd
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -417,7 +418,7 @@ func (e *Encoder) Flush() error {
 // The Encoder can still be re-used after calling this.
 func (e *Encoder) Close() error {
 	s := &e.state
-	if s.encoder == nil {
+	if s.encoder == nil || errors.Is(s.err, ErrDecoderClosed) {
 		return nil
 	}
 	err := e.nextBlock(true)
@@ -459,6 +460,11 @@ func (e *Encoder) Close() error {
 		}
 		_, s.err = s.w.Write(frame)
 	}
+	if s.err == nil {
+		s.err = ErrDecoderClosed
+		return nil
+	}
+
 	return s.err
 }
 

--- a/zstd/encoder_test.go
+++ b/zstd/encoder_test.go
@@ -278,13 +278,17 @@ func TestEncoderRegression(t *testing.T) {
 					if err != nil {
 						t.Error(err)
 					}
+					err = enc.Close()
+					if err != nil {
+						t.Error(err)
+					}
 					encoded = dst.Bytes()
 					if len(encoded) > enc.MaxEncodedSize(len(in)) {
 						t.Errorf("max encoded size for %v: got: %d, want max: %d", len(in), len(encoded), enc.MaxEncodedSize(len(in)))
 					}
 					got, err = dec.DecodeAll(encoded, make([]byte, 0, len(in)/2))
 					if err != nil {
-						t.Logf("error: %v\nwant: %v\ngot:  %v", err, in, got)
+						t.Logf("error: %v\nwant: %v\ngot:  %v", err, len(in), len(got))
 						t.Error(err)
 					}
 				})

--- a/zstd/encoder_test.go
+++ b/zstd/encoder_test.go
@@ -6,6 +6,7 @@ package zstd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -281,6 +282,10 @@ func TestEncoderRegression(t *testing.T) {
 					err = enc.Close()
 					if err != nil {
 						t.Error(err)
+					}
+					_, err = enc.Write([]byte{1, 2, 3, 4})
+					if !errors.Is(err, ErrEncoderClosed) {
+						t.Errorf("unexpected error: %v", err)
 					}
 					encoded = dst.Bytes()
 					if len(encoded) > enc.MaxEncodedSize(len(in)) {

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -88,6 +88,10 @@ var (
 	// Close has been called.
 	ErrDecoderClosed = errors.New("decoder used after Close")
 
+	// ErrEncoderClosed will be returned if the Encoder was used after
+	// Close has been called.
+	ErrEncoderClosed = errors.New("encoder used after Close")
+
 	// ErrDecoderNilInput is returned when a nil Reader was provided
 	// and an operation other than Reset/DecodeAll/Close was attempted.
 	ErrDecoderNilInput = errors.New("nil input provided as reader")


### PR DESCRIPTION
Fixes #1016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new error variable, `ErrEncoderClosed`, for improved error handling when using the Encoder after closure.
- **Bug Fixes**
	- Enhanced error handling in the `Write`, `Flush`, and `Close` methods of the Encoder to manage specific error states after closure.
- **Tests**
	- Improved test cases for the Zstandard encoder, including refined error messages and performance logging.
	- Streamlined code and enhanced test data handling for better accuracy and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->