### PR TITLE
Avoiding extra allocation in zlib.reader.Reset

### DIFF
--- a/zlib/reader.go
+++ b/zlib/reader.go
@@ -132,7 +132,7 @@ func (z *reader) Close() error {
 }
 
 func (z *reader) Reset(r io.Reader, dict []byte) error {
-	*z = reader{decompressor: z.decompressor}
+	*z = reader{decompressor: z.decompressor, digest: z.digest}
 	if fr, ok := r.(flate.Reader); ok {
 		z.r = fr
 	} else {


### PR DESCRIPTION
Without change in this PR line 182 ( z.digest.Reset() ) never works and we always have an extra allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of internal state when resetting, ensuring certain data is preserved as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->