### PR TITLE
zstd: avoid unused BuildDict encoder allocation

### DIFF
--- a/zstd/dict.go
+++ b/zstd/dict.go
@@ -230,7 +230,7 @@ func BuildDict(o BuildDictOptions) ([]byte, error) {
 	}
 	block := blockEnc{lowMem: false}
 	block.init()
-	enc := encoder(&bestFastEncoder{fastBase: fastBase{maxMatchOff: int32(maxMatchLen), bufferReset: math.MaxInt32 - int32(maxMatchLen*2), lowMem: false}})
+	var enc encoder
 	if o.Level != 0 {
 		eOpts := encoderOptions{
 			level:      o.Level,
@@ -242,6 +242,7 @@ func BuildDict(o BuildDictOptions) ([]byte, error) {
 		enc = eOpts.encoder()
 	} else {
 		o.Level = SpeedBestCompression
+		enc = encoder(&bestFastEncoder{fastBase: fastBase{maxMatchOff: int32(maxMatchLen), bufferReset: math.MaxInt32 - int32(maxMatchLen*2), lowMem: false}})
 	}
 	var (
 		remain [256]int

--- a/zstd/dict_test.go
+++ b/zstd/dict_test.go
@@ -47,6 +47,104 @@ func TestDecoder_SmallDict(t *testing.T) {
 	}
 }
 
+func buildDictLevelPathFixture() (samples [][]byte, history, src []byte) {
+	history = bytes.Repeat([]byte("build dict common phrase alpha beta gamma delta "), 16)
+	sample := func(suffix string) []byte {
+		b := append([]byte(nil), history...)
+		return append(b, suffix...)
+	}
+	samples = [][]byte{
+		sample("city=honolulu email=a@example.com status=active"),
+		sample("city=seattle email=b@example.com status=active"),
+		sample("city=london email=c@example.com status=paused"),
+		sample("city=honolulu email=d@example.com status=active"),
+	}
+	src = sample("city=honolulu email=roundtrip@example.com status=active")
+	return samples, history, src
+}
+
+func TestBuildDictLevelPathsRoundTrip(t *testing.T) {
+	samples, history, src := buildDictLevelPathFixture()
+	for _, tt := range []struct {
+		name  string
+		level EncoderLevel
+	}{
+		{name: "default"},
+		{name: "explicit", level: SpeedFastest},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dict, err := BuildDict(BuildDictOptions{
+				ID:       1,
+				Contents: samples,
+				History:  history,
+				Offsets:  [3]int{1, 4, 8},
+				Level:    tt.level,
+			})
+			if err != nil {
+				t.Fatalf("BuildDict failed: %v", err)
+			}
+
+			enc, err := NewWriter(nil, WithEncoderDict(dict), WithEncoderLevel(SpeedFastest), WithEncoderConcurrency(1))
+			if err != nil {
+				t.Fatalf("NewWriter failed: %v", err)
+			}
+			defer enc.Close()
+			encoded := enc.EncodeAll(src, nil)
+
+			dec, err := NewReader(nil, WithDecoderDicts(dict), WithDecoderConcurrency(1))
+			if err != nil {
+				t.Fatalf("NewReader failed: %v", err)
+			}
+			defer dec.Close()
+			decoded, err := dec.DecodeAll(encoded, nil)
+			if err != nil {
+				t.Fatalf("DecodeAll failed: %v", err)
+			}
+			if !bytes.Equal(decoded, src) {
+				t.Fatalf("decoded output mismatch: got %q want %q", decoded, src)
+			}
+		})
+	}
+}
+
+func BenchmarkBuildDictLevelPaths(b *testing.B) {
+	samples, history, _ := buildDictLevelPathFixture()
+	for _, tt := range []struct {
+		name  string
+		level EncoderLevel
+	}{
+		{name: "default"},
+		{name: "explicit-fastest", level: SpeedFastest},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			_, err := BuildDict(BuildDictOptions{
+				ID:       1,
+				Contents: samples,
+				History:  history,
+				Offsets:  [3]int{1, 4, 8},
+				Level:    tt.level,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := BuildDict(BuildDictOptions{
+					ID:       1,
+					Contents: samples,
+					History:  history,
+					Offsets:  [3]int{1, 4, 8},
+					Level:    tt.level,
+				})
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func TestEncoder_SmallDict(t *testing.T) {
 	// All files have CRC
 	zr := testCreateZipReader("testdata/dict-tests-small.zip", t)


### PR DESCRIPTION
## Summary

Avoid constructing a `bestFastEncoder` in `BuildDict` when callers provide an explicit `BuildDictOptions.Level`.

The previous code allocated the default best-compression encoder before checking the requested level. For explicit levels, that encoder was immediately overwritten by `eOpts.encoder()`, so its large tables were allocated and discarded without being used.

This delays the best encoder construction until the default `Level == 0` path, where it is still used. The PR also adds:

- `TestBuildDictLevelPathsRoundTrip` for default and explicit-level dictionary builds.
- `BenchmarkBuildDictLevelPaths` to report the allocation difference between those paths.

## Evidence

Correctness validation:

```
go test ./zstd
```

Allocation benchmark included in this PR:

```
go test ./zstd -run '^$' -bench '^BenchmarkBuildDictLevelPaths$' -benchmem -benchtime=5x -count=5
```

Environment: Go 1.25.5, darwin/arm64, Apple M3.

For the baseline, the benchmark/test additions were run on `upstream/master` without the `zstd/dict.go` implementation change.

Explicit `SpeedFastest` dictionary build:

| Branch | B/op | allocs/op |
| --- | ---: | ---: |
| upstream/master | ~37,137,232 | 82 |
| this PR | ~1,477,456 | 81 |

That is about 35.66 MB/op less allocation and one fewer allocation for explicit-level dictionary builds on this fixture. The default `Level == 0` path remains around 72.26 MB/op, as expected, since it still constructs the best-compression encoder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for dictionary building with different encoder level configurations and round-trip validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->