### PR TITLE
typo : s2/index.go

### DIFF
--- a/s2/index.go
+++ b/s2/index.go
@@ -72,7 +72,7 @@ func (i *Index) add(compressedOffset, uncompressedOffset int64) error {
 			return fmt.Errorf("internal error: Earlier uncompressed received (%d > %d)", latest.uncompressedOffset, uncompressedOffset)
 		}
 		if latest.compressedOffset > compressedOffset {
-			return fmt.Errorf("internal error: Earlier compressed received (%d > %d)", latest.uncompressedOffset, uncompressedOffset)
+			return fmt.Errorf("internal error: Earlier compressed received (%d > %d)", latest.compressedOffset, compressedOffset)
 		}
 		if latest.uncompressedOffset+minIndexDist > uncompressedOffset {
 			// Only add entry if distance is large enough.


### PR DESCRIPTION
I don't know, but maybe we should output like this?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messaging to ensure accurate feedback when encountering data order issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->