### PR TITLE
snappy/s2: Limit length of varint in `decodedLen`

### DIFF
--- a/internal/snapref/decode.go
+++ b/internal/snapref/decode.go
@@ -31,7 +31,7 @@ func DecodedLen(src []byte) (int, error) {
 // that the length header occupied.
 func decodedLen(src []byte) (blockLen, headerLen int, err error) {
 	v, n := binary.Uvarint(src)
-	if n <= 0 || v > 0xffffffff {
+	if n <= 0 || n > 5 || v > 0xffffffff {
 		return 0, 0, ErrCorrupt
 	}
 

--- a/s2/decode.go
+++ b/s2/decode.go
@@ -35,7 +35,7 @@ func DecodedLen(src []byte) (int, error) {
 // that the length header occupied.
 func decodedLen(src []byte) (blockLen, headerLen int, err error) {
 	v, n := binary.Uvarint(src)
-	if n <= 0 || v > 0xffffffff {
+	if n <= 0 || n > 5 || v > 0xffffffff {
 		return 0, 0, ErrCorrupt
 	}
 

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -227,6 +227,15 @@ func TestInvalidVarint(t *testing.T) {
 		// varint] (up to a maximum of 2^32 - 1)".
 		"valid varint (as uint64), but value overflows uint32",
 		"\x80\x80\x80\x80\x10",
+	}, {
+		// 8-byte overlong varint encoding value 4. The format spec limits
+		// the varint preamble to 5 bytes. binary.Uvarint accepts up to 10
+		// bytes so this decodes to a valid uint32 value (4), but the
+		// overlong encoding must be rejected.
+		"overlong varint (8 bytes encoding value 4), exceeds 5-byte max",
+		"\x84\x80\x80\x80\x80\x80\x80\x00" +
+			"\x00\x00\x00\x00\x00\x00\x00" +
+			"\x30",
 	}}
 
 	for _, tc := range testCases {

--- a/snappy/snappy_test.go
+++ b/snappy/snappy_test.go
@@ -146,6 +146,15 @@ func TestInvalidVarint(t *testing.T) {
 		// varint] (up to a maximum of 2^32 - 1)".
 		"valid varint (as uint64), but value overflows uint32",
 		"\x80\x80\x80\x80\x10",
+	}, {
+		// 8-byte overlong varint encoding value 4. The format spec limits
+		// the varint preamble to 5 bytes. binary.Uvarint accepts up to 10
+		// bytes so this decodes to a valid uint32 value (4), but the
+		// overlong encoding must be rejected.
+		"overlong varint (8 bytes encoding value 4), exceeds 5-byte max",
+		"\x84\x80\x80\x80\x80\x80\x80\x00" +
+			"\x00\x00\x00\x00\x00\x00\x00" +
+			"\x30",
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
To match C++ implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of compressed-data headers to better detect and reject malformed/overlong encodings, reducing risk of silent corruption.

* **Tests**
  * Added test cases covering malformed length encodings to ensure decoding surfaces corruption errors consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->