### PR TITLE
flate: Add inflate checkpoints

### DIFF
--- a/flate/dict_decoder.go
+++ b/flate/dict_decoder.go
@@ -28,9 +28,10 @@ type dictDecoder struct {
 	hist []byte // Sliding window history
 
 	// Invariant: 0 <= rdPos <= wrPos <= len(hist)
-	wrPos int  // Current output position in buffer
-	rdPos int  // Have emitted hist[:rdPos] already
-	full  bool // Has a full window length been written yet?
+	wrPos   int   // Current output position in buffer
+	rdPos   int   // Have emitted hist[:rdPos] already
+	flushed int64 // Total bytes returned by readFlush since init
+	full    bool  // Has a full window length been written yet?
 }
 
 // init initializes dictDecoder to have a sliding window dictionary of the given
@@ -167,15 +168,32 @@ loop:
 	return dstPos - dstBase
 }
 
+// appendWindow appends the current sliding window (up to len(hist) most recent
+// bytes, oldest first) to dst.
+func (dd *dictDecoder) appendWindow(dst []byte) []byte {
+	if dd.full {
+		dst = append(dst, dd.hist[dd.wrPos:]...)
+		return append(dst, dd.hist[:dd.wrPos]...)
+	}
+	return append(dst, dd.hist[:dd.wrPos]...)
+}
+
 // readFlush returns a slice of the historical buffer that is ready to be
 // emitted to the user. The data returned by readFlush must be fully consumed
 // before calling any other dictDecoder methods.
 func (dd *dictDecoder) readFlush() []byte {
 	toRead := dd.hist[dd.rdPos:dd.wrPos]
+	dd.flushed += int64(len(toRead))
 	dd.rdPos = dd.wrPos
 	if dd.wrPos == len(dd.hist) {
 		dd.wrPos, dd.rdPos = 0, 0
 		dd.full = true
 	}
 	return toRead
+}
+
+// decoded reports the total number of bytes written into the dictionary since
+// init (i.e. excluding any preset dict bytes).
+func (dd *dictDecoder) decoded() int64 {
+	return dd.flushed + int64(dd.wrPos-dd.rdPos)
 }

--- a/flate/inflate.go
+++ b/flate/inflate.go
@@ -342,6 +342,11 @@ type decompressor struct {
 	final bool
 
 	flushMode flushMode
+	cb        func(InflateCheckpoint)
+	cp        InflateCheckpoint
+	hasCP     bool  // WithResumeFrom was supplied
+	uncOffset int64 // baseline uncompressed offset (from a resume checkpoint)
+	cpBuf     []byte
 }
 
 func (f *decompressor) nextBlock() {
@@ -676,6 +681,18 @@ func (f *decompressor) finishBlock() {
 		f.toRead = f.dict.readFlush()
 	}
 
+	if f.cb != nil {
+		bitPos := f.roffset*8 - int64(f.nb)
+		f.cpBuf = f.dict.appendWindow(f.cpBuf[:0])
+		f.cb(InflateCheckpoint{
+			UncompressedOffset: f.uncOffset + f.dict.decoded(),
+			CompressedOffset:   bitPos / 8,
+			Final:              f.final,
+			BitOffset:          uint8(bitPos & 7),
+			Window:             f.cpBuf,
+		})
+	}
+
 	f.step = nextBlock
 }
 
@@ -806,6 +823,45 @@ func (f *decompressor) Reset(r io.Reader, dict []byte) error {
 	return nil
 }
 
+// ResetCP will adjust the input to the provided checkpoint.
+// It is assumed the input stream is forwarded to cp.CompressedOffset.
+func (f *decompressor) ResetCP(r io.Reader, cp InflateCheckpoint) error {
+	*f = decompressor{
+		r:        makeReader(r),
+		bits:     f.bits,
+		codebits: f.codebits,
+		h1:       f.h1,
+		h2:       f.h2,
+		dict:     f.dict,
+		step:     nextBlock,
+		cpBuf:    f.cpBuf,
+	}
+	return f.applyCP(cp)
+}
+
+// applyCP seeds the decompressor state from a resume checkpoint:
+// loads the sliding window, sets the absolute compressed/uncompressed
+// offsets, and skips cp.BitOffset bits into the first input byte so
+// the next decode aligns with the start of a deflate block.
+func (f *decompressor) applyCP(cp InflateCheckpoint) error {
+	f.dict.init(maxMatchOffset, cp.Window)
+	f.roffset = cp.CompressedOffset
+	f.uncOffset = cp.UncompressedOffset
+	f.final = cp.Final
+	f.b = 0
+	f.nb = 0
+	if cp.BitOffset > 0 {
+		c, err := f.r.ReadByte()
+		if err != nil {
+			return noEOF(err)
+		}
+		f.roffset++
+		f.b = uint32(c) >> cp.BitOffset
+		f.nb = 8 - uint(cp.BitOffset)
+	}
+	return nil
+}
+
 type ReaderOpt func(*decompressor)
 
 // WithPartialBlock tells decompressor to return after each block,
