### PR TITLE
fix: check `r.err != nil` but return a nil value error `err`

### DIFF
--- a/zstd/snappy.go
+++ b/zstd/snappy.go
@@ -197,7 +197,7 @@ func (r *SnappyConverter) Convert(in io.Reader, w io.Writer) (int64, error) {
 
 			n, r.err = w.Write(r.block.output)
 			if r.err != nil {
-				return written, err
+				return written, r.err
 			}
 			written += int64(n)
 			continue

--- a/zstd/snappy.go
+++ b/zstd/snappy.go
@@ -239,7 +239,7 @@ func (r *SnappyConverter) Convert(in io.Reader, w io.Writer) (int64, error) {
 			}
 			n, r.err = w.Write(r.block.output)
 			if r.err != nil {
-				return written, err
+				return written, r.err
 			}
 			written += int64(n)
 			continue


### PR DESCRIPTION
IMO, maybe the code should flow one style 
```go
			err := r.block.encodeLits(r.block.literals, false)
			if err != nil {
				return written, err
			}
			n, r.err = w.Write(r.block.output)
			if r.err != nil {
				return written, r.err
			}
```

btw, I create a linter to detect code that returns a non-relevant nilness error bug. I checked the top 1000 GitHub Go repositories and found this, all result listed in https://github.com/alingse/sundrylint/issues/4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the Snappy conversion process to ensure accurate error reporting during write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->