### PR TITLE
refactor: use built-in `min` function

### DIFF
--- a/snappy/xerial/xerial.go
+++ b/snappy/xerial/xerial.go
@@ -115,13 +115,6 @@ func EncodeBetter(dst, src []byte) []byte {
 	return dst
 }
 
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 const (
 	sizeOffset = 16
 	sizeBytes  = 4

--- a/zip/writer.go
+++ b/zip/writer.go
@@ -406,8 +406,8 @@ func writeHeader(w io.Writer, h *header) error {
 	// flags.
 	if h.raw && !h.hasDataDescriptor() {
 		b.uint32(h.CRC32)
-		b.uint32(uint32(min64(h.CompressedSize64, uint32max)))
-		b.uint32(uint32(min64(h.UncompressedSize64, uint32max)))
+		b.uint32(uint32(min(h.CompressedSize64, uint32max)))
+		b.uint32(uint32(min(h.UncompressedSize64, uint32max)))
 	} else {
 		// When this package handle the compression, these values are
 		// always written to the trailing data descriptor.
@@ -427,13 +427,6 @@ func writeHeader(w io.Writer, h *header) error {
 	return err
 }
 
-func min64(x, y uint64) uint64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // CreateRaw adds a file to the zip archive using the provided [FileHeader] and
 // returns a [Writer] to which the file contents should be written. The file's
 // contents must be written to the io.Writer before the next call to [Writer.Create],
@@ -445,8 +438,8 @@ func (w *Writer) CreateRaw(fh *FileHeader) (io.Writer, error) {
 		return nil, err
 	}
 
-	fh.CompressedSize = uint32(min64(fh.CompressedSize64, uint32max))
-	fh.UncompressedSize = uint32(min64(fh.UncompressedSize64, uint32max))
+	fh.CompressedSize = uint32(min(fh.CompressedSize64, uint32max))
+	fh.UncompressedSize = uint32(min(fh.UncompressedSize64, uint32max))
 
 	h := &header{
 		FileHeader: fh,

--- a/zip/zip_test.go
+++ b/zip/zip_test.go
@@ -197,13 +197,6 @@ func (r *rleBuffer) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func min(x, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 func memset(a []byte, b byte) {
 	if len(a) == 0 {
 		return


### PR DESCRIPTION
We can use the built-in `min` function since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed `min` and `min64` utility functions across multiple packages
	- Simplified size calculations in ZIP file writing process
	- Replaced explicit minimum value functions with direct comparisons

- **Tests**
	- Updated test utility functions to use inline comparisons

The changes primarily focus on code simplification and removal of redundant utility functions without impacting core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->