### PR TITLE
fix(gzhttp): preserve qvalue when extra parameters follow in Accept-Encoding

### DIFF
--- a/gzhttp/compress.go
+++ b/gzhttp/compress.go
@@ -881,9 +881,9 @@ func parseCoding(s string) (coding string, qvalue float64, err error) {
 		}
 		return coding, DefaultQValue, err
 	}
+	qvalue = DefaultQValue
 	for n, part := range strings.Split(s, ";") {
 		part = strings.TrimSpace(part)
-		qvalue = DefaultQValue
 
 		if n == 0 {
 			coding = strings.ToLower(part)

--- a/gzhttp/compress_test.go
+++ b/gzhttp/compress_test.go
@@ -40,6 +40,9 @@ func TestParseEncodings(t *testing.T) {
 		// More random stuff
 		"AAA;q=1":     {"aaa": 1.0},
 		"BBB ; q = 2": {"bbb": 1.0},
+
+		"gzip;q=0.5;level=6":     {"gzip": 0.5},
+		"gzip;q=0.3;level=6;x=y": {"gzip": 0.3},
 	}
 
 	for eg, exp := range examples {


### PR DESCRIPTION
parseCoding() reset qvalue to DefaultQValue on every loop iteration, causing "gzip;q=0.5;level=6" to incorrectly return qvalue=1.0 instead of 0.5.

Move qvalue initialization before the loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP compression encoding parsing now correctly processes quality parameters in Accept-Encoding headers with multiple specifications and extended parameters.

* **Tests**
  * Added test cases for gzip encoding with quality values and additional parameters to ensure proper parsing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->