### PR TITLE
Add `WriterPool` for zero-allocation reuse of `flate.Writer` and `gzip.Writer`

### DIFF
--- a/flate/writer_pool.go
+++ b/flate/writer_pool.go
@@ -1,0 +1,40 @@
+package flate
+
+import (
+	"io"
+	"sync"
+)
+
+// WriterPool is a pool of reusable flate.Writers.
+// Writers in the pool are reused via Reset, avoiding allocation
+// of large internal data structures like hash tables.
+type WriterPool struct {
+	pool  sync.Pool
+	level int
+}
+
+// NewWriterPool creates a new WriterPool for the given compression level.
+// level must be in the range [-2, 9] or a custom window size.
+func NewWriterPool(level int) *WriterPool {
+	return &WriterPool{level: level}
+}
+
+// Get returns a Writer from the pool, or creates a new one if the pool is empty.
+// The Writer is reset to write to w.
+func (p *WriterPool) Get(w io.Writer) *Writer {
+	v := p.pool.Get()
+	if v == nil {
+		wr, _ := NewWriter(w, p.level)
+		return wr
+	}
+	wr := v.(*Writer)
+	wr.Reset(w)
+	return wr
+}
+
+// Put returns a Writer to the pool. The Writer is closed before being returned.
+// The Writer should not be used after Put is called.
+func (p *WriterPool) Put(w *Writer) {
+	w.Close()
+	p.pool.Put(w)
+}

--- a/flate/writer_test.go
+++ b/flate/writer_test.go
@@ -506,6 +506,50 @@ func copyBuffer(dst io.Writer, src io.Reader, buf []byte) (written int64, err er
 	return written, err
 }
 
