### PR TITLE
flate: fix buffer formatting in tests

### DIFF
--- a/flate/inflate_test.go
+++ b/flate/inflate_test.go
@@ -37,7 +37,7 @@ func TestReset(t *testing.T) {
 
 	for i, s := range ss {
 		if s != inflated[i].String() {
-			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i], s)
+			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i].String(), s)
 		}
 	}
 }
@@ -94,7 +94,7 @@ func TestResetDict(t *testing.T) {
 
 	for i, s := range ss {
 		if s != inflated[i].String() {
-			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i], s)
+			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i].String(), s)
 		}
 	}
 }


### PR DESCRIPTION
Fix two test diagnostics that pass bytes.Buffer values to %q. Current Go vet reports these as invalid format strings.

The tests already compare inflated[i].String(), so the diagnostic now formats the same string value.

Tested:
- go test ./flate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test failure messages to show the decompressed text value more clearly when comparisons fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->