### PR TITLE
zip: add NameDecoder callback for legacy encoding rewrite

### DIFF
--- a/zip/reader.go
+++ b/zip/reader.go
@@ -37,6 +37,10 @@ type Reader struct {
 	Comment       string
 	decompressors map[uint16]Decompressor
 
+	// nameDecoder, if non-nil, rewrites Name/Comment from a legacy encoding
+	// into UTF-8 before encoding detection runs. It is set via NewReaderWithOptions.
+	nameDecoder func(f *FileHeader) error
+
 	// Some JAR files are zip files with a prefix that is a bash script.
 	// The baseOffset field is the start of the zip file proper.
 	baseOffset int64
@@ -107,6 +111,31 @@ func NewReader(r io.ReaderAt, size int64) (*Reader, error) {
 		return nil, errors.New("zip: size cannot be negative")
 	}
 	zr := new(Reader)
+	var err error
+	if err = zr.init(r, size); err != nil && err != ErrInsecurePath {
+		return nil, err
+	}
+	return zr, err
+}
+
+// ReaderOptions holds optional knobs for [NewReaderWithOptions]. The zero
+// value is equivalent to calling [NewReader]. New fields may be added in the
+// future; callers should set only the options they need.
+type ReaderOptions struct {
+	// NameDecoder, if non-nil, is invoked for each entry as its directory
+	// header is read, before UTF-8 encoding detection runs. The callback may
+	// rewrite Name and Comment to convert from a legacy encoding into UTF-8.
+	// If NameDecoder returns a non-nil error, archive reading stops and the
+	// error is returned.
+	NameDecoder func(f *FileHeader) error
+}
+
+// NewReaderWithOptions is like [NewReader] but applies the supplied options.
+func NewReaderWithOptions(r io.ReaderAt, size int64, opts ReaderOptions) (*Reader, error) {
+	if size < 0 {
+		return nil, errors.New("zip: size cannot be negative")
+	}
+	zr := &Reader{nameDecoder: opts.NameDecoder}
 	var err error
 	if err = zr.init(r, size); err != nil && err != ErrInsecurePath {
 		return nil, err
@@ -387,6 +416,14 @@ func readDirectoryHeader(f *File, r io.Reader) error {
 	f.Name = string(d[:filenameLen])
 	f.Extra = d[filenameLen : filenameLen+extraLen]
 	f.Comment = string(d[filenameLen+extraLen:])
+
+	// Allow the user to rewrite Name/Comment from a legacy encoding into
+	// UTF-8 before encoding detection runs.
+	if f.zip != nil && f.zip.nameDecoder != nil {
+		if err := f.zip.nameDecoder(&f.FileHeader); err != nil {
+			return err
+		}
+	}
 
 	// Determine the character encoding.
 	utf8Valid1, utf8Require1 := detectUTF8(f.Name)

--- a/zip/reader_test.go
+++ b/zip/reader_test.go
@@ -1914,3 +1914,114 @@ func BenchmarkReaderManyShallowFiles(b *testing.B) {
 		zr.Open("does-not-exist")
 	}
 }
+
+// TestNameDecoder verifies that a NameDecoder passed via ReaderOptions may
+// rewrite Name and Comment before UTF-8 detection runs.
+func TestNameDecoder(t *testing.T) {
+	rawName := "\x93\xfa\x96{\x8c\xea.txt"
+	rawComment := "\x83R\x83\x81\x83\x93\x83g"
+	decodedName := "日本語.txt"
+	decodedComment := "コメント"
+
+	var buf bytes.Buffer
+	zw := NewWriter(&buf)
+	if _, err := zw.CreateHeader(&FileHeader{
+		Name:    rawName,
+		Comment: rawComment,
+		NonUTF8: true,
+		Method:  Store,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var called int
+	decoder := func(f *FileHeader) error {
+		called++
+		if f.Name != rawName {
+			t.Errorf("decoder got Name=%q, want %q", f.Name, rawName)
+		}
+		if f.Comment != rawComment {
+			t.Errorf("decoder got Comment=%q, want %q", f.Comment, rawComment)
+		}
+		f.Name = decodedName
+		f.Comment = decodedComment
+		// Mark the entry as UTF-8 now that the decoder has rewritten it.
+		f.Flags |= 0x800
+		return nil
+	}
+	zr, err := NewReaderWithOptions(bytes.NewReader(buf.Bytes()), int64(buf.Len()), ReaderOptions{NameDecoder: decoder})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called != 1 {
+		t.Fatalf("NameDecoder called %d times, want 1", called)
+	}
+	if len(zr.File) != 1 {
+		t.Fatalf("File count = %d, want 1", len(zr.File))
+	}
+	got := zr.File[0]
+	if got.Name != decodedName {
+		t.Errorf("Name = %q, want %q", got.Name, decodedName)
+	}
+	if got.Comment != decodedComment {
+		t.Errorf("Comment = %q, want %q", got.Comment, decodedComment)
+	}
+	if got.NonUTF8 {
+		t.Errorf("NonUTF8 = true, want false after decoder rewrite to UTF-8")
+	}
+}
+
+// TestNameDecoderDefault verifies that NewReader preserves the existing
+// behavior when no decoder is supplied.
+func TestNameDecoderDefault(t *testing.T) {
+	rawName := "\x93\xfa\x96{\x8c\xea.txt"
+
+	var buf bytes.Buffer
+	zw := NewWriter(&buf)
+	if _, err := zw.CreateHeader(&FileHeader{
+		Name:    rawName,
+		NonUTF8: true,
+		Method:  Store,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(zr.File) != 1 {
+		t.Fatalf("File count = %d, want 1", len(zr.File))
+	}
+	if zr.File[0].Name != rawName {
+		t.Errorf("Name = %q, want raw %q", zr.File[0].Name, rawName)
+	}
+	if !zr.File[0].NonUTF8 {
+		t.Errorf("NonUTF8 = false, want true for non-UTF-8 raw name")
+	}
+}
+
+// TestNameDecoderError verifies that an error returned by the decoder is
+// propagated from NewReaderWithOptions.
+func TestNameDecoderError(t *testing.T) {
+	var buf bytes.Buffer
+	zw := NewWriter(&buf)
+	if _, err := zw.CreateHeader(&FileHeader{Name: "file.txt", Method: Store}); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := fmt.Errorf("decode failure")
+	_, err := NewReaderWithOptions(bytes.NewReader(buf.Bytes()), int64(buf.Len()), ReaderOptions{NameDecoder: func(*FileHeader) error { return wantErr }})
+	if err != wantErr {
+		t.Errorf("NewReaderWithOptions err = %v, want %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
Closes #1142.

Adds an opt-in `NameDecoder func(*FileHeader) error` callback on `zip.Reader` that fires per entry after Name, Comment, Extra, and Flags are populated from raw bytes and before UTF-8 detection runs, matching the design in #1142 ("a callback function to receive these would be my preferred solution... can be set on the zip.Reader"). When the callback is nil, behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ZIP reader accepts an optional custom hook to rewrite entry names and comments before encoding detection.
  * If the hook returns an error, archive initialization is aborted and the error is returned.

* **Tests**
  * Added tests for custom decoding, default (no-hook) behavior, and hook error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klauspost/compress/pull/1150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->