### PR TITLE
zstd: Remove unreachable debugging code raising insecure_file_permissions

### DIFF
--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -5,14 +5,10 @@
 package zstd
 
 import (
-	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
-	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/klauspost/compress/huff0"
@@ -647,21 +643,6 @@ func (b *blockDec) prepareSequences(in []byte, hist *history) (err error) {
 	if err := seqs.initialize(br, hist, b.dst); err != nil {
 		println("initializing sequences:", err)
 		return err
-	}
-	// Extract blocks...
-	if false && hist.dict == nil {
-		fatalErr := func(err error) {
-			if err != nil {
-				panic(err)
-			}
-		}
-		fn := fmt.Sprintf("n-%d-lits-%d-prev-%d-%d-%d-win-%d.blk", hist.decoders.nSeqs, len(hist.decoders.literals), hist.recentOffsets[0], hist.recentOffsets[1], hist.recentOffsets[2], hist.windowSize)
-		var buf bytes.Buffer
-		fatalErr(binary.Write(&buf, binary.LittleEndian, hist.decoders.litLengths.fse))
-		fatalErr(binary.Write(&buf, binary.LittleEndian, hist.decoders.matchLengths.fse))
-		fatalErr(binary.Write(&buf, binary.LittleEndian, hist.decoders.offsets.fse))
-		buf.Write(in)
-		os.WriteFile(filepath.Join("testdata", "seqs", fn), buf.Bytes(), os.ModePerm)
 	}
 
 	return nil


### PR DESCRIPTION
This code was in an `if false &&` condition, but when scanned with security tools, the write to file with os.ModeFile (777) permission raises an insecure_file_permissions and should be removed to avoid security scan tools issues for everyone.

![image](https://github.com/user-attachments/assets/33acc9a7-31c2-4ba1-9cd9-654c37e30c53)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed unused imports and commented-out code to streamline the codebase. 
	- Simplified the file structure without affecting the core functionality of the decoding process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->