### PR TITLE
Run modernize. Deprecate Go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x, 1.25.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       CGO_ENABLED: 0
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5.5.0
       with:
-        go-version: 1.24.x
+        go-version: 1.25.x
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5.5.0
       with:
-        go-version: 1.24.x
+        go-version: 1.25.x
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -151,7 +151,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.2.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
-          version: 2.3.2
+          version: 2.11.2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dict/builder.go
+++ b/dict/builder.go
@@ -103,12 +103,12 @@ func buildDict(input [][]byte, o Options) ([]byte, error) {
 	if hashBytes < 4 || hashBytes > 8 {
 		return nil, fmt.Errorf("HashBytes must be >= 4 and <= 8")
 	}
-	println := func(args ...interface{}) {
+	println := func(args ...any) {
 		if o.Output != nil {
 			fmt.Fprintln(o.Output, args...)
 		}
 	}
-	printf := func(s string, args ...interface{}) {
+	printf := func(s string, args ...any) {
 		if o.Output != nil {
 			fmt.Fprintf(o.Output, s, args...)
 		}
@@ -237,10 +237,7 @@ func buildDict(input [][]byte, o Options) ([]byte, error) {
 			// Already added
 			continue
 		}
-		wantLen := e.n / uint32(hashBytes) / 4
-		if wantLen <= lowestOcc {
-			wantLen = lowestOcc
-		}
+		wantLen := max(e.n/uint32(hashBytes)/4, lowestOcc)
 
 		var tmp = make([]byte, 0, hashBytes*2)
 		{

--- a/flate/deflate_test.go
+++ b/flate/deflate_test.go
@@ -238,7 +238,7 @@ func testSync(t *testing.T, level int, input []byte, name string) {
 	r := NewReader(buf)
 
 	// Write half the input and read back.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		var lo, hi int
 		if i == 0 {
 			lo, hi = 0, (len(input)+1)/2
@@ -340,7 +340,7 @@ func testToFromWithLevelAndLimit(t *testing.T, level int, input []byte, name str
 }
 
 func testToFromWithLimit(t *testing.T, input []byte, name string, limit [11]int) {
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		testToFromWithLevelAndLimit(t, i, input, name, limit[i])
 	}
 	testToFromWithLevelAndLimit(t, -2, input, name, limit[10])
@@ -470,7 +470,7 @@ func TestRegression2508(t *testing.T) {
 		t.Fatalf("NewWriter: %v", err)
 	}
 	buf := make([]byte, 1024)
-	for i := 0; i < 131072; i++ {
+	for range 131072 {
 		if _, err := w.Write(buf); err != nil {
 			t.Fatalf("writer failed: %v", err)
 		}
@@ -491,7 +491,7 @@ func TestWriterReset(t *testing.T) {
 			t.Fatalf("NewWriter: %v", err)
 		}
 		buf := []byte("hello world")
-		for i := 0; i < 1024; i++ {
+		for range 1024 {
 			w.Write(buf)
 		}
 		w.Reset(io.Discard)
@@ -556,7 +556,7 @@ func testResetOutput(t *testing.T, name string, newWriter func(w io.Writer) (*Wr
 			t.Fatalf("NewWriter: %v", err)
 		}
 		b := []byte("hello world - how are you doing?")
-		for i := 0; i < 1024; i++ {
+		for range 1024 {
 			w.Write(b)
 		}
 		w.Close()
@@ -564,7 +564,7 @@ func testResetOutput(t *testing.T, name string, newWriter func(w io.Writer) (*Wr
 
 		buf2 := new(bytes.Buffer)
 		w.Reset(buf2)
-		for i := 0; i < 1024; i++ {
+		for range 1024 {
 			w.Write(b)
 		}
 		w.Close()

--- a/flate/dict_decoder.go
+++ b/flate/dict_decoder.go
@@ -104,10 +104,7 @@ func (dd *dictDecoder) writeCopy(dist, length int) int {
 	dstBase := dd.wrPos
 	dstPos := dstBase
 	srcPos := dstPos - dist
-	endPos := dstPos + length
-	if endPos > len(dd.hist) {
-		endPos = len(dd.hist)
-	}
+	endPos := min(dstPos+length, len(dd.hist))
 
 	// Copy non-overlapping section after destination position.
 	//

--- a/flate/huffman_bit_writer.go
+++ b/flate/huffman_bit_writer.go
@@ -303,10 +303,7 @@ func (w *huffmanBitWriter) generateCodegen(numLiterals int, numOffsets int, litE
 			w.codegenFreq[size]++
 			count--
 			for count >= 3 {
-				n := 6
-				if n > count {
-					n = count
-				}
+				n := min(6, count)
 				codegen[outIndex] = 16
 				outIndex++
 				codegen[outIndex] = uint8(n - 3)
@@ -316,10 +313,7 @@ func (w *huffmanBitWriter) generateCodegen(numLiterals int, numOffsets int, litE
 			}
 		} else {
 			for count >= 11 {
-				n := 138
-				if n > count {
-					n = count
-				}
+				n := min(138, count)
 				codegen[outIndex] = 18
 				outIndex++
 				codegen[outIndex] = uint8(n - 11)
@@ -472,7 +466,7 @@ func (w *huffmanBitWriter) writeDynamicHeader(numLiterals int, numOffsets int, n
 	w.writeBits(int32(numOffsets-1), 5)
 	w.writeBits(int32(numCodegens-4), 4)
 
-	for i := 0; i < numCodegens; i++ {
+	for i := range numCodegens {
 		value := uint(w.codegenEncoding.codes[codegenOrder[i]].len())
 		w.writeBits(int32(value), 3)
 	}

--- a/flate/huffman_code.go
+++ b/flate/huffman_code.go
@@ -91,7 +91,7 @@ func generateFixedLiteralEncoding() *huffmanEncoder {
 	h := newHuffmanEncoder(literalCount)
 	codes := h.codes
 	var ch uint16
-	for ch = 0; ch < literalCount; ch++ {
+	for ch = range uint16(literalCount) {
 		var bits uint16
 		var size uint8
 		switch {

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -485,7 +485,7 @@ func (f *decompressor) readHuffman() error {
 	f.nb -= 5 + 5 + 4
 
 	// (HCLEN+4)*3 bits: code lengths in the magic codeOrder order.
-	for i := 0; i < nclen; i++ {
+	for i := range nclen {
 		for f.nb < 3 {
 			if err := f.moreBits(); err != nil {
 				return err
@@ -776,7 +776,7 @@ func fixedHuffmanDecoderInit() {
 	fixedOnce.Do(func() {
 		// These come from the RFC section 3.2.6.
 		var bits [288]int
-		for i := 0; i < 144; i++ {
+		for i := range 144 {
 			bits[i] = 8
 		}
 		for i := 144; i < 256; i++ {

--- a/flate/level5.go
+++ b/flate/level5.go
@@ -677,10 +677,7 @@ func (e *fastEncL5Window) matchlen(s, t int32, src []byte) int32 {
 			panic(fmt.Sprint(s, "-", t, "(", s-t, ") > maxMatchLength (", maxMatchOffset, ")"))
 		}
 	}
-	s1 := int(s) + maxMatchLength - 4
-	if s1 > len(src) {
-		s1 = len(src)
-	}
+	s1 := min(int(s)+maxMatchLength-4, len(src))
 
 	// Extend the match to be as long as possible.
 	return int32(matchLen(src[s:s1], src[t:]))

--- a/flate/stateless.go
+++ b/flate/stateless.go
@@ -56,7 +56,7 @@ func NewStatelessWriter(dst io.Writer) io.WriteCloser {
 
 // bitWriterPool contains bit writers that can be reused.
 var bitWriterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return newHuffmanBitWriter(nil)
 	},
 }
@@ -184,7 +184,7 @@ func statelessEnc(dst *tokens, src []byte, startAt int16) {
 	// Index until startAt
 	if startAt > 0 {
 		cv := load3232(src, 0)
-		for i := int16(0); i < startAt; i++ {
+		for i := range startAt {
 			table[hashSL(cv)] = tableEntry{offset: i}
 			cv = (cv >> 8) | (uint32(src[i+4]) << 24)
 		}

--- a/flate/token_test.go
+++ b/flate/token_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type testFatal interface {
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 }
 
 // loadTestTokens will load test tokens.

--- a/flate/writer_test.go
+++ b/flate/writer_test.go
@@ -280,7 +280,7 @@ func TestWriteError(t *testing.T) {
 	in := buf.Bytes()
 	// We create our own buffer to control number of writes.
 	copyBuf := make([]byte, 128)
-	for l := 0; l < 10; l++ {
+	for l := range 10 {
 		for fail := 1; fail <= 256; fail *= 2 {
 			// Fail after 'fail' writes
 			ew := &errorWriter{N: fail}
@@ -334,7 +334,7 @@ func TestWriter_Reset(t *testing.T) {
 		fmt.Fprintf(buf, "asdasfasf%d%dfghfgujyut%dyutyu\n", i, i, i)
 	}
 	in := buf.Bytes()
-	for l := 0; l < 10; l++ {
+	for l := range 10 {
 		l := l
 		if testing.Short() && l > 1 {
 			continue
@@ -364,7 +364,7 @@ func TestWriter_Reset(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				for i := 0; i < 50; i++ {
+				for range 50 {
 					// skip ahead again... This should wrap around...
 					w.d.fast.Reset()
 				}
@@ -374,7 +374,7 @@ func TestWriter_Reset(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				for i := 0; i < (math.MaxUint32-bufferReset)/maxMatchOffset; i++ {
+				for range (math.MaxUint32 - bufferReset) / maxMatchOffset {
 					// skip ahead to where we are close to wrap around...
 					w.d.fast.Reset()
 				}

--- a/fse/bitwriter.go
+++ b/fse/bitwriter.go
@@ -143,7 +143,7 @@ func (b *bitWriter) flush32() {
 // flushAlign will flush remaining full bytes and align to next byte boundary.
 func (b *bitWriter) flushAlign() {
 	nbBytes := (b.nBits + 7) >> 3
-	for i := uint8(0); i < nbBytes; i++ {
+	for i := range nbBytes {
 		b.out = append(b.out, byte(b.bitContainer>>(i*8)))
 	}
 	b.nBits = 0

--- a/fse/compress.go
+++ b/fse/compress.go
@@ -396,7 +396,7 @@ func (s *Scratch) buildCTable() error {
 			if v > largeLimit {
 				s.zeroBits = true
 			}
-			for nbOccurrences := int16(0); nbOccurrences < v; nbOccurrences++ {
+			for range v {
 				tableSymbol[position] = symbol
 				position = (position + step) & tableMask
 				for position > highThreshold {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/klauspost/compress
 
-go 1.22
+go 1.23
 
 retract (
 	// https://github.com/klauspost/compress/pull/503

--- a/gzhttp/asserts_test.go
+++ b/gzhttp/asserts_test.go
@@ -9,21 +9,21 @@ import (
 	"testing"
 )
 
-func assertEqual(t testing.TB, want, got interface{}) {
+func assertEqual(t testing.TB, want, got any) {
 	t.Helper()
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("want %#v, got %#v", want, got)
 	}
 }
 
-func assertNotEqual(t testing.TB, want, got interface{}) {
+func assertNotEqual(t testing.TB, want, got any) {
 	t.Helper()
 	if reflect.DeepEqual(want, got) {
 		t.Fatalf("did not want %#v, got %#v", want, got)
 	}
 }
 
-func assertNil(t testing.TB, object interface{}) {
+func assertNil(t testing.TB, object any) {
 	if isNil(object) {
 		return
 	}
@@ -31,7 +31,7 @@ func assertNil(t testing.TB, object interface{}) {
 	t.Fatalf("Expected value to be nil.")
 }
 
-func assertNotNil(t testing.TB, object interface{}) {
+func assertNotNil(t testing.TB, object any) {
 	if !isNil(object) {
 		return
 	}
@@ -40,7 +40,7 @@ func assertNotNil(t testing.TB, object interface{}) {
 }
 
 // isNil checks if a specified object is nil or not, without Failing.
-func isNil(object interface{}) bool {
+func isNil(object any) bool {
 	if object == nil {
 		return true
 	}
@@ -63,7 +63,7 @@ func isNil(object interface{}) bool {
 
 // containsKind checks if a specified kind in the slice of kinds.
 func containsKind(kinds []reflect.Kind, kind reflect.Kind) bool {
-	for i := 0; i < len(kinds); i++ {
+	for i := range kinds {
 		if kind == kinds[i] {
 			return true
 		}

--- a/gzhttp/compress_test.go
+++ b/gzhttp/compress_test.go
@@ -974,10 +974,7 @@ func TestFlush(t *testing.T) {
 				for len(tb) > 0 {
 					// Write 100 bytes per run
 					// Detection should not be affected (we send 100 bytes)
-					toWrite := 100
-					if toWrite > len(tb) {
-						toWrite = len(tb)
-					}
+					toWrite := min(100, len(tb))
 					_, err := w.Write(tb[:toWrite])
 					if err != nil {
 						t.Fatal(err)
@@ -1064,7 +1061,7 @@ func TestRandomJitter(t *testing.T) {
 		t.Fatal(err)
 	}
 	changed := false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1095,7 +1092,7 @@ func TestRandomJitter(t *testing.T) {
 		}
 	}))
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1121,7 +1118,7 @@ func TestRandomJitter(t *testing.T) {
 		w.Write(payload[:512])
 	}))
 	changed = false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1153,7 +1150,7 @@ func TestRandomJitter(t *testing.T) {
 	}))
 
 	changed = false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1178,7 +1175,7 @@ func TestRandomJitter(t *testing.T) {
 
 	// Mutate *after* the flush.
 	// Should no longer affect length.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1208,7 +1205,7 @@ func TestRandomJitter(t *testing.T) {
 	}
 	handler = wrapper(writePayload)
 	changed = false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1280,7 +1277,7 @@ func TestRandomJitterParanoid(t *testing.T) {
 		t.Fatal(err)
 	}
 	changed := false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1311,7 +1308,7 @@ func TestRandomJitterParanoid(t *testing.T) {
 		}
 	}))
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1337,7 +1334,7 @@ func TestRandomJitterParanoid(t *testing.T) {
 		w.Write(payload[:512])
 	}))
 	changed = false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1369,7 +1366,7 @@ func TestRandomJitterParanoid(t *testing.T) {
 	}))
 
 	changed = false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1394,7 +1391,7 @@ func TestRandomJitterParanoid(t *testing.T) {
 
 	// Mutate *after* the flush.
 	// Should no longer affect length.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -1424,7 +1421,7 @@ func TestRandomJitterParanoid(t *testing.T) {
 	}
 	handler = wrapper(writePayload)
 	changed = false
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		result = w.Result()
@@ -2020,7 +2017,6 @@ func TestContentTypeDetectWithJitter(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/gzhttp/writer/gzkp/gzkp.go
+++ b/gzhttp/writer/gzkp/gzkp.go
@@ -35,7 +35,7 @@ func poolIndex(level int) int {
 
 func addLevelPool(level int) {
 	gzipWriterPools[poolIndex(level)] = &sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			// NewWriterLevel only returns error on a bad level, we are guaranteeing
 			// that this will be a valid level so it is okay to ignore the returned
 			// error.

--- a/gzhttp/writer/gzstd/stdlib.go
+++ b/gzhttp/writer/gzstd/stdlib.go
@@ -35,7 +35,7 @@ func poolIndex(level int) int {
 
 func addLevelPool(level int) {
 	gzipWriterPools[poolIndex(level)] = &sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			// NewWriterLevel only returns error on a bad level, we are guaranteeing
 			// that this will be a valid level so it is okay to ignore the returned
 			// error.

--- a/gzip/gunzip_test.go
+++ b/gzip/gunzip_test.go
@@ -519,7 +519,7 @@ func TestWriteTo(t *testing.T) {
 	}
 	compressed := &bytes.Buffer{}
 	// Do it twice to test MultiStream functionality
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		w, err := NewWriterLevel(compressed, -2)
 		if err != nil {
 			t.Fatal(err)

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -246,7 +246,7 @@ func testFile(i, level int, t *testing.T) {
 	if len(testbuf) != i*dl {
 		// Make results predictable
 		testbuf = make([]byte, i*dl)
-		for j := 0; j < i; j++ {
+		for j := range i {
 			copy(testbuf[j*dl:j*dl+dl], dat)
 		}
 	}
@@ -324,7 +324,7 @@ func testFileWindow(i, window int, t *testing.T) {
 	if len(testbuf) != i*dl {
 		// Make results predictable
 		testbuf = make([]byte, i*dl)
-		for j := 0; j < i; j++ {
+		for j := range i {
 			copy(testbuf[j*dl:j*dl+dl], dat)
 		}
 	}

--- a/huff0/_generate/go.mod
+++ b/huff0/_generate/go.mod
@@ -1,8 +1,8 @@
 module github.com/klauspost/compress/s2/_generate
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.4
+toolchain go1.24.2
 
 require (
 	github.com/klauspost/compress v1.15.15

--- a/huff0/_generate/go.mod
+++ b/huff0/_generate/go.mod
@@ -1,4 +1,4 @@
-module github.com/klauspost/compress/s2/_generate
+module github.com/klauspost/compress/huff0/_generate
 
 go 1.23
 

--- a/huff0/_generate/go.mod
+++ b/huff0/_generate/go.mod
@@ -12,7 +12,7 @@ require (
 require (
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/tools v0.25.0 // indirect
+	golang.org/x/tools v0.25.1 // indirect
 )
 
 replace github.com/klauspost/compress => ../..

--- a/huff0/_generate/go.sum
+++ b/huff0/_generate/go.sum
@@ -4,5 +4,5 @@ golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.25.0 h1:oFU9pkj/iJgs+0DT+VMHrx+oBKs/LJMV+Uvg78sl+fE=
-golang.org/x/tools v0.25.0/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=
+golang.org/x/tools v0.25.1 h1:YeIyhd0M7gStYR9jb2IFXVVT+QJhgXu1ZECOuRwofh4=
+golang.org/x/tools v0.25.1/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=

--- a/huff0/bitwriter.go
+++ b/huff0/bitwriter.go
@@ -85,7 +85,7 @@ func (b *bitWriter) flush32() {
 // flushAlign will flush remaining full bytes and align to next byte boundary.
 func (b *bitWriter) flushAlign() {
 	nbBytes := (b.nBits + 7) >> 3
-	for i := uint8(0); i < nbBytes; i++ {
+	for i := range nbBytes {
 		b.out = append(b.out, byte(b.bitContainer>>(i*8)))
 	}
 	b.nBits = 0

--- a/huff0/compress.go
+++ b/huff0/compress.go
@@ -276,7 +276,7 @@ func (s *Scratch) compress4X(src []byte) ([]byte, error) {
 	offsetIdx := len(s.Out)
 	s.Out = append(s.Out, sixZeros[:]...)
 
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		toDo := src
 		if len(toDo) > segmentSize {
 			toDo = toDo[:segmentSize]
@@ -312,7 +312,7 @@ func (s *Scratch) compress4Xp(src []byte) ([]byte, error) {
 	segmentSize := (len(src) + 3) / 4
 	var wg sync.WaitGroup
 	wg.Add(4)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		toDo := src
 		if len(toDo) > segmentSize {
 			toDo = toDo[:segmentSize]
@@ -326,7 +326,7 @@ func (s *Scratch) compress4Xp(src []byte) ([]byte, error) {
 		}(i)
 	}
 	wg.Wait()
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		o := s.tmpOut[i]
 		if len(o) > math.MaxUint16 {
 			// We cannot store the size in the jump table

--- a/huff0/compress_test.go
+++ b/huff0/compress_test.go
@@ -400,7 +400,7 @@ func TestCompress4XReuse(t *testing.T) {
 	rng := rand.NewSource(0x1337)
 	var s Scratch
 	s.Reuse = ReusePolicyAllow
-	for i := 0; i < 255; i++ {
+	for i := range 255 {
 		if testing.Short() && i > 10 {
 			break
 		}
@@ -434,7 +434,7 @@ func TestCompress4XReuseActually(t *testing.T) {
 	rng := rand.NewSource(0x1337)
 	var s Scratch
 	s.Reuse = ReusePolicyAllow
-	for i := 0; i < 255; i++ {
+	for i := range 255 {
 		if testing.Short() && i > 10 {
 			break
 		}

--- a/huff0/decompress.go
+++ b/huff0/decompress.go
@@ -626,7 +626,7 @@ func (d *Decoder) decompress4X8bit(dst, src []byte) ([]byte, error) {
 
 	var br [4]bitReaderBytes
 	start := 6
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		length := int(src[i*2]) | (int(src[i*2+1]) << 8)
 		if start+length >= len(src) {
 			return nil, errors.New("truncated input (or invalid offset)")
@@ -798,10 +798,7 @@ func (d *Decoder) decompress4X8bit(dst, src []byte) ([]byte, error) {
 	remainBytes := dstEvery - (decoded / 4)
 	for i := range br {
 		offset := dstEvery * i
-		endsAt := offset + remainBytes
-		if endsAt > len(out) {
-			endsAt = len(out)
-		}
+		endsAt := min(offset+remainBytes, len(out))
 		br := &br[i]
 		bitsLeft := br.remaining()
 		for bitsLeft > 0 {
@@ -864,7 +861,7 @@ func (d *Decoder) decompress4X8bit(dst, src []byte) ([]byte, error) {
 func (d *Decoder) decompress4X8bitExactly(dst, src []byte) ([]byte, error) {
 	var br [4]bitReaderBytes
 	start := 6
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		length := int(src[i*2]) | (int(src[i*2+1]) << 8)
 		if start+length >= len(src) {
 			return nil, errors.New("truncated input (or invalid offset)")
@@ -1035,10 +1032,7 @@ func (d *Decoder) decompress4X8bitExactly(dst, src []byte) ([]byte, error) {
 	remainBytes := dstEvery - (decoded / 4)
 	for i := range br {
 		offset := dstEvery * i
-		endsAt := offset + remainBytes
-		if endsAt > len(out) {
-			endsAt = len(out)
-		}
+		endsAt := min(offset+remainBytes, len(out))
 		br := &br[i]
 		bitsLeft := br.remaining()
 		for bitsLeft > 0 {

--- a/huff0/decompress_amd64.go
+++ b/huff0/decompress_amd64.go
@@ -58,7 +58,7 @@ func (d *Decoder) Decompress4X(dst, src []byte) ([]byte, error) {
 	var br [4]bitReaderShifted
 	// Decode "jump table"
 	start := 6
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		length := int(src[i*2]) | (int(src[i*2+1]) << 8)
 		if start+length >= len(src) {
 			return nil, errors.New("truncated input (or invalid offset)")
@@ -109,10 +109,7 @@ func (d *Decoder) Decompress4X(dst, src []byte) ([]byte, error) {
 	remainBytes := dstEvery - (decoded / 4)
 	for i := range br {
 		offset := dstEvery * i
-		endsAt := offset + remainBytes
-		if endsAt > len(out) {
-			endsAt = len(out)
-		}
+		endsAt := min(offset+remainBytes, len(out))
 		br := &br[i]
 		bitsLeft := br.remaining()
 		for bitsLeft > 0 {

--- a/huff0/huff0.go
+++ b/huff0/huff0.go
@@ -201,7 +201,7 @@ func (c cTable) write(s *Scratch) error {
 	for i := range hist[:16] {
 		hist[i] = 0
 	}
-	for n := uint8(0); n < maxSymbolValue; n++ {
+	for n := range maxSymbolValue {
 		v := bitsToWeight[c[n].nBits] & 15
 		huffWeight[n] = v
 		hist[v]++
@@ -271,7 +271,7 @@ func (c cTable) estTableSize(s *Scratch) (sz int, err error) {
 	for i := range hist[:16] {
 		hist[i] = 0
 	}
-	for n := uint8(0); n < maxSymbolValue; n++ {
+	for n := range maxSymbolValue {
 		v := bitsToWeight[c[n].nBits] & 15
 		huffWeight[n] = v
 		hist[v]++

--- a/internal/lz4ref/block.go
+++ b/internal/lz4ref/block.go
@@ -77,7 +77,7 @@ func (c *Compressor) put(h uint32, si int) {
 
 func (c *Compressor) reset() { c.inUse = [htSize / 32]uint32{} }
 
-var compressorPool = sync.Pool{New: func() interface{} { return new(Compressor) }}
+var compressorPool = sync.Pool{New: func() any { return new(Compressor) }}
 
 func CompressBlock(src, dst []byte) (int, error) {
 	c := compressorPool.Get().(*Compressor)

--- a/internal/snapref/decode.go
+++ b/internal/snapref/decode.go
@@ -209,7 +209,7 @@ func (r *Reader) fill() error {
 			if !r.readFull(r.buf[:len(magicBody)], false) {
 				return r.err
 			}
-			for i := 0; i < len(magicBody); i++ {
+			for i := range len(magicBody) {
 				if r.buf[i] != magicBody[i] {
 					r.err = ErrCorrupt
 					return r.err

--- a/s2/_generate/go.mod
+++ b/s2/_generate/go.mod
@@ -1,8 +1,6 @@
 module github.com/klauspost/compress/s2/_generate
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.23
 
 require (
 	github.com/klauspost/asmfmt v1.3.2

--- a/s2/_generate/go.mod
+++ b/s2/_generate/go.mod
@@ -12,5 +12,5 @@ require (
 require (
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/tools v0.25.0 // indirect
+	golang.org/x/tools v0.25.1 // indirect
 )

--- a/s2/_generate/go.sum
+++ b/s2/_generate/go.sum
@@ -6,5 +6,5 @@ golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.25.0 h1:oFU9pkj/iJgs+0DT+VMHrx+oBKs/LJMV+Uvg78sl+fE=
-golang.org/x/tools v0.25.0/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=
+golang.org/x/tools v0.25.1 h1:YeIyhd0M7gStYR9jb2IFXVVT+QJhgXu1ZECOuRwofh4=
+golang.org/x/tools v0.25.1/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=

--- a/s2/cmd/_s2sx/go.mod
+++ b/s2/cmd/_s2sx/go.mod
@@ -1,6 +1,8 @@
 module github.com/klauspost/compress/s2/cmd/s2sx
 
-go 1.22
+go 1.23
+
+toolchain go1.24.2
 
 require github.com/klauspost/compress v1.11.9
 

--- a/s2/cmd/_s2sx/go.mod
+++ b/s2/cmd/_s2sx/go.mod
@@ -1,4 +1,4 @@
-module github.com/klauspost/compress/s2/cmd/s2sx
+module github.com/klauspost/compress/s2/cmd/_s2sx
 
 go 1.23
 

--- a/s2/encode_all.go
+++ b/s2/encode_all.go
@@ -903,10 +903,7 @@ func encodeBlockDictGo(dst, src []byte, dict *Dict) (d int) {
 	// sLimit is when to stop looking for offset/length copies. The inputMargin
 	// lets us use a fast path for emitLiteral in the main loop, while we are
 	// looking for copies.
-	sLimit := len(src) - inputMargin
-	if sLimit > MaxDictSrcOffset-maxAhead {
-		sLimit = MaxDictSrcOffset - maxAhead
-	}
+	sLimit := min(len(src)-inputMargin, MaxDictSrcOffset-maxAhead)
 
 	// Bail if we can't compress to at least this.
 	dstLimit := len(src) - len(src)>>5 - 5

--- a/s2/encode_best.go
+++ b/s2/encode_best.go
@@ -42,10 +42,7 @@ func encodeBlockBest(dst, src []byte, dict *Dict) (d int) {
 	if len(src) < minNonLiteralBlockSize {
 		return 0
 	}
-	sLimitDict := len(src) - inputMargin
-	if sLimitDict > MaxDictSrcOffset-inputMargin {
-		sLimitDict = MaxDictSrcOffset - inputMargin
-	}
+	sLimitDict := min(len(src)-inputMargin, MaxDictSrcOffset-inputMargin)
 
 	var lTable [maxLTableSize]uint64
 	var sTable [maxSTableSize]uint64

--- a/s2/encode_better.go
+++ b/s2/encode_better.go
@@ -914,10 +914,7 @@ func encodeBlockBetterDict(dst, src []byte, dict *Dict) (d int) {
 		debug = false
 	)
 
-	sLimit := len(src) - inputMargin
-	if sLimit > MaxDictSrcOffset-maxAhead {
-		sLimit = MaxDictSrcOffset - maxAhead
-	}
+	sLimit := min(len(src)-inputMargin, MaxDictSrcOffset-maxAhead)
 	if len(src) < minNonLiteralBlockSize {
 		return 0
 	}

--- a/s2/reader.go
+++ b/s2/reader.go
@@ -1046,7 +1046,7 @@ func (r *Reader) ReadByte() (byte, error) {
 		return c, nil
 	}
 	var tmp [1]byte
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		n, err := r.Read(tmp[:])
 		if err != nil {
 			return 0, err

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -62,7 +62,7 @@ func TestMaxEncodedLen(t *testing.T) {
 	}
 	t.Log("Maxblock:", MaxBlockSize, "reduction:", intReduction)
 	// Test all sizes up to maxBlockSize.
-	for i := int64(0); i < maxBlockSize; i++ {
+	for i := range int64(maxBlockSize) {
 		testSet = append(testSet, struct{ in, out int64 }{in: i, out: i + int64(binary.PutVarint([]byte{binary.MaxVarintLen32: 0}, i)) + literalExtraSize(i)})
 	}
 	for i := range testSet {
@@ -161,7 +161,7 @@ func TestEmpty(t *testing.T) {
 func TestSmallCopy(t *testing.T) {
 	for _, ebuf := range [][]byte{nil, make([]byte, 20), make([]byte, 64)} {
 		for _, dbuf := range [][]byte{nil, make([]byte, 20), make([]byte, 64)} {
-			for i := 0; i < 32; i++ {
+			for i := range 32 {
 				s := "aaaa" + strings.Repeat("b", i) + "aaaabbbb"
 				if err := roundtrip([]byte(s), ebuf, dbuf); err != nil {
 					t.Errorf("len(ebuf)=%d, len(dbuf)=%d, i=%d: %v", len(ebuf), len(dbuf), i, err)
@@ -749,13 +749,13 @@ func TestFramingFormat(t *testing.T) {
 	// because it is larger than maxBlockSize (64k).
 	src := make([]byte, 1e6)
 	rng := rand.New(rand.NewSource(1))
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if i%2 == 0 {
-			for j := 0; j < 1e5; j++ {
+			for j := range int(1e5) {
 				src[1e5*i+j] = uint8(rng.Intn(256))
 			}
 		} else {
-			for j := 0; j < 1e5; j++ {
+			for j := range int(1e5) {
 				src[1e5*i+j] = uint8(i)
 			}
 		}
@@ -785,13 +785,13 @@ func TestFramingFormatBetter(t *testing.T) {
 	// because it is larger than maxBlockSize (64k).
 	src := make([]byte, 1e6)
 	rng := rand.New(rand.NewSource(1))
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if i%2 == 0 {
-			for j := 0; j < 1e5; j++ {
+			for j := range int(1e5) {
 				src[1e5*i+j] = uint8(rng.Intn(256))
 			}
 		} else {
-			for j := 0; j < 1e5; j++ {
+			for j := range int(1e5) {
 				src[1e5*i+j] = uint8(i)
 			}
 		}
@@ -1674,7 +1674,7 @@ func downloadBenchmarkFiles(b testing.TB, basename string) (errRet error) {
 
 func TestEstimateBlockSize(t *testing.T) {
 	var input []byte
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		EstimateBlockSize(input)
 		input = append(input, 0)
 	}

--- a/s2/writer.go
+++ b/s2/writer.go
@@ -47,7 +47,7 @@ func NewWriter(w io.Writer, opts ...WriterOption) *Writer {
 	w2.obufLen = obufHeaderLen + MaxEncodedLen(w2.blockSize)
 	w2.paramsOK = true
 	w2.ibuf = make([]byte, 0, w2.blockSize)
-	w2.buffers.New = func() interface{} {
+	w2.buffers.New = func() any {
 		return make([]byte, w2.obufLen)
 	}
 	w2.Reset(w)

--- a/snappy/snappy_test.go
+++ b/snappy/snappy_test.go
@@ -95,7 +95,7 @@ func TestEmpty(t *testing.T) {
 func TestSmallCopy(t *testing.T) {
 	for _, ebuf := range [][]byte{nil, make([]byte, 20), make([]byte, 64)} {
 		for _, dbuf := range [][]byte{nil, make([]byte, 20), make([]byte, 64)} {
-			for i := 0; i < 32; i++ {
+			for i := range 32 {
 				s := "aaaa" + strings.Repeat("b", i) + "aaaabbbb"
 				if err := roundtrip([]byte(s), ebuf, dbuf); err != nil {
 					t.Errorf("len(ebuf)=%d, len(dbuf)=%d, i=%d: %v", len(ebuf), len(dbuf), i, err)
@@ -598,13 +598,13 @@ func TestFramingFormat(t *testing.T) {
 	// because it is larger than maxBlockSize (64k).
 	src := make([]byte, 1e6)
 	rng := rand.New(rand.NewSource(1))
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if i%2 == 0 {
-			for j := 0; j < 1e5; j++ {
+			for j := range int(1e5) {
 				src[1e5*i+j] = uint8(rng.Intn(256))
 			}
 		} else {
-			for j := 0; j < 1e5; j++ {
+			for j := range int(1e5) {
 				src[1e5*i+j] = uint8(i)
 			}
 		}

--- a/snappy/xerial/xerial_test.go
+++ b/snappy/xerial/xerial_test.go
@@ -18,9 +18,10 @@ var snappyStreamTestCases = map[string][]byte{
 
 func makeMassive(input string, numCopies int) string {
 	outBuff := make([]byte, len(input)*numCopies)
-
-	for range numCopies {
-		copy(outBuff[len(outBuff):], input)
+	in := []byte(input)
+	for i := range numCopies {
+		start := i * len(in)
+		copy(outBuff[start:], in)
 	}
 
 	return string(outBuff)

--- a/snappy/xerial/xerial_test.go
+++ b/snappy/xerial/xerial_test.go
@@ -19,7 +19,7 @@ var snappyStreamTestCases = map[string][]byte{
 func makeMassive(input string, numCopies int) string {
 	outBuff := make([]byte, len(input)*numCopies)
 
-	for i := 0; i < numCopies; i++ {
+	for range numCopies {
 		copy(outBuff[len(outBuff):], input)
 	}
 
@@ -66,7 +66,7 @@ func TestSnappyDecodeStreams(t *testing.T) {
 
 func TestSnappyDecodeMalformedTruncatedHeader(t *testing.T) {
 	// Truncated headers should not cause a panic.
-	for i := 0; i < len(xerialHeader); i++ {
+	for i := range xerialHeader {
 		buf := make([]byte, i)
 		copy(buf, xerialHeader[:i])
 		if _, err := Decode(buf); err != ErrMalformed {

--- a/zip/reader_test.go
+++ b/zip/reader_test.go
@@ -659,7 +659,7 @@ func readTestZip(t *testing.T, zt ZipTest) {
 	// test simultaneous reads
 	n := 0
 	done := make(chan bool)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		for j, ft := range zt.File {
 			go func(j int, ft ZipTestFile) {
 				readTestFile(t, zt, ft, z.File[j], raw)
@@ -1049,7 +1049,7 @@ func biggestZipBytes() []byte {
 
 func returnBigZipBytes() (r io.ReaderAt, size int64) {
 	b := biggestZipBytes()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		r, err := NewReader(bytes.NewReader(b), int64(len(b)))
 		if err != nil {
 			panic(err)
@@ -1215,7 +1215,6 @@ func TestFS(t *testing.T) {
 			[]string{"a/b/c"},
 		},
 	} {
-		test := test
 		t.Run(test.file, func(t *testing.T) {
 			t.Parallel()
 			z, err := OpenReader(test.file)
@@ -1249,7 +1248,6 @@ func TestFSWalk(t *testing.T) {
 			wantErr: true,
 		},
 	} {
-		test := test
 		t.Run(test.file, func(t *testing.T) {
 			t.Parallel()
 			z, err := OpenReader(test.file)
@@ -1458,7 +1456,7 @@ func TestCVE202133196(t *testing.T) {
 	// files doesn't cause an issue
 	b := bytes.NewBuffer(nil)
 	w := NewWriter(b)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_, err := w.Create("")
 		if err != nil {
 			t.Fatalf("Writer.Create failed: %s", err)

--- a/zip/writer_test.go
+++ b/zip/writer_test.go
@@ -632,7 +632,7 @@ func BenchmarkCompressedZipGarbage(b *testing.B) {
 	runOnce := func(buf *bytes.Buffer) {
 		buf.Reset()
 		zw := NewWriter(buf)
-		for j := 0; j < 3; j++ {
+		for range 3 {
 			w, _ := zw.CreateHeader(&FileHeader{
 				Name:   "foo",
 				Method: Deflate,

--- a/zip/zip_test.go
+++ b/zip/zip_test.go
@@ -26,7 +26,7 @@ func TestOver65kFiles(t *testing.T) {
 	buf := new(strings.Builder)
 	w := NewWriter(buf)
 	const nFiles = (1 << 16) + 42
-	for i := 0; i < nFiles; i++ {
+	for i := range nFiles {
 		_, err := w.CreateHeader(&FileHeader{
 			Name:   fmt.Sprintf("%d.dat", i),
 			Method: Store, // Deflate is too slow when it is compiled with -race flag
@@ -46,7 +46,7 @@ func TestOver65kFiles(t *testing.T) {
 	if got := len(zr.File); got != nFiles {
 		t.Fatalf("File contains %d files, want %d", got, nFiles)
 	}
-	for i := 0; i < nFiles; i++ {
+	for i := range nFiles {
 		want := fmt.Sprintf("%d.dat", i)
 		if zr.File[i].Name != want {
 			t.Fatalf("File(%d) = %q, want %q", i, zr.File[i].Name, want)
@@ -350,7 +350,7 @@ func TestZip64ManyRecords(t *testing.T) {
 	t.Parallel()
 	gen := func(numRec int) func(*Writer) {
 		return func(w *Writer) {
-			for i := 0; i < numRec; i++ {
+			for range numRec {
 				_, err := w.CreateHeader(&FileHeader{
 					Name:   "a.txt",
 					Method: Store,
@@ -422,10 +422,7 @@ func (ss *suffixSaver) Write(p []byte) (n int, err error) {
 	ss.size += int64(len(p))
 	if len(ss.buf) < ss.keep {
 		space := ss.keep - len(ss.buf)
-		add := len(p)
-		if add > space {
-			add = space
-		}
+		add := min(len(p), space)
 		ss.buf = append(ss.buf, p[:add]...)
 		p = p[add:]
 	}
@@ -567,7 +564,7 @@ func testZip64(t testing.TB, size int64) *rleBuffer {
 	for i := range chunk {
 		chunk[i] = '.'
 	}
-	for i := 0; i < chunks; i++ {
+	for range chunks {
 		_, err := f.Write(chunk)
 		if err != nil {
 			t.Fatal("write chunk:", err)
@@ -599,7 +596,7 @@ func testZip64(t testing.TB, size int64) *rleBuffer {
 		t.Fatal("opening:", err)
 	}
 	rc.(*checksumReader).hash = fakeHash32{}
-	for i := 0; i < chunks; i++ {
+	for range chunks {
 		_, err := io.ReadFull(rc, chunk)
 		if err != nil {
 			t.Fatal("read:", err)

--- a/zlib/writer_test.go
+++ b/zlib/writer_test.go
@@ -81,7 +81,7 @@ func testLevelDict(t *testing.T, fn string, b0 []byte, level int, d string) {
 		t.Errorf("%s (level=%d, dict=%q): length mismatch %d versus %d", fn, level, d, len(b0), len(b1))
 		return
 	}
-	for i := 0; i < len(b0); i++ {
+	for i := range b0 {
 		if b0[i] != b1[i] {
 			t.Errorf("%s (level=%d, dict=%q): mismatch at %d, 0x%02x versus 0x%02x\n", fn, level, d, i, b0[i], b1[i])
 			return

--- a/zstd/_generate/go.mod
+++ b/zstd/_generate/go.mod
@@ -1,8 +1,8 @@
 module github.com/klauspost/compress/s2/_generate
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.4
+toolchain go1.24.2
 
 require (
 	github.com/klauspost/compress v1.15.15

--- a/zstd/_generate/go.mod
+++ b/zstd/_generate/go.mod
@@ -12,7 +12,7 @@ require (
 require (
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/tools v0.25.0 // indirect
+	golang.org/x/tools v0.25.1 // indirect
 )
 
 replace github.com/klauspost/compress => ../..

--- a/zstd/_generate/go.mod
+++ b/zstd/_generate/go.mod
@@ -1,4 +1,4 @@
-module github.com/klauspost/compress/s2/_generate
+module github.com/klauspost/compress/zstd/_generate
 
 go 1.23
 

--- a/zstd/_generate/go.sum
+++ b/zstd/_generate/go.sum
@@ -4,5 +4,5 @@ golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.25.0 h1:oFU9pkj/iJgs+0DT+VMHrx+oBKs/LJMV+Uvg78sl+fE=
-golang.org/x/tools v0.25.0/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=
+golang.org/x/tools v0.25.1 h1:YeIyhd0M7gStYR9jb2IFXVVT+QJhgXu1ZECOuRwofh4=
+golang.org/x/tools v0.25.1/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=

--- a/zstd/bitwriter.go
+++ b/zstd/bitwriter.go
@@ -88,7 +88,7 @@ func (b *bitWriter) flush32() {
 // flushAlign will flush remaining full bytes and align to next byte boundary.
 func (b *bitWriter) flushAlign() {
 	nbBytes := (b.nBits + 7) >> 3
-	for i := uint8(0); i < nbBytes; i++ {
+	for i := range nbBytes {
 		b.out = append(b.out, byte(b.bitContainer>>(i*8)))
 	}
 	b.nBits = 0

--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -54,11 +54,11 @@ const (
 )
 
 var (
-	huffDecoderPool = sync.Pool{New: func() interface{} {
+	huffDecoderPool = sync.Pool{New: func() any {
 		return &huff0.Scratch{}
 	}}
 
-	fseDecoderPool = sync.Pool{New: func() interface{} {
+	fseDecoderPool = sync.Pool{New: func() any {
 		return &fseDecoder{}
 	}}
 )
@@ -553,7 +553,7 @@ func (b *blockDec) prepareSequences(in []byte, hist *history) (err error) {
 		if compMode&3 != 0 {
 			return errors.New("corrupt block: reserved bits not zero")
 		}
-		for i := uint(0); i < 3; i++ {
+		for i := range uint(3) {
 			mode := seqCompMode((compMode >> (6 - i*2)) & 3)
 			if debugDecoder {
 				println("Table", tableIndex(i), "is", mode)

--- a/zstd/decoder.go
+++ b/zstd/decoder.go
@@ -373,11 +373,9 @@ func (d *Decoder) DecodeAll(input, dst []byte) ([]byte, error) {
 		if cap(dst) == 0 && !d.o.limitToCap {
 			// Allocate len(input) * 2 by default if nothing is provided
 			// and we didn't get frame content size.
-			size := len(input) * 2
-			// Cap to 1 MB.
-			if size > 1<<20 {
-				size = 1 << 20
-			}
+			size := min(
+				// Cap to 1 MB.
+				len(input)*2, 1<<20)
 			if uint64(size) > d.o.maxDecodedSize {
 				size = int(d.o.maxDecodedSize)
 			}

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -113,10 +113,7 @@ func TestNewReaderMismatch(t *testing.T) {
 				if err == nil {
 					const sizeBack = 8 << 20
 					defer org.Close()
-					start := int64(cHash)/4*blockSize - sizeBack
-					if start < 0 {
-						start = 0
-					}
+					start := max(int64(cHash)/4*blockSize-sizeBack, 0)
 					_, err = org.Seek(start, io.SeekStart)
 					if err != nil {
 						t.Fatal(err)
@@ -227,7 +224,7 @@ func TestNewDecoderMemory(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Write 256KB
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		tmp := strings.Repeat(string([]byte{byte(i)}), 1024)
 		_, err := enc.Write([]byte(tmp))
 		if err != nil {
@@ -292,7 +289,7 @@ func TestNewDecoderMemoryHighMem(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Write 256KB
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		tmp := strings.Repeat(string([]byte{byte(i)}), 1024)
 		_, err := enc.Write([]byte(tmp))
 		if err != nil {
@@ -357,7 +354,7 @@ func TestNewDecoderFrameSize(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Write 256KB
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		tmp := strings.Repeat(string([]byte{byte(i)}), 1024)
 		_, err := enc.Write([]byte(tmp))
 		if err != nil {
@@ -873,7 +870,7 @@ func TestDecoder_Reset(t *testing.T) {
 	t.Log("Encoded content matched")
 
 	// Decode using reset+copy
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		err = dec.Reset(bytes.NewBuffer(dst))
 		if err != nil {
 			t.Fatal(err)
@@ -894,7 +891,7 @@ func TestDecoder_Reset(t *testing.T) {
 		}
 	}
 	// Test without WriterTo interface support.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		err = dec.Reset(bytes.NewBuffer(dst))
 		if err != nil {
 			t.Fatal(err)
@@ -1834,7 +1831,6 @@ func testDecoderDecodeAll(t *testing.T, fn string, dec *Decoder) {
 	}
 	var wg sync.WaitGroup
 	for i, tt := range zr.File {
-		tt := tt
 		if !strings.HasSuffix(tt.Name, ".zst") || (testing.Short() && i > 20) {
 			continue
 		}
@@ -1892,7 +1888,6 @@ func testDecoderDecodeAllError(t *testing.T, fn string, dec *Decoder, errMap map
 
 	var wg sync.WaitGroup
 	for _, tt := range zr.File {
-		tt := tt
 		if !strings.HasSuffix(tt.Name, ".zst") {
 			continue
 		}

--- a/zstd/dict_test.go
+++ b/zstd/dict_test.go
@@ -124,7 +124,6 @@ func TestEncoder_SmallDict(t *testing.T) {
 			var b []byte
 			var tmp []byte
 			for i := range encs {
-				i := i
 				t.Run(encNames[i], func(t *testing.T) {
 					b = encs[i].EncodeAll(decoded, b[:0])
 					tmp, err = dec.DecodeAll(in, tmp[:0])
@@ -151,7 +150,6 @@ func TestEncoder_SmallDict(t *testing.T) {
 			// Attempt to compress with all dicts
 			var tmp []byte
 			for i := range encs {
-				i := i
 				enc := encs[i]
 				t.Run(encNames[i], func(t *testing.T) {
 					var buf bytes.Buffer
@@ -269,7 +267,6 @@ func TestEncoder_SmallDictFresh(t *testing.T) {
 			var b []byte
 			var tmp []byte
 			for i := range encs {
-				i := i
 				t.Run(encNames[i], func(t *testing.T) {
 					enc := encs[i]()
 					defer enc.Close()
@@ -298,7 +295,6 @@ func TestEncoder_SmallDictFresh(t *testing.T) {
 			// Attempt to compress with all dicts
 			var tmp []byte
 			for i := range encs {
-				i := i
 				t.Run(encNames[i], func(t *testing.T) {
 					enc := encs[i]()
 					defer enc.Close()

--- a/zstd/enc_base.go
+++ b/zstd/enc_base.go
@@ -41,11 +41,9 @@ func (e *fastBase) AppendCRC(dst []byte) []byte {
 // or a window size small enough to contain the input size, if > 0.
 func (e *fastBase) WindowSize(size int64) int32 {
 	if size > 0 && size < int64(e.maxMatchOff) {
-		b := int32(1) << uint(bits.Len(uint(size)))
-		// Keep minimum window.
-		if b < 1024 {
-			b = 1024
-		}
+		b := max(
+			// Keep minimum window.
+			int32(1)<<uint(bits.Len(uint(size))), 1024)
 		return b
 	}
 	return e.maxMatchOff

--- a/zstd/enc_better.go
+++ b/zstd/enc_better.go
@@ -190,10 +190,7 @@ encodeLoop:
 					// and have to do special offset treatment.
 					startLimit := nextEmit + 1
 
-					tMin := s - e.maxMatchOff
-					if tMin < 0 {
-						tMin = 0
-					}
+					tMin := max(s-e.maxMatchOff, 0)
 					for repIndex > tMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch-1 {
 						repIndex--
 						start--
@@ -252,10 +249,7 @@ encodeLoop:
 					// and have to do special offset treatment.
 					startLimit := nextEmit + 1
 
-					tMin := s - e.maxMatchOff
-					if tMin < 0 {
-						tMin = 0
-					}
+					tMin := max(s-e.maxMatchOff, 0)
 					for repIndex > tMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch-1 {
 						repIndex--
 						start--
@@ -480,10 +474,7 @@ encodeLoop:
 		l := matched
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] && l < maxMatchLength {
 			s--
 			t--
@@ -719,10 +710,7 @@ encodeLoop:
 					// and have to do special offset treatment.
 					startLimit := nextEmit + 1
 
-					tMin := s - e.maxMatchOff
-					if tMin < 0 {
-						tMin = 0
-					}
+					tMin := max(s-e.maxMatchOff, 0)
 					for repIndex > tMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch-1 {
 						repIndex--
 						start--
@@ -783,10 +771,7 @@ encodeLoop:
 					// and have to do special offset treatment.
 					startLimit := nextEmit + 1
 
-					tMin := s - e.maxMatchOff
-					if tMin < 0 {
-						tMin = 0
-					}
+					tMin := max(s-e.maxMatchOff, 0)
 					for repIndex > tMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch-1 {
 						repIndex--
 						start--
@@ -1005,10 +990,7 @@ encodeLoop:
 		l := matched
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] && l < maxMatchLength {
 			s--
 			t--

--- a/zstd/enc_dfast.go
+++ b/zstd/enc_dfast.go
@@ -149,10 +149,7 @@ encodeLoop:
 					// and have to do special offset treatment.
 					startLimit := nextEmit + 1
 
-					tMin := s - e.maxMatchOff
-					if tMin < 0 {
-						tMin = 0
-					}
+					tMin := max(s-e.maxMatchOff, 0)
 					for repIndex > tMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch-1 {
 						repIndex--
 						start--
@@ -266,10 +263,7 @@ encodeLoop:
 		l := e.matchlen(s+4, t+4, src) + 4
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] && l < maxMatchLength {
 			s--
 			t--
@@ -462,10 +456,7 @@ encodeLoop:
 					// and have to do special offset treatment.
 					startLimit := nextEmit + 1
 
-					tMin := s - e.maxMatchOff
-					if tMin < 0 {
-						tMin = 0
-					}
+					tMin := max(s-e.maxMatchOff, 0)
 					for repIndex > tMin && start > startLimit && src[repIndex-1] == src[start-1] {
 						repIndex--
 						start--
@@ -576,10 +567,7 @@ encodeLoop:
 		l := int32(matchLen(src[s+4:], src[t+4:])) + 4
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] {
 			s--
 			t--
@@ -809,10 +797,7 @@ encodeLoop:
 					// and have to do special offset treatment.
 					startLimit := nextEmit + 1
 
-					tMin := s - e.maxMatchOff
-					if tMin < 0 {
-						tMin = 0
-					}
+					tMin := max(s-e.maxMatchOff, 0)
 					for repIndex > tMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch-1 {
 						repIndex--
 						start--
@@ -927,10 +912,7 @@ encodeLoop:
 		l := e.matchlen(s+4, t+4, src) + 4
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] && l < maxMatchLength {
 			s--
 			t--

--- a/zstd/enc_fast.go
+++ b/zstd/enc_fast.go
@@ -143,10 +143,7 @@ encodeLoop:
 				// and have to do special offset treatment.
 				startLimit := nextEmit + 1
 
-				sMin := s - e.maxMatchOff
-				if sMin < 0 {
-					sMin = 0
-				}
+				sMin := max(s-e.maxMatchOff, 0)
 				for repIndex > sMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch {
 					repIndex--
 					start--
@@ -223,10 +220,7 @@ encodeLoop:
 		l := e.matchlen(s+4, t+4, src) + 4
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] && l < maxMatchLength {
 			s--
 			t--
@@ -387,10 +381,7 @@ encodeLoop:
 				// and have to do special offset treatment.
 				startLimit := nextEmit + 1
 
-				sMin := s - e.maxMatchOff
-				if sMin < 0 {
-					sMin = 0
-				}
+				sMin := max(s-e.maxMatchOff, 0)
 				for repIndex > sMin && start > startLimit && src[repIndex-1] == src[start-1] {
 					repIndex--
 					start--
@@ -469,10 +460,7 @@ encodeLoop:
 		l := e.matchlen(s+4, t+4, src) + 4
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] {
 			s--
 			t--
@@ -655,10 +643,7 @@ encodeLoop:
 				// and have to do special offset treatment.
 				startLimit := nextEmit + 1
 
-				sMin := s - e.maxMatchOff
-				if sMin < 0 {
-					sMin = 0
-				}
+				sMin := max(s-e.maxMatchOff, 0)
 				for repIndex > sMin && start > startLimit && src[repIndex-1] == src[start-1] && seq.matchLen < maxMatchLength-zstdMinMatch {
 					repIndex--
 					start--
@@ -735,10 +720,7 @@ encodeLoop:
 		l := e.matchlen(s+4, t+4, src) + 4
 
 		// Extend backwards
-		tMin := s - e.maxMatchOff
-		if tMin < 0 {
-			tMin = 0
-		}
+		tMin := max(s-e.maxMatchOff, 0)
 		for t > tMin && s > nextEmit && src[t-1] == src[s-1] && l < maxMatchLength {
 			s--
 			t--

--- a/zstd/framedec.go
+++ b/zstd/framedec.go
@@ -238,10 +238,7 @@ func (d *frameDec) reset(br byteBuffer) error {
 
 	if d.WindowSize == 0 && d.SingleSegment {
 		// We may not need window in this case.
-		d.WindowSize = d.FrameContentSize
-		if d.WindowSize < MinWindowSize {
-			d.WindowSize = MinWindowSize
-		}
+		d.WindowSize = max(d.FrameContentSize, MinWindowSize)
 		if d.WindowSize > d.o.maxDecodedSize {
 			if debugDecoder {
 				printf("window size %d > max %d\n", d.WindowSize, d.o.maxWindowSize)

--- a/zstd/fse_encoder.go
+++ b/zstd/fse_encoder.go
@@ -149,7 +149,7 @@ func (s *fseEncoder) buildCTable() error {
 			if v > largeLimit {
 				s.zeroBits = true
 			}
-			for nbOccurrences := int16(0); nbOccurrences < v; nbOccurrences++ {
+			for range v {
 				tableSymbol[position] = symbol
 				position = (position + step) & tableMask
 				for position > highThreshold {

--- a/zstd/internal/xxhash/xxhash_test.go
+++ b/zstd/internal/xxhash/xxhash_test.go
@@ -115,7 +115,7 @@ func TestBinaryMarshaling(t *testing.T) {
 
 	d0 := New()
 	d1 := New()
-	for i := 0; i < 64; i++ {
+	for i := range 64 {
 		b, err := d0.MarshalBinary()
 		if err != nil {
 			t.Fatal(err)

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -231,10 +231,7 @@ func (s *sequenceDecs) decodeSync(hist []byte) error {
 	llTable, mlTable, ofTable := s.litLengths.fse.dt[:maxTablesize], s.matchLengths.fse.dt[:maxTablesize], s.offsets.fse.dt[:maxTablesize]
 	llState, mlState, ofState := s.litLengths.state.state, s.matchLengths.state.state, s.offsets.state.state
 	out := s.out
-	maxBlockSize := maxCompressedBlockSize
-	if s.windowSize < maxBlockSize {
-		maxBlockSize = s.windowSize
-	}
+	maxBlockSize := min(s.windowSize, maxCompressedBlockSize)
 
 	if debugDecoder {
 		println("decodeSync: decoding", seqs, "sequences", br.remain(), "bits remain on stream")

--- a/zstd/seqdec_amd64.go
+++ b/zstd/seqdec_amd64.go
@@ -79,10 +79,7 @@ func (s *sequenceDecs) decodeSyncSimple(hist []byte) (bool, error) {
 
 	br := s.br
 
-	maxBlockSize := maxCompressedBlockSize
-	if s.windowSize < maxBlockSize {
-		maxBlockSize = s.windowSize
-	}
+	maxBlockSize := min(s.windowSize, maxCompressedBlockSize)
 
 	ctx := decodeSyncAsmContext{
 		llTable:     s.litLengths.fse.dt[:maxTablesize],
@@ -237,10 +234,7 @@ func sequenceDecs_decode_56_bmi2(s *sequenceDecs, br *bitReader, ctx *decodeAsmC
 func (s *sequenceDecs) decode(seqs []seqVals) error {
 	br := s.br
 
-	maxBlockSize := maxCompressedBlockSize
-	if s.windowSize < maxBlockSize {
-		maxBlockSize = s.windowSize
-	}
+	maxBlockSize := min(s.windowSize, maxCompressedBlockSize)
 
 	ctx := decodeAsmContext{
 		llTable:   s.litLengths.fse.dt[:maxTablesize],

--- a/zstd/seqdec_amd64_test.go
+++ b/zstd/seqdec_amd64_test.go
@@ -132,7 +132,7 @@ func Test_sequenceDecs_decodeNoBMI(t *testing.T) {
 				w, err := zw.Create(tt.Name)
 				fatalIf(err)
 				c := csv.NewWriter(w)
-				w.Write([]byte(fmt.Sprintf("%d,%d,%d\n", s.prevOffset[0], s.prevOffset[1], s.prevOffset[2])))
+				w.Write(fmt.Appendf(nil, "%d,%d,%d\n", s.prevOffset[0], s.prevOffset[1], s.prevOffset[2]))
 				for _, seq := range seqs {
 					c.Write([]string{strconv.Itoa(seq.mo), strconv.Itoa(seq.ml), strconv.Itoa(seq.ll)})
 				}

--- a/zstd/seqdec_test.go
+++ b/zstd/seqdec_test.go
@@ -103,7 +103,7 @@ func TestSequenceDecsAdjustOffset(t *testing.T) {
 	for i := range tc {
 		// given
 		var sd sequenceDecs
-		for j := 0; j < 3; j++ {
+		for j := range 3 {
 			sd.prevOffset[j] = tc[i].prevOffset[j]
 		}
 
@@ -117,7 +117,7 @@ func TestSequenceDecsAdjustOffset(t *testing.T) {
 			t.Errorf("testcase #%d: wrong function result", i)
 		}
 
-		for j := 0; j < 3; j++ {
+		for j := range 3 {
 			if sd.prevOffset[j] != tc[i].res.prevOffset[j] {
 				t.Logf("result:   %v", sd.prevOffset)
 				t.Logf("expected: %v", tc[i].res.prevOffset)
@@ -279,7 +279,7 @@ func Test_seqdec_decoder(t *testing.T) {
 				w, err := zw.Create(tt.Name)
 				fatalIf(err)
 				c := csv.NewWriter(w)
-				w.Write([]byte(fmt.Sprintf("%d,%d,%d\n", s.prevOffset[0], s.prevOffset[1], s.prevOffset[2])))
+				w.Write(fmt.Appendf(nil, "%d,%d,%d\n", s.prevOffset[0], s.prevOffset[1], s.prevOffset[2]))
 				for _, seq := range seqs {
 					c.Write([]string{strconv.Itoa(seq.mo), strconv.Itoa(seq.ml), strconv.Itoa(seq.ll)})
 				}

--- a/zstd/snappy.go
+++ b/zstd/snappy.go
@@ -257,7 +257,7 @@ func (r *SnappyConverter) Convert(in io.Reader, w io.Writer) (int64, error) {
 			if !r.readFull(r.buf[:len(snappyMagicBody)], false) {
 				return written, r.err
 			}
-			for i := 0; i < len(snappyMagicBody); i++ {
+			for i := range len(snappyMagicBody) {
 				if r.buf[i] != snappyMagicBody[i] {
 					println("r.buf[i] != snappyMagicBody[i]", r.buf[i], snappyMagicBody[i], i)
 					r.err = ErrSnappyCorrupt

--- a/zstd/zip.go
+++ b/zstd/zip.go
@@ -19,7 +19,7 @@ const ZipMethodWinZip = 93
 const ZipMethodPKWare = 20
 
 // zipReaderPool is the default reader pool.
-var zipReaderPool = sync.Pool{New: func() interface{} {
+var zipReaderPool = sync.Pool{New: func() any {
 	z, err := NewReader(nil, WithDecoderLowmem(true), WithDecoderMaxWindow(128<<20), WithDecoderConcurrency(1))
 	if err != nil {
 		panic(err)

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -98,13 +98,13 @@ var (
 	ErrDecoderNilInput = errors.New("nil input provided as reader")
 )
 
-func println(a ...interface{}) {
+func println(a ...any) {
 	if debug || debugDecoder || debugEncoder {
 		log.Println(a...)
 	}
 }
 
-func printf(format string, a ...interface{}) {
+func printf(format string, a ...any) {
 	if debug || debugDecoder || debugEncoder {
 		log.Printf(format, a...)
 	}

--- a/zstd/zstd_test.go
+++ b/zstd/zstd_test.go
@@ -100,7 +100,7 @@ func TestWriterMemUsage(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						_ = zr.EncodeAll(data, dst[:0])
 					}
 				})
@@ -130,7 +130,7 @@ func BenchmarkMem(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			for j := 0; j < 16; j++ {
+			for range 16 {
 				w.Reset(io.Discard)
 
 				if _, err := w.Write(data); err != nil {
@@ -156,7 +156,7 @@ func BenchmarkMem(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			for j := 0; j < 16; j++ {
+			for range 16 {
 				w.Reset(io.Discard)
 
 				if _, err := w.Write(data); err != nil {


### PR DESCRIPTION
Running: https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI/tooling updated: Go versions bumped in workflows (matrix now includes 1.23–1.25) and GoReleaser upgraded.
  - Module Go directive bumped to 1.23 across modules.

- Refactor
  - Internal code modernizations and simplifications to boundary/clamping and iteration styles for clearer, more consistent code.

- Tests
  - Test code updated to modern iteration patterns; some subtest capture behavior adjusted to reduce flakiness.

- Bug Fixes
  - Minor robustness and boundary-handling improvements in compression/decoding paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->