### PR TITLE
Add notice to S2 about MinLZ

### DIFF
--- a/s2/README.md
+++ b/s2/README.md
@@ -1,3 +1,17 @@
+# MinLZ 
+
+I have taken the experiences from this library and created a backwards compatible compression package called MinLZ.
+
+That package will seamlessly decode S2 content, making the transition from this package fairly trivial.
+
+There are many improvements to pretty much all aspects of S2 since we have "broken free" of the Snappy format specification.
+You can read a writeup on [Design and Improvements over S2](https://gist.github.com/klauspost/a25b66198cdbdf7b5b224f670c894ed5).
+
+The only aspect not covered is custom dictionary encoding. While I do intend to fix errors in this package, 
+I do not expect to make significant improvements, since I consider MinLZ a better basis for going forward.
+
+See https://github.com/minio/minlz for all details. 
+
 # S2 Compression
 
 S2 is an extension of [Snappy](https://github.com/google/snappy).


### PR DESCRIPTION
I have taken the experiences from this library and created a backwards compatible compression package called MinLZ.

That package will seamlessly decode S2 content, making the transition from this package fairly trivial.

There are many improvements to pretty much all aspects of S2 since we have "broken free" of the Snappy format specification. You can read a writeup on [Design and Improvements over S2](https://gist.github.com/klauspost/a25b66198cdbdf7b5b224f670c894ed5).

The only aspect not covered is custom dictionary encoding. While I do intend to fix errors in this package, I do not expect to make significant improvements, since I consider MinLZ a better basis for going forward.

See https://github.com/minio/minlz for all details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section introducing MinLZ, a new compression package that is backwards compatible with the existing S2 library.
	- The update provides a concise overview of improvements in decoding and links to detailed design insights and repository information for future development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->