### PR TITLE
huff0: Allow building tables from histogram.

### DIFF
--- a/huff0/build_table.go
+++ b/huff0/build_table.go
@@ -1,0 +1,133 @@
+package huff0
+
+import "errors"
+
+// BuildCTable builds a Huffman compression table from a precomputed symbol
+// histogram and installs it as the previous (reuse) table on s.
+//
+// After this call:
+//   - EstimateSize/CanUseTable can probe the table against other histograms.
+//   - Compress1X/Compress4X with Reuse = ReusePolicyMust will encode without
+//     emitting a new table header.
+//   - TransferCTable can hand the table to a sibling Scratch.
+//
+// count[i] is the number of occurrences of symbol i. The histogram must have
+// at least 2 distinct non-zero symbols; ErrUseRLE is returned for a single
+// symbol and an error is returned for an empty histogram.
+func (s *Scratch) BuildCTable(count *[256]uint32) error {
+	if s == nil {
+		return errors.New("huff0: BuildCTable on nil Scratch")
+	}
+	var err error
+	s, err = s.prepare(nil)
+	if err != nil {
+		return err
+	}
+	s.count = *count
+	var total, maxCount int
+	var symLen uint16
+	for i, v := range s.count {
+		total += int(v)
+		if int(v) > maxCount {
+			maxCount = int(v)
+		}
+		if v != 0 {
+			symLen = uint16(i) + 1
+		}
+	}
+	if total == 0 {
+		return errors.New("huff0: empty histogram")
+	}
+	if symLen < 2 || maxCount == total {
+		return ErrUseRLE
+	}
+	s.symbolLen = symLen
+	s.maxCount = maxCount
+	s.srcLen = total
+	if err := s.buildCTable(); err != nil {
+		return err
+	}
+	if cap(s.prevTable) < len(s.cTable) {
+		s.prevTable = make(cTable, 0, maxSymbolValue+1)
+	}
+	s.prevTable = s.prevTable[:len(s.cTable)]
+	copy(s.prevTable, s.cTable)
+	s.prevTableLog = s.actualTableLog
+	// Force the next Compress* to recount from real input.
+	s.clearCount = true
+	s.maxCount = 0
+	return nil
+}
+
+// EstimateSize returns an estimated compressed payload size in bytes for the
+// supplied histogram using the table currently stored in prevTable. It returns
+// -1 when the table cannot encode every non-zero symbol of hist (i.e. when
+// CanUseTable would return false). The estimate excludes the table header.
+func (s *Scratch) EstimateSize(hist *[256]uint32) int {
+	if s == nil || len(s.prevTable) == 0 {
+		return -1
+	}
+	pt := s.prevTable
+	nbBits := uint32(7)
+	for i, v := range hist {
+		if v == 0 {
+			continue
+		}
+		if i >= len(pt) || pt[i].nBits == 0 {
+			return -1
+		}
+		nbBits += uint32(pt[i].nBits) * v
+	}
+	return int(nbBits >> 3)
+}
+
+// CanUseTable reports whether the table in prevTable can encode every
+// non-zero symbol present in hist.
+func (s *Scratch) CanUseTable(hist *[256]uint32) bool {
+	if s == nil || len(s.prevTable) == 0 {
+		return false
+	}
+	pt := s.prevTable
+	for i, v := range hist {
+		if v == 0 {
+			continue
+		}
+		if i >= len(pt) || pt[i].nBits == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// AppendTable serializes the table currently stored in prevTable (e.g. as
+// installed by BuildCTable or carried over from a previous Compress call)
+// into a self-delimiting zstd-style header and appends it to dst. The
+// returned slice can be parsed back by ReadTable.
+func (s *Scratch) AppendTable(dst []byte) ([]byte, error) {
+	if s == nil || len(s.prevTable) == 0 {
+		return dst, errors.New("huff0: AppendTable with empty table")
+	}
+	// cTable.write reads s.actualTableLog, s.symbolLen, s.huffWeight, s.fse
+	// and writes into s.Out. Save/restore Out so we don't disturb in-flight
+	// compression buffers.
+	saveOut := s.Out
+	saveTL := s.actualTableLog
+	saveSL := s.symbolLen
+	if s.fse == nil {
+		// Lazily init in case AppendTable is called on a fresh Scratch.
+		if _, err := s.prepare(nil); err != nil {
+			return dst, err
+		}
+		saveOut = s.Out
+	}
+	s.Out = s.Out[:0]
+	s.actualTableLog = s.prevTableLog
+	s.symbolLen = uint16(len(s.prevTable))
+	if err := s.prevTable.write(s); err != nil {
+		s.Out, s.actualTableLog, s.symbolLen = saveOut, saveTL, saveSL
+		return dst, err
+	}
+	dst = append(dst, s.Out...)
+	s.Out, s.actualTableLog, s.symbolLen = saveOut, saveTL, saveSL
+	return dst, nil
+}

--- a/huff0/build_table.go
+++ b/huff0/build_table.go
@@ -18,6 +18,9 @@ func (s *Scratch) BuildCTable(count *[256]uint32) error {
 	if s == nil {
 		return errors.New("huff0: BuildCTable on nil Scratch")
 	}
+	if count == nil {
+		return errors.New("huff0: nil count passed to BuildCTable")
+	}
 	var err error
 	s, err = s.prepare(nil)
 	if err != nil {
@@ -64,7 +67,7 @@ func (s *Scratch) BuildCTable(count *[256]uint32) error {
 // -1 when the table cannot encode every non-zero symbol of hist (i.e. when
 // CanUseTable would return false). The estimate excludes the table header.
 func (s *Scratch) EstimateSize(hist *[256]uint32) int {
-	if s == nil || len(s.prevTable) == 0 {
+	if s == nil || hist == nil || len(s.prevTable) == 0 {
 		return -1
 	}
 	pt := s.prevTable
@@ -84,7 +87,7 @@ func (s *Scratch) EstimateSize(hist *[256]uint32) int {
 // CanUseTable reports whether the table in prevTable can encode every
 // non-zero symbol present in hist.
 func (s *Scratch) CanUseTable(hist *[256]uint32) bool {
-	if s == nil || len(s.prevTable) == 0 {
+	if s == nil || hist == nil || len(s.prevTable) == 0 {
 		return false
 	}
 	pt := s.prevTable

--- a/huff0/build_table_test.go
+++ b/huff0/build_table_test.go
@@ -36,6 +36,38 @@ func TestBuildCTableEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildCTableNilCount(t *testing.T) {
+	var s Scratch
+	if err := s.BuildCTable(nil); err == nil {
+		t.Fatalf("expected error for nil count")
+	}
+}
+
+func TestEstimateSizeAndCanUseTableNilHist(t *testing.T) {
+	var count [256]uint32
+	count['a'] = 10
+	count['b'] = 5
+	var s Scratch
+	if err := s.BuildCTable(&count); err != nil {
+		t.Fatalf("BuildCTable: %v", err)
+	}
+	if got := s.EstimateSize(nil); got != -1 {
+		t.Fatalf("EstimateSize(nil) = %d, want -1", got)
+	}
+	if s.CanUseTable(nil) {
+		t.Fatalf("CanUseTable(nil) = true, want false")
+	}
+	// Also exercise the nil-receiver and unloaded-table paths so the guards
+	// behave even before BuildCTable has installed prevTable.
+	var empty Scratch
+	if got := empty.EstimateSize(&count); got != -1 {
+		t.Fatalf("EstimateSize on empty Scratch = %d, want -1", got)
+	}
+	if empty.CanUseTable(&count) {
+		t.Fatalf("CanUseTable on empty Scratch = true, want false")
+	}
+}
+
 func TestBuildCTableSingleSymbol(t *testing.T) {
 	var count [256]uint32
 	count[42] = 100

--- a/huff0/build_table_test.go
+++ b/huff0/build_table_test.go
@@ -1,0 +1,227 @@
+package huff0
+
+import (
+	"bytes"
+	"errors"
+	"math/rand"
+	"testing"
+)
+
+func TestBuildCTableSimple(t *testing.T) {
+	var count [256]uint32
+	count['a'] = 60
+	count['b'] = 30
+	count['c'] = 10
+	var s Scratch
+	if err := s.BuildCTable(&count); err != nil {
+		t.Fatalf("BuildCTable: %v", err)
+	}
+	if len(s.prevTable) < 4 {
+		t.Fatalf("prevTable too short: %d", len(s.prevTable))
+	}
+	if s.prevTable['a'].nBits == 0 || s.prevTable['b'].nBits == 0 || s.prevTable['c'].nBits == 0 {
+		t.Fatalf("expected non-zero nBits for active symbols")
+	}
+	// Symbols below the active set are zero in the trimmed prevTable.
+	if s.prevTable[0].nBits != 0 {
+		t.Fatalf("expected zero nBits for unused symbol 0")
+	}
+}
+
+func TestBuildCTableEmpty(t *testing.T) {
+	var count [256]uint32
+	var s Scratch
+	if err := s.BuildCTable(&count); err == nil {
+		t.Fatalf("expected error for empty histogram")
+	}
+}
+
+func TestBuildCTableSingleSymbol(t *testing.T) {
+	var count [256]uint32
+	count[42] = 100
+	var s Scratch
+	if err := s.BuildCTable(&count); !errors.Is(err, ErrUseRLE) {
+		t.Fatalf("expected ErrUseRLE, got %v", err)
+	}
+}
+
+func TestBuildCTableEstimateAndCanUse(t *testing.T) {
+	var count [256]uint32
+	for i := range 32 {
+		count[i] = uint32(32 - i) // skewed
+	}
+	var s Scratch
+	if err := s.BuildCTable(&count); err != nil {
+		t.Fatalf("BuildCTable: %v", err)
+	}
+	if !s.CanUseTable(&count) {
+		t.Fatalf("CanUseTable: expected true for source histogram")
+	}
+	size := s.EstimateSize(&count)
+	if size <= 0 {
+		t.Fatalf("EstimateSize: expected positive, got %d", size)
+	}
+	var foreign [256]uint32
+	foreign[200] = 10 // not in original
+	if s.CanUseTable(&foreign) {
+		t.Fatalf("CanUseTable: expected false for foreign histogram")
+	}
+	if s.EstimateSize(&foreign) >= 0 {
+		t.Fatalf("EstimateSize: expected -1 for foreign histogram")
+	}
+}
+
+// TestBuildCTableRoundtrip builds a table from a histogram, then encodes data
+// with that prebuilt table (ReusePolicyMust) and verifies the decoder
+// reconstructs the input via the standard table-in-stream format.
+func TestBuildCTableRoundtrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	// Generate skewed input bytes (so compression yields meaningful tables).
+	input := make([]byte, 16<<10)
+	for i := range input {
+		// 80% zero, 20% in [1,9]
+		if rng.Intn(5) == 0 {
+			input[i] = byte(1 + rng.Intn(9))
+		}
+	}
+	var count [256]uint32
+	for _, b := range input {
+		count[b]++
+	}
+
+	var src Scratch
+	if err := src.BuildCTable(&count); err != nil {
+		t.Fatalf("BuildCTable: %v", err)
+	}
+
+	// Hand-off the prebuilt table to the encoder via prevTable + ReusePolicyMust.
+	var enc Scratch
+	enc.TransferCTable(&src)
+	enc.Reuse = ReusePolicyMust
+
+	out, reused, err := Compress4X(input, &enc)
+	if err != nil {
+		t.Fatalf("Compress4X: %v", err)
+	}
+	if !reused {
+		t.Fatalf("expected table reuse")
+	}
+	if len(enc.OutTable) != 0 {
+		t.Fatalf("expected no table emitted on reuse, got %d bytes", len(enc.OutTable))
+	}
+
+	// To verify decompression we have to ship the table to the decoder.
+	// Encode once more without ReusePolicy to obtain the serialized table,
+	// then concatenate that header with the reuse-only data above to mimic
+	// a stream that starts with the table.
+	var noReuse Scratch
+	noReuse.Reuse = ReusePolicyNone
+	if _, _, err := Compress4X(input, &noReuse); err != nil {
+		t.Fatalf("Compress4X (no reuse): %v", err)
+	}
+	if len(noReuse.OutTable) == 0 {
+		t.Fatalf("expected non-empty OutTable on non-reuse")
+	}
+
+	// Read a decoder-side scratch from the table header.
+	var dec Scratch
+	dec.MaxDecodedSize = len(input)
+	dec2, rem, err := ReadTable(noReuse.OutTable, &dec)
+	if err != nil {
+		t.Fatalf("ReadTable: %v", err)
+	}
+	if len(rem) != 0 {
+		t.Fatalf("expected no remainder, got %d", len(rem))
+	}
+
+	got, err := dec2.Decompress4X(out, len(input))
+	if err != nil {
+		t.Fatalf("Decompress4X: %v", err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("roundtrip mismatch: got len=%d want len=%d", len(got), len(input))
+	}
+}
+
+// TestAppendTableRoundtrip verifies AppendTable produces a header that
+// ReadTable can parse, restoring an equivalent table.
+func TestAppendTableRoundtrip(t *testing.T) {
+	var count [256]uint32
+	rng := rand.New(rand.NewSource(99))
+	for i := range 64 {
+		count[i] = uint32(1 + rng.Intn(1000))
+	}
+	var src Scratch
+	if err := src.BuildCTable(&count); err != nil {
+		t.Fatalf("BuildCTable: %v", err)
+	}
+	hdr, err := src.AppendTable(nil)
+	if err != nil {
+		t.Fatalf("AppendTable: %v", err)
+	}
+	if len(hdr) == 0 {
+		t.Fatalf("AppendTable produced empty header")
+	}
+	var dst Scratch
+	_, rem, err := ReadTable(hdr, &dst)
+	if err != nil {
+		t.Fatalf("ReadTable: %v", err)
+	}
+	if len(rem) != 0 {
+		t.Fatalf("expected no remainder, got %d bytes", len(rem))
+	}
+	if dst.prevTableLog != src.prevTableLog {
+		t.Fatalf("prevTableLog mismatch: src=%d dst=%d", src.prevTableLog, dst.prevTableLog)
+	}
+	for i := range count {
+		if count[i] == 0 {
+			continue
+		}
+		if i >= len(dst.prevTable) || dst.prevTable[i].nBits == 0 {
+			t.Fatalf("missing symbol %d in roundtripped table", i)
+		}
+	}
+}
+
+// TestBuildCTableMatchesCompress verifies that BuildCTable followed by reuse
+// produces output identical to the table embedded by a regular Compress4X
+// call on the same input (modulo the table header).
+func TestBuildCTableMatchesCompress(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	input := make([]byte, 8<<10)
+	for i := range input {
+		input[i] = byte(rng.Intn(16))
+	}
+	var ref Scratch
+	ref.Reuse = ReusePolicyNone
+	refOut, refReused, err := Compress4X(input, &ref)
+	if err != nil {
+		t.Fatalf("ref Compress4X: %v", err)
+	}
+	if refReused {
+		t.Fatalf("ref should not reuse")
+	}
+	refData := refOut[len(ref.OutTable):]
+
+	var count [256]uint32
+	for _, b := range input {
+		count[b]++
+	}
+	var built Scratch
+	if err := built.BuildCTable(&count); err != nil {
+		t.Fatalf("BuildCTable: %v", err)
+	}
+	var enc Scratch
+	enc.TransferCTable(&built)
+	enc.Reuse = ReusePolicyMust
+	out, reused, err := Compress4X(input, &enc)
+	if err != nil {
+		t.Fatalf("Compress4X: %v", err)
+	}
+	if !reused {
+		t.Fatalf("expected reuse")
+	}
+	if !bytes.Equal(out, refData) {
+		t.Fatalf("compressed payload mismatch: built=%d ref=%d", len(out), len(refData))
+	}
+}


### PR DESCRIPTION
Add interface to build tables from the histograms themselves.

Adds direct method to export the current table and helpers for size reuse (also via histograms).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build Huffman compression tables from symbol frequency data
  * Estimate compressed size and validate table compatibility with input histograms
  * Serialize and append compression tables for reuse and transfer between encoder/decoder

* **Tests**
  * Comprehensive tests covering table building, error cases, estimation/eligibility, serialization roundtrips, and end-to-end compression/decompression workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klauspost/compress/pull/1155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->