### PR TITLE
zstd: Fix incorrect buffer size in dictionary encodes

### DIFF
--- a/zstd/enc_base.go
+++ b/zstd/enc_base.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	dictShardBits = 6
+	dictShardBits = 7
 )
 
 type fastBase struct {

--- a/zstd/enc_dfast.go
+++ b/zstd/enc_dfast.go
@@ -13,7 +13,7 @@ const (
 	dFastLongLen       = 8                       // Bytes used for table hash
 
 	dLongTableShardCnt  = 1 << (dFastLongTableBits - dictShardBits) // Number of shards in the table
-	dLongTableShardSize = dFastLongTableSize / tableShardCnt        // Size of an individual shard
+	dLongTableShardSize = dFastLongTableSize / dLongTableShardCnt   // Size of an individual shard
 
 	dFastShortTableBits = tableBits                // Bits used in the short match table
 	dFastShortTableSize = 1 << dFastShortTableBits // Size of the table


### PR DESCRIPTION
Fix incorrect dLongTableShardSize leading to inefficient zeroing of

Also make shards 128 bytes to reduce memory use somewhat.