### PR TITLE
huff0: Allow building table from oversized histogram.

### DIFF
--- a/huff0/build_table.go
+++ b/huff0/build_table.go
@@ -44,6 +44,38 @@ func (s *Scratch) BuildCTable(count *[256]uint32) error {
 	if symLen < 2 || maxCount == total {
 		return ErrUseRLE
 	}
+	// huff0's internal rank table assumes total ≤ BlockSizeMax (it uses
+	// highBit32(count+1) + 1 as a rank index into a fixed-size array).
+	// Histograms summed across multiple blocks can exceed that; scale the
+	// counts down preserving the distribution. Non-zero entries round up so
+	// rare symbols stay representable.
+	if total > BlockSizeMax {
+		shift := uint(0)
+		for total>>shift > BlockSizeMax {
+			shift++
+		}
+		round := uint32(1<<shift) - 1
+		var newTotal, newMax int
+		for i, v := range s.count {
+			if v == 0 {
+				continue
+			}
+			scaled := (v + round) >> shift
+			if scaled == 0 {
+				scaled = 1
+			}
+			s.count[i] = scaled
+			newTotal += int(scaled)
+			if int(scaled) > newMax {
+				newMax = int(scaled)
+			}
+		}
+		total = newTotal
+		maxCount = newMax
+		if maxCount == total {
+			return ErrUseRLE
+		}
+	}
 	s.symbolLen = symLen
 	s.maxCount = maxCount
 	s.srcLen = total

--- a/huff0/build_table_test.go
+++ b/huff0/build_table_test.go
@@ -36,6 +36,37 @@ func TestBuildCTableEmpty(t *testing.T) {
 	}
 }
 
+// TestBuildCTableOversizedTotal exercises histograms that sum to more than
+// huff0's internal BlockSizeMax — the case that arises when summing the
+// per-block histograms of a multi-block bitmap. Without scaling, huffSort
+// places nodes at out-of-range rank indices and buildCTable panics on a
+// negative index.
+func TestBuildCTableOversizedTotal(t *testing.T) {
+	var count [256]uint32
+	// 4 MB of one dominant symbol, plus a handful of rare singletons.
+	count[0] = 4 << 20
+	count[1] = 2
+	count[2] = 1
+	count[128] = 1
+	count[255] = 3
+	var s Scratch
+	if err := s.BuildCTable(&count); err != nil {
+		t.Fatalf("BuildCTable: %v", err)
+	}
+	if len(s.prevTable) == 0 {
+		t.Fatalf("prevTable not installed")
+	}
+	// Every originally non-zero symbol must be representable.
+	for i, v := range count {
+		if v == 0 {
+			continue
+		}
+		if i >= len(s.prevTable) || s.prevTable[i].nBits == 0 {
+			t.Fatalf("symbol %d lost during scaling", i)
+		}
+	}
+}
+
 func TestBuildCTableNilCount(t *testing.T) {
 	var s Scratch
 	if err := s.BuildCTable(nil); err == nil {


### PR DESCRIPTION
A histogram of a block larger than max block size could cause huff0 to panic. Scale table down on BuildCTable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized data histograms in Huffman table construction. The system now rescales histograms exceeding size limits while maintaining relative data distribution, ensuring stable table generation.

* **Tests**
  * Added test coverage for oversized histogram processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klauspost/compress/pull/1156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->