### PR TITLE
s2: fix insufficient repeat index validation in NewDict

### DIFF
--- a/s2/dict.go
+++ b/s2/dict.go
@@ -57,7 +57,7 @@ func NewDict(dict []byte) *Dict {
 		return nil
 	}
 	d.repeat = int(r)
-	if d.repeat > len(dict) {
+	if d.repeat > len(dict)-8 {
 		return nil
 	}
 	return &d


### PR DESCRIPTION
NewDict allowed repeat indices that left fewer than 8 readable bytes, causing potential out-of-bounds reads during dictionary table init and encoding. The check `d.repeat > len(dict)` was both off-by-one (allowing repeat == len) and didn't account for the 8-byte load width used by load64() in the encoding paths.

Align validation with MakeDictManual which correctly uses >= len(data)-8.

Add TestNewDictRepeatBounds covering edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for dictionary initialization to ensure sufficient data is available for subsequent read operations.

* **Tests**
  * Added test coverage for dictionary boundary validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->