### PR TITLE
gzhttp: match qvalue parameter case-insensitively (RFC 7231)

### DIFF
--- a/gzhttp/compress.go
+++ b/gzhttp/compress.go
@@ -1158,8 +1158,8 @@ func parseCoding(s string) (coding string, qvalue float64, err error) {
 
 		if n == 0 {
 			coding = strings.ToLower(part)
-		} else if after, ok := strings.CutPrefix(part, "q="); ok {
-			qvalue, err = strconv.ParseFloat(after, 64)
+		} else if len(part) >= 2 && strings.EqualFold(part[:2], "q=") {
+			qvalue, err = strconv.ParseFloat(part[2:], 64)
 
 			if qvalue < 0.0 {
 				qvalue = 0.0

--- a/gzhttp/compress_test.go
+++ b/gzhttp/compress_test.go
@@ -43,6 +43,10 @@ func TestParseEncodings(t *testing.T) {
 
 		"gzip;q=0.5;level=6":     {"gzip": 0.5},
 		"gzip;q=0.3;level=6;x=y": {"gzip": 0.3},
+
+		"gzip;Q=0.5":     {"gzip": 0.5},
+		"GZIP;Q=0.7":     {"gzip": 0.7},
+		"gzip;Q=0.4;x=y": {"gzip": 0.4},
 	}
 
 	for eg, exp := range examples {


### PR DESCRIPTION
parseCoding only matched lowercase q=, but RFC 7231 says the weight parameter name is case-insensitive (Q= should also work).
Switched to strings.EqualFold on the 2-byte prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP compression negotiation to properly handle quality value parameters regardless of case, ensuring requests with uppercase parameter names are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->