@@ -823,6 +879,36 @@ func WithDict(dict []byte) ReaderOpt {
 	}
 }
 
+// InflateCheckpoint provides a resumable checkpoint for inflate.
+type InflateCheckpoint struct {
+	UncompressedOffset int64  // Byte offset in the decompressed stream
+	CompressedOffset   int64  // Byte offset in the compressed stream
+	Final              bool   // True if this is the final block
+	BitOffset          uint8  // 0-7 bits
+	Window             []byte // 32KB sliding window dictionary
+}
+
+// WithEobCallback will call the provided function after each block
+// with the current gzip checkpoint.
+// After returning the provided window can no longer be referenced.
+// The callback will not be triggered after a block is marked "final".
+// The callback is not retained after Reset.
+func WithEobCallback(cb func(InflateCheckpoint)) ReaderOpt {
+	return func(f *decompressor) {
+		f.cb = cb
+	}
+}
+
+// WithResumeFrom will adjust the input to the provided checkpoint.
+// It is assumed the input stream is forwarded to the provided offset.
+// The checkpoint is removed when Reset is called.
+func WithResumeFrom(cp InflateCheckpoint) ReaderOpt {
+	return func(f *decompressor) {
+		f.cp = cp
+		f.hasCP = true
+	}
+}
+
 // NewReaderOpts returns new reader with provided options
 func NewReaderOpts(r io.Reader, opts ...ReaderOpt) io.ReadCloser {
 	fixedHuffmanDecoderInit()
@@ -836,6 +922,12 @@ func NewReaderOpts(r io.Reader, opts ...ReaderOpt) io.ReadCloser {
 
 	for _, opt := range opts {
 		opt(&f)
+	}
+
+	if f.hasCP {
+		if err := f.applyCP(f.cp); err != nil {
+			f.err = err
+		}
 	}
 
 	return &f

--- a/flate/inflate_test.go
+++ b/flate/inflate_test.go
@@ -281,6 +281,154 @@ func TestWriteTo(t *testing.T) {
 	}
 }
 
+func TestInflateCheckpointResume(t *testing.T) {
+	// Compress a moderately large, varied input so the deflate writer emits
+	// multiple blocks. Most boundaries land on non-byte-aligned bit positions,
+	// which exercises BitOffset on resume.
+	raw := make([]byte, 0, 256<<10)
+	for range 4000 {
+		raw = append(raw, "the quick brown fox jumps over the lazy dog "...)
+		raw = append(raw, "Lorem ipsum dolor sit amet, consectetur "...)
+	}
+
+	var compressed bytes.Buffer
+	w, err := NewWriter(&compressed, DefaultCompression)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	type cpRec struct {
+		cp     InflateCheckpoint
+		window []byte
+	}
+	var cps []cpRec
+	var seenFinal bool
+	cb := func(cp InflateCheckpoint) {
+		if cp.Final {
+			if seenFinal {
+				t.Fatalf("final callback called twice")
+			}
+			seenFinal = true
+			return
+		}
+		// Window is reused between callbacks, copy it.
+		cps = append(cps, cpRec{cp: cp, window: append([]byte(nil), cp.Window...)})
+	}
+
+	r := NewReaderOpts(bytes.NewReader(compressed.Bytes()), WithEobCallback(cb))
+	decoded, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !bytes.Equal(decoded, raw) {
+		t.Fatalf("decoded mismatch: %d vs %d", len(decoded), len(raw))
+	}
+	if len(cps) < 2 {
+		t.Fatalf("expected multiple non-final block callbacks, got %d", len(cps))
+	}
+	t.Logf("got %d block(s)", len(cps))
+
+	// Offsets must be monotonically non-decreasing.
+	for i := 1; i < len(cps); i++ {
+		prev, cur := cps[i-1].cp, cps[i].cp
+		if cur.UncompressedOffset < prev.UncompressedOffset {
+			t.Errorf("UncompressedOffset regressed at %d: %d -> %d", i, prev.UncompressedOffset, cur.UncompressedOffset)
+		}
+		pbits := prev.CompressedOffset*8 + int64(prev.BitOffset)
+		cbits := cur.CompressedOffset*8 + int64(cur.BitOffset)
+		if cbits < pbits {
+			t.Errorf("CompressedOffset regressed at %d: %d -> %d", i, pbits, cbits)
+		}
+	}
+
+	// Resume from every checkpoint (the final block no longer triggers cb).
+	sawBitOffset := false
+	for i, rec := range cps {
+		cp := rec.cp
+		cp.Window = rec.window
+		if cp.BitOffset != 0 {
+			sawBitOffset = true
+		}
+		src := compressed.Bytes()[cp.CompressedOffset:]
+		rr := NewReaderOpts(bytes.NewReader(src), WithResumeFrom(cp))
+		got, err := io.ReadAll(rr)
+		if err != nil {
+			t.Errorf("resume %d (CompOff=%d BitOff=%d): %v", i, cp.CompressedOffset, cp.BitOffset, err)
+			continue
+		}
+		want := raw[cp.UncompressedOffset:]
+		if !bytes.Equal(got, want) {
+			t.Errorf("resume %d: output mismatch (%d vs %d bytes)", i, len(got), len(want))
+		}
+	}
+	if !sawBitOffset {
+		t.Errorf("no non-zero BitOffset checkpoints — BitOffset resume path not exercised")
+	}
+}
+
+func TestInflateCheckpointResetCP(t *testing.T) {
+	// Verify ResetCP applies a checkpoint to an existing reader.
+	var raw []byte
+	for range 4000 {
+		raw = append(raw, "the quick brown fox jumps over the lazy dog "...)
+		raw = append(raw, "Lorem ipsum dolor sit amet, consectetur "...)
+	}
+
+	var compressed bytes.Buffer
+	w, err := NewWriter(&compressed, DefaultCompression)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write(raw)
+	w.Close()
+
+	var cps []InflateCheckpoint
+	var seenFinal bool
+	cb := func(cp InflateCheckpoint) {
+		if cp.Final {
+			if seenFinal {
+				t.Fatalf("final callback called twice")
+			}
+			seenFinal = true
+			return
+		}
+		cp.Window = append([]byte(nil), cp.Window...)
+		cps = append(cps, cp)
+	}
+	r := NewReaderOpts(bytes.NewReader(compressed.Bytes()), WithEobCallback(cb))
+	if _, err := io.ReadAll(r); err != nil {
+		t.Fatal(err)
+	}
+	if len(cps) < 2 {
+		t.Skipf("only %d block(s); need at least 2 for ResetCP test", len(cps))
+	}
+	t.Logf("ResetCP test with %d block(s)", len(cps))
+
+	cp := cps[len(cps)-1]
+	dec, ok := NewReader(nil).(interface {
+		ResetCP(io.Reader, InflateCheckpoint) error
+	})
+	if !ok {
+		t.Fatal("reader does not implement ResetCP")
+	}
+	if err := dec.ResetCP(bytes.NewReader(compressed.Bytes()[cp.CompressedOffset:]), cp); err != nil {
+		t.Fatalf("ResetCP: %v", err)
+	}
+	got, err := io.ReadAll(dec.(io.Reader))
+	if err != nil {
+		t.Fatalf("read after ResetCP: %v", err)
+	}
+	if want := raw[cp.UncompressedOffset:]; !bytes.Equal(got, want) {
+		t.Fatalf("ResetCP output mismatch (%d vs %d bytes)", len(got), len(want))
+	}
+}
+
 func TestReaderPartialBlock(t *testing.T) {
 	data, err := os.ReadFile("testdata/partial-block")
 	if err != nil {


### PR DESCRIPTION
Allows adding an inflate end-of-block callback with checkpoint information. Callback is cleared on Reset and cannot be re-applied to an existing Reader.

For resuming either use `WithResumeFrom` or assert the `ResetCP(io.Reader, flate.InflateCheckpoint) error` interface. The input stream should be forwarded to the compressed offset.

ref: #1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable decompression with block-level checkpointing. Decompression can now pause at non-final block boundaries and resume from saved checkpoints, providing fine-grained control over streaming workflows. End-of-block callbacks enable progress tracking by reporting current decompression state and byte offsets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klauspost/compress/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->