### PR TITLE
s2: Fix amd64 stack frame corruption

### DIFF
--- a/s2/decode_amd64.s
+++ b/s2/decode_amd64.s
@@ -51,7 +51,7 @@
 //
 // The d variable is implicitly R_DST - R_DBASE,  and len(dst)-d is R_DEND - R_DST.
 // The s variable is implicitly R_SRC - R_SBASE, and len(src)-s is R_SEND - R_SRC.
-TEXT ·s2Decode(SB), NOSPLIT, $48-56
+TEXT ·s2Decode(SB), NOSPLIT, $56-56
 	// Initialize R_SRC, R_DST and R_DBASE-R_SEND.
 	MOVQ dst_base+0(FP), R_DBASE
 	MOVQ dst_len+8(FP), R_DLEN


### PR DESCRIPTION
Fixes crash when pre-empted.

Fixes #1097 - see for analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a low-level stack frame allocation issue on 64-bit systems to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->