+func TestWriterPoolRoundtrip(t *testing.T) {
+	for level := HuffmanOnly; level <= BestCompression; level++ {
+		t.Run(fmt.Sprint("level-", level), func(t *testing.T) {
+			pool := NewWriterPool(level)
+			payload := []byte("Hello, World! This is a test payload.")
+			var buf bytes.Buffer
+
+			w := pool.Get(&buf)
+			n, err := w.Write(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != len(payload) {
+				t.Fatalf("short write: %d != %d", n, len(payload))
+			}
+			pool.Put(w)
+
+			r := NewReader(&buf)
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("roundtrip mismatch")
+			}
+
+			// Reuse the writer from pool
+			var buf2 bytes.Buffer
+			w2 := pool.Get(&buf2)
+			w2.Write(payload)
+			pool.Put(w2)
+
+			r2 := NewReader(&buf2)
+			got2, err := io.ReadAll(r2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got2, payload) {
+				t.Fatalf("roundtrip mismatch on reuse")
+			}
+		})
+	}
+}
+
 func BenchmarkCompressAllocations(b *testing.B) {
 	payload := []byte(strings.Repeat("Tiny payload", 20))
 	for j := -2; j <= 9; j++ {
@@ -539,6 +583,37 @@ func BenchmarkCompressAllocationsSingle(b *testing.B) {
 			}
 			w.Write(payload)
 			w.Close()
+		}
+	})
+}
+
+func BenchmarkCompressAllocationsPool(b *testing.B) {
+	payload := []byte(strings.Repeat("Tiny payload", 20))
+	for level := HuffmanOnly; level <= BestCompression; level++ {
+		b.Run("level("+strconv.Itoa(level)+")", func(b *testing.B) {
+			pool := NewWriterPool(level)
+			b.Run("pool", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					w := pool.Get(io.Discard)
+					w.Write(payload)
+					pool.Put(w)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkCompressAllocationsPoolSingle(b *testing.B) {
+	payload := []byte(strings.Repeat("Tiny payload", 20))
+	const level = 2
+	pool := NewWriterPool(level)
+	b.Run("pool", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			w := pool.Get(io.Discard)
+			w.Write(payload)
+			pool.Put(w)
 		}
 	})
 }

--- a/gzip/gzip_pool.go
+++ b/gzip/gzip_pool.go
@@ -1,0 +1,39 @@
+package gzip
+
+import (
+	"io"
+	"sync"
+)
+
+// WriterPool is a pool of reusable gzip.Writers.
+// Writers in the pool are reused via Reset, avoiding allocation
+// of large internal data structures like hash tables.
+type WriterPool struct {
+	pool  sync.Pool
+	level int
+}
+
+// NewWriterPool creates a new WriterPool for the given compression level.
+func NewWriterPool(level int) *WriterPool {
+	return &WriterPool{level: level}
+}
+
+// Get returns a Writer from the pool, or creates a new one if the pool is empty.
+// The Writer is reset to write to w.
+func (p *WriterPool) Get(w io.Writer) *Writer {
+	v := p.pool.Get()
+	if v == nil {
+		z, _ := NewWriterLevel(w, p.level)
+		return z
+	}
+	z := v.(*Writer)
+	z.Reset(w)
+	return z
+}
+
+// Put returns a Writer to the pool. The Writer is closed before being returned.
+// The Writer should not be used after Put is called.
+func (p *WriterPool) Put(z *Writer) {
+	z.Close()
+	p.pool.Put(z)
+}

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -538,6 +538,58 @@ func benchmarkGzipN(b *testing.B, level int) {
 	}
 }
 
+func TestWriterPoolRoundtrip(t *testing.T) {
+	for level := HuffmanOnly; level <= BestCompression; level++ {
+		t.Run(fmt.Sprint("level-", level), func(t *testing.T) {
+			pool := NewWriterPool(level)
+			payload := []byte("Hello, World! This is a test payload.")
+			var buf bytes.Buffer
+
+			w := pool.Get(&buf)
+			n, err := w.Write(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != len(payload) {
+				t.Fatalf("short write: %d != %d", n, len(payload))
+			}
+			pool.Put(w)
+
+			r, err := NewReader(&buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r.Close()
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("roundtrip mismatch")
+			}
+
+			// Reuse the writer from pool
+			var buf2 bytes.Buffer
+			w2 := pool.Get(&buf2)
+			w2.Write(payload)
+			pool.Put(w2)
+
+			r2, err := NewReader(&buf2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got2, err := io.ReadAll(r2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r2.Close()
+			if !bytes.Equal(got2, payload) {
+				t.Fatalf("roundtrip mismatch on reuse")
+			}
+		})
+	}
+}
+
 func BenchmarkCompressAllocations(b *testing.B) {
 	payload := []byte(strings.Repeat("Tiny payload", 20))
 	for j := -2; j <= 9; j++ {
@@ -572,6 +624,37 @@ func BenchmarkCompressAllocationsSingle(b *testing.B) {
 			}
 			w.Write(payload)
 			w.Close()
+		}
+	})
+}
+
+func BenchmarkCompressAllocationsPool(b *testing.B) {
+	payload := []byte(strings.Repeat("Tiny payload", 20))
+	for level := HuffmanOnly; level <= BestCompression; level++ {
+		b.Run("level("+strconv.Itoa(level)+")", func(b *testing.B) {
+			pool := NewWriterPool(level)
+			b.Run("pool", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					w := pool.Get(io.Discard)
+					w.Write(payload)
+					pool.Put(w)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkCompressAllocationsPoolSingle(b *testing.B) {
+	payload := []byte(strings.Repeat("Tiny payload", 20))
+	const level = 2
+	pool := NewWriterPool(level)
+	b.Run("pool", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			w := pool.Get(io.Discard)
+			w.Write(payload)
+			pool.Put(w)
 		}
 	})
 }


### PR DESCRIPTION
## Motivation

Heap profiles of applications that frequently compress data show that repeated calls to `flate.NewWriter` / `gzip.NewWriter` dominate memory usage. Each call allocates large internal hash tables (`fastEnc` structs up to ~384 KB each), which accumulate as live objects until GC runs.

For example, the Kafka client library [`github.com/twmb/franz-go`](https://github.com/twmb/franz-go) creates a new `gzip.Writer` (via `flate.NewWriter`) for every compressed Kafka message batch. Under production load with high-throughput topics, this results in thousands of concurrent compressor instances, retaining gigabytes of encoder hash tables in heap — a flamegraph showed **~2.4 GB** of live memory from `klauspost/compress` alone.

Both `flate.Writer` and `gzip.Writer` already have a `Reset()` method that reuses the internal encoder, but callers must manage the lifecycle manually — there is no pooling abstraction.

## Changes

Add `WriterPool` types to the `flate` and `gzip` packages.

### `flate` — `writer_pool.go`

```go
type WriterPool struct { ... }

func NewWriterPool(level int) *WriterPool
func (p *WriterPool) Get(w io.Writer) *Writer
func (p *WriterPool) Put(w *Writer)
```

### `gzip` — `gzip_pool.go`

```go
type WriterPool struct { ... }

func NewWriterPool(level int) *WriterPool
func (p *WriterPool) Get(w io.Writer) *Writer
func (p *WriterPool) Put(w *Writer)
```

## Usage

**Before** (new allocation per stream — retains encoder tables per writer):

```go
for _, data := range blobs {
    var buf bytes.Buffer
    w, _ := flate.NewWriter(&buf, flate.DefaultCompression)
    w.Write(data)
    w.Close()
}
```

**After** (reuses encoder tables — zero allocs per stream after warm-up):

```go
pool := flate.NewWriterPool(flate.DefaultCompression)

for _, data := range blobs {
    var buf bytes.Buffer
    w := pool.Get(&buf)
    w.Write(data)
    pool.Put(w)
}
```

Same pattern for `gzip.WriterPool`.

## Benchmarks

Benchmarked on `AMD Ryzen 7 5700U` with a ~260 byte payload (`"Tiny payload"` repeated 20 times).

### `flate`

| Level               | `NewWriter` B/op | `NewWriter` allocs/op | Pool B/op | Pool allocs/op |
| ------------------- | ---------------- | --------------------- | --------- | -------------- |
| -2 (Huffman)        | 313,986          | 11                    | 1         | **0**          |
| -1 (Default)        | 1,075,846        | 13                    | 0         | **0**          |
| 0 (NoCompression)   | 346,754          | 11                    | 0         | **0**          |
| 1 (BestSpeed)       | 813,702          | 13                    | 0         | **0**          |
| 2                   | 1,206,920        | 13                    | 3         | **0**          |
| 3                   | 1,206,917        | 13                    | 3         | **0**          |
| 4                   | 944,772          | 13                    | 2         | **0**          |
| 5                   | 1,075,845        | 13                    | 0         | **0**          |
| 6                   | 1,075,844        | 13                    | 3         | **0**          |
| 7                   | 1,010,307        | 12                    | 0         | **0**          |
| 8                   | 1,010,307        | 12                    | 14        | **0**          |
| 9 (BestCompression) | 1,142,660        | 14                    | 16        | **0**          |

### `gzip`

| Level               | `NewWriterLevel` B/op | `NewWriterLevel` allocs/op | Pool B/op | Pool allocs/op |
| ------------------- | --------------------- | -------------------------- | --------- | -------------- |
| -2 (Huffman)        | 314,146               | 12                         | 0         | **0**          |
| -1 (Default)        | 1,076,007             | 14                         | 3         | **0**          |
| 0 (NoCompression)   | 346,914               | 12                         | 0         | **0**          |
| 1 (BestSpeed)       | 813,862               | 14                         | 2         | **0**          |
| 2                   | 1,207,079             | 14                         | 10        | **0**          |
| 3                   | 1,207,076             | 14                         | 3         | **0**          |
| 4                   | 944,931               | 14                         | 2         | **0**          |
| 5                   | 1,076,004             | 14                         | 6         | **0**          |
| 6                   | 1,076,004             | 14                         | 3         | **0**          |
| 7                   | 1,010,468             | 13                         | 18        | **0**          |
| 8                   | 1,010,469             | 13                         | 15        | **0**          |
| 9 (BestCompression) | 1,142,818             | 15                         | 17        | **0**          |

The pool eliminates per-operation allocations entirely (**0 allocs/op**), which in long-running servers translates to zero GC pressure from compressor allocations.

## Tests

- `TestWriterPoolRoundtrip` — roundtrip test across all levels with reuse verification (both `flate` and `gzip`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WriterPool abstraction for flate and gzip compression packages, enabling efficient reuse of writer instances to reduce memory allocations during compression operations.

* **Tests**
  * Added comprehensive roundtrip validation tests for writer pool functionality across multiple compression levels.
  * Added allocation benchmarks measuring compression performance improvements with pooled writers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klauspost/compress/pull/1153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->