### PR TITLE
flate: use `Peek` instead of `ReadByte` for the `bufio.Reader` decode path

### DIFF
--- a/flate/_gen/gen_inflate.go
+++ b/flate/_gen/gen_inflate.go
@@ -297,8 +297,7 @@ func peekBufio(fr *bufio.Reader) ([]byte, error) {
 		getS: `c, err := fr.ReadByte()
 if err != nil {
 f.b, f.nb = fb, fnb`,
-		getE: `
-return
+		getE: `return
 }`,
 	}
 	peek := readImpl{
@@ -310,8 +309,7 @@ pbuf, err = peekBufio(fr)
 pos = 0
 if len(pbuf) == 0 {
 f.b, f.nb = fb, fnb`,
-		getE: `
-return
+		getE: `return
 }
 }
 c := pbuf[pos]

--- a/flate/_gen/gen_inflate.go
+++ b/flate/_gen/gen_inflate.go
@@ -49,7 +49,7 @@ func (f *decompressor) $FUNCNAME$() {
 	// but is smart enough to keep local variables in registers, so use nb and b,
 	// inline call to moreBits and reassign b,nb back to f on return.
 	fnb, fb, dict := f.nb, f.b, &f.dict
-
+$PEEKTOP$
 	switch f.stepState {
 	case stateInit:
 		goto readLiteral
@@ -70,12 +70,9 @@ readLiteral:
 			n := uint(f.hl.maxRead)
 			for {
 				for fnb < n {
-					c, err := fr.ReadByte()
-					if err != nil {
-						f.b, f.nb = fb, fnb
+					$GETBYTE_S$
 						f.err = noEOF(err)
-						return
-					}
+$GETBYTE_E$
 					f.roffset++
 					fb |= uint32(c) << (fnb & regSizeMaskUint32)
 					fnb += 8
@@ -88,7 +85,7 @@ readLiteral:
 				}
 				if n <= fnb {
 					if n == 0 {
-						f.b, f.nb = fb, fnb
+$DISCARD$						f.b, f.nb = fb, fnb
 						if debugDecode {
 							fmt.Println("huffsym: n==0")
 						}
@@ -108,7 +105,7 @@ readLiteral:
 		case v < 256:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
-				f.toRead = dict.readFlush()
+$DISCARD$				f.toRead = dict.readFlush()
 				f.step = $FUNCNAME$
 				f.stepState = stateInit
 				f.b, f.nb = fb, fnb
@@ -116,7 +113,7 @@ readLiteral:
 			}
 			goto readLiteral
 		case v == 256:
-			f.b, f.nb = fb, fnb
+$DISCARD$			f.b, f.nb = fb, fnb
 			f.finishBlock()
 			return
 		// otherwise, reference to older data
@@ -127,15 +124,12 @@ readLiteral:
 			length = int(val.length) + 3
 			n := uint(val.extra)
 			for fnb < n {
-				c, err := fr.ReadByte()
-				if err != nil {
-					f.b, f.nb = fb, fnb
+				$GETBYTE_S$
 					if debugDecode {
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
-					return
-				}
+$GETBYTE_E$
 				f.roffset++
 				fb |= uint32(c) << (fnb&regSizeMaskUint32)
 				fnb += 8	
@@ -144,7 +138,7 @@ readLiteral:
 			fb >>= n & regSizeMaskUint32
 			fnb -= n
 		default:
-			if debugDecode {
+$DISCARD$			if debugDecode {
 				fmt.Println(v, ">= maxNumLit")
 			}
 			f.err = CorruptInputError(f.roffset)
@@ -155,15 +149,12 @@ readLiteral:
 		var dist uint32
 		if f.hd == nil {
 			for fnb < 5 {
-				c, err := fr.ReadByte()
-				if err != nil {
-					f.b, f.nb = fb, fnb
+				$GETBYTE_S$
 					if debugDecode {
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
-					return
-				}
+$GETBYTE_E$
 				f.roffset++
 				fb |= uint32(c) << (fnb&regSizeMaskUint32)
 				fnb += 8
@@ -182,12 +173,9 @@ readLiteral:
 			// inline call to moreBits and reassign b,nb back to f on return.
 			for {
 				for fnb < n {
-					c, err := fr.ReadByte()
-					if err != nil {
-						f.b, f.nb = fb, fnb
+					$GETBYTE_S$
 						f.err = noEOF(err)
-						return
-					}
+$GETBYTE_E$
 					f.roffset++
 					fb |= uint32(c) << (fnb & regSizeMaskUint32)
 					fnb += 8
@@ -200,7 +188,7 @@ readLiteral:
 				}
 				if n <= fnb {
 					if n == 0 {
-						f.b, f.nb = fb, fnb
+$DISCARD$						f.b, f.nb = fb, fnb
 						if debugDecode {
 							fmt.Println("huffsym: n==0")
 						}
@@ -223,15 +211,12 @@ readLiteral:
 			// have 1 bit in bottom of dist, need nb more.
 			extra := (dist & 1) << (nb & regSizeMaskUint32)
 			for fnb < nb {
-				c, err := fr.ReadByte()
-				if err != nil {
-					f.b, f.nb = fb, fnb
+				$GETBYTE_S$
 					if debugDecode {
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
-					return
-				}
+$GETBYTE_E$
 				f.roffset++
 				fb |= uint32(c) << (fnb&regSizeMaskUint32)
 				fnb += 8
@@ -242,7 +227,7 @@ readLiteral:
 			dist = 1<<((nb+1)&regSizeMaskUint32) + 1 + extra
 			// slower: dist = bitMask32[nb+1] + 2 + extra
 		default:
-			f.b, f.nb = fb, fnb
+$DISCARD$			f.b, f.nb = fb, fnb
 			if debugDecode {
 				fmt.Println("dist too big:", dist, maxNumDist)
 			}
@@ -252,7 +237,7 @@ readLiteral:
 
 		// No check on length; encoding can be prescient.
 		if dist > uint32(dict.histSize()) {
-			f.b, f.nb = fb, fnb
+$DISCARD$			f.b, f.nb = fb, fnb
 			if debugDecode {
 				fmt.Println("dist > dict.histSize():", dist, dict.histSize())
 			}
@@ -274,7 +259,7 @@ copyHistory:
 		f.copyLen -= cnt
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
-			f.toRead = dict.readFlush()
+$DISCARD$			f.toRead = dict.readFlush()
 			f.step = $FUNCNAME$ // We need to continue this work
 			f.stepState = stateDict
 			f.b, f.nb = fb, fnb
@@ -286,11 +271,69 @@ copyHistory:
 }
 
 `
-	for i, t := range types {
-		s := strings.Replace(template, "$FUNCNAME$", "huffman"+names[i], -1)
-		s = strings.Replace(s, "$TYPE$", t, -1)
-		f.WriteString(s)
+
+	f.WriteString(`
+func peekBufio(fr *bufio.Reader) ([]byte, error) {
+	if fr.Buffered() == 0 {
+		if _, err := fr.Peek(1); err != nil && fr.Buffered() == 0 {
+			return nil, err
+		}
 	}
+	return fr.Peek(fr.Buffered())
+}
+
+`)
+	// Each variant pulls the next input byte differently. The default reads via
+	// fr.ReadByte(). The *bufio.Reader variant reads from a Peek window so the
+	// per-byte fill inlines as a slice index; since Peek only views the buffer and
+	// Discard advances it, it must Discard consumed bytes before every return.
+	// getS/getE wrap each read site around that site's own EOF handling:
+	//     <getS> <site-specific error body> <getE>
+	// (output indentation is normalized by the go fmt step, so these need not be
+	// pre-indented).
+	type readImpl struct{ top, getS, getE, discard string }
+
+	readByte := readImpl{
+		getS: `c, err := fr.ReadByte()
+if err != nil {
+f.b, f.nb = fb, fnb`,
+		getE: `
+return
+}`,
+	}
+	peek := readImpl{
+		top: "pbuf, _ := fr.Peek(fr.Buffered())\npos := 0\n",
+		getS: `if pos >= len(pbuf) {
+fr.Discard(pos)
+var err error
+pbuf, err = peekBufio(fr)
+pos = 0
+if len(pbuf) == 0 {
+f.b, f.nb = fb, fnb`,
+		getE: `
+return
+}
+}
+c := pbuf[pos]
+pos++`,
+		discard: "fr.Discard(pos)\n",
+	}
+
+	for i, t := range types {
+		r := readByte
+		if t == "*bufio.Reader" {
+			r = peek
+		}
+		f.WriteString(strings.NewReplacer(
+			"$FUNCNAME$", "huffman"+names[i],
+			"$TYPE$", t,
+			"$PEEKTOP$", r.top,
+			"$GETBYTE_S$", r.getS,
+			"$GETBYTE_E$", r.getE,
+			"$DISCARD$", r.discard,
+		).Replace(template))
+	}
+
 	f.WriteString("func (f *decompressor) huffmanBlockDecoder() {\n")
 	f.WriteString("\tswitch f.r.(type) {\n")
 	for i, t := range types {

--- a/flate/inflate_bufio_test.go
+++ b/flate/inflate_bufio_test.go
@@ -1,0 +1,62 @@
+package flate
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+	"testing/iotest"
+)
+
+// roundtripBufio round-trips data through readers that force the *bufio.Reader
+// decode path (huffmanBufioReader, which reads via Peek and Discards consumed
+// bytes at each return), asserting byte-for-byte equality. The OneByte/Half
+// wrappers stress the Peek-refill boundaries.
+func roundtripBufio(t *testing.T, data []byte) {
+	t.Helper()
+	for _, lvl := range []int{0, 1, 6, 9} {
+		var comp bytes.Buffer
+		w, err := NewWriter(&comp, lvl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		c := comp.Bytes()
+		for name, mk := range map[string]func() io.Reader{
+			"onebyte": func() io.Reader { return iotest.OneByteReader(bytes.NewReader(c)) },
+			"half":    func() io.Reader { return iotest.HalfReader(bytes.NewReader(c)) },
+			"bufio":   func() io.Reader { return bufio.NewReader(bytes.NewReader(c)) },
+		} {
+			got, err := io.ReadAll(NewReader(mk()))
+			if err != nil {
+				t.Fatalf("level %d, %s reader: %v", lvl, name, err)
+			}
+			if !bytes.Equal(got, data) {
+				t.Fatalf("level %d, %s reader: round-trip mismatch (%d vs %d bytes)", lvl, name, len(got), len(data))
+			}
+		}
+	}
+}
+
+func FuzzInflateBufio(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add(bytes.Repeat([]byte("hello world "), 5000))
+	f.Add(bytes.Repeat([]byte{0}, 100000))
+	seq := make([]byte, 20000)
+	for i := range seq {
+		seq[i] = byte(i*31 + i/7)
+	}
+	f.Add(seq)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<18 { // keep fuzz execs fast; larger inputs add no new paths here
+			return
+		}
+		roundtripBufio(t, data)
+	})
+}

--- a/flate/inflate_gen.go
+++ b/flate/inflate_gen.go
@@ -59,7 +59,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -120,7 +119,6 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -149,7 +147,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -174,7 +171,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -219,7 +215,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -315,7 +310,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -376,7 +370,6 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -405,7 +398,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -430,7 +422,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -475,7 +466,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -577,7 +567,6 @@ readLiteral:
 						if len(pbuf) == 0 {
 							f.b, f.nb = fb, fnb
 							f.err = noEOF(err)
-
 							return
 						}
 					}
@@ -648,7 +637,6 @@ readLiteral:
 							fmt.Println("morebits n>0:", err)
 						}
 						f.err = err
-
 						return
 					}
 				}
@@ -685,7 +673,6 @@ readLiteral:
 							fmt.Println("morebits f.nb<5:", err)
 						}
 						f.err = err
-
 						return
 					}
 				}
@@ -717,7 +704,6 @@ readLiteral:
 						if len(pbuf) == 0 {
 							f.b, f.nb = fb, fnb
 							f.err = noEOF(err)
-
 							return
 						}
 					}
@@ -770,7 +756,6 @@ readLiteral:
 							fmt.Println("morebits f.nb<nb:", err)
 						}
 						f.err = err
-
 						return
 					}
 				}
@@ -872,7 +857,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -933,7 +917,6 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -962,7 +945,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -987,7 +969,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -1032,7 +1013,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -1128,7 +1108,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -1189,7 +1168,6 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -1218,7 +1196,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++
@@ -1243,7 +1220,6 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
-
 						return
 					}
 					f.roffset++
@@ -1288,7 +1264,6 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
-
 					return
 				}
 				f.roffset++

--- a/flate/inflate_gen.go
+++ b/flate/inflate_gen.go
@@ -10,6 +10,15 @@ import (
 	"strings"
 )
 
+func peekBufio(fr *bufio.Reader) ([]byte, error) {
+	if fr.Buffered() == 0 {
+		if _, err := fr.Peek(1); err != nil && fr.Buffered() == 0 {
+			return nil, err
+		}
+	}
+	return fr.Peek(fr.Buffered())
+}
+
 // Decode a single Huffman block from f.
 // hl and hd are the Huffman states for the lit/length values
 // and the distance values, respectively. If hd == nil, using the
@@ -50,6 +59,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -110,6 +120,7 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -138,6 +149,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -162,6 +174,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -206,6 +219,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -301,6 +315,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -361,6 +376,7 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -389,6 +405,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -413,6 +430,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -457,6 +475,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -527,6 +546,8 @@ func (f *decompressor) huffmanBufioReader() {
 	// but is smart enough to keep local variables in registers, so use nb and b,
 	// inline call to moreBits and reassign b,nb back to f on return.
 	fnb, fb, dict := f.nb, f.b, &f.dict
+	pbuf, _ := fr.Peek(fr.Buffered())
+	pos := 0
 
 	switch f.stepState {
 	case stateInit:
@@ -548,12 +569,20 @@ readLiteral:
 			n := uint(f.hl.maxRead)
 			for {
 				for fnb < n {
-					c, err := fr.ReadByte()
-					if err != nil {
-						f.b, f.nb = fb, fnb
-						f.err = noEOF(err)
-						return
+					if pos >= len(pbuf) {
+						fr.Discard(pos)
+						var err error
+						pbuf, err = peekBufio(fr)
+						pos = 0
+						if len(pbuf) == 0 {
+							f.b, f.nb = fb, fnb
+							f.err = noEOF(err)
+
+							return
+						}
 					}
+					c := pbuf[pos]
+					pos++
 					f.roffset++
 					fb |= uint32(c) << (fnb & regSizeMaskUint32)
 					fnb += 8
@@ -566,6 +595,7 @@ readLiteral:
 				}
 				if n <= fnb {
 					if n == 0 {
+						fr.Discard(pos)
 						f.b, f.nb = fb, fnb
 						if debugDecode {
 							fmt.Println("huffsym: n==0")
@@ -586,6 +616,7 @@ readLiteral:
 		case v < 256:
 			dict.writeByte(byte(v))
 			if dict.availWrite() == 0 {
+				fr.Discard(pos)
 				f.toRead = dict.readFlush()
 				f.step = huffmanBufioReader
 				f.stepState = stateInit
@@ -594,6 +625,7 @@ readLiteral:
 			}
 			goto readLiteral
 		case v == 256:
+			fr.Discard(pos)
 			f.b, f.nb = fb, fnb
 			f.finishBlock()
 			return
@@ -605,15 +637,23 @@ readLiteral:
 			length = int(val.length) + 3
 			n := uint(val.extra)
 			for fnb < n {
-				c, err := fr.ReadByte()
-				if err != nil {
-					f.b, f.nb = fb, fnb
-					if debugDecode {
-						fmt.Println("morebits n>0:", err)
+				if pos >= len(pbuf) {
+					fr.Discard(pos)
+					var err error
+					pbuf, err = peekBufio(fr)
+					pos = 0
+					if len(pbuf) == 0 {
+						f.b, f.nb = fb, fnb
+						if debugDecode {
+							fmt.Println("morebits n>0:", err)
+						}
+						f.err = err
+
+						return
 					}
-					f.err = err
-					return
 				}
+				c := pbuf[pos]
+				pos++
 				f.roffset++
 				fb |= uint32(c) << (fnb & regSizeMaskUint32)
 				fnb += 8
@@ -622,6 +662,7 @@ readLiteral:
 			fb >>= n & regSizeMaskUint32
 			fnb -= n
 		default:
+			fr.Discard(pos)
 			if debugDecode {
 				fmt.Println(v, ">= maxNumLit")
 			}
@@ -633,15 +674,23 @@ readLiteral:
 		var dist uint32
 		if f.hd == nil {
 			for fnb < 5 {
-				c, err := fr.ReadByte()
-				if err != nil {
-					f.b, f.nb = fb, fnb
-					if debugDecode {
-						fmt.Println("morebits f.nb<5:", err)
+				if pos >= len(pbuf) {
+					fr.Discard(pos)
+					var err error
+					pbuf, err = peekBufio(fr)
+					pos = 0
+					if len(pbuf) == 0 {
+						f.b, f.nb = fb, fnb
+						if debugDecode {
+							fmt.Println("morebits f.nb<5:", err)
+						}
+						f.err = err
+
+						return
 					}
-					f.err = err
-					return
 				}
+				c := pbuf[pos]
+				pos++
 				f.roffset++
 				fb |= uint32(c) << (fnb & regSizeMaskUint32)
 				fnb += 8
@@ -660,12 +709,20 @@ readLiteral:
 			// inline call to moreBits and reassign b,nb back to f on return.
 			for {
 				for fnb < n {
-					c, err := fr.ReadByte()
-					if err != nil {
-						f.b, f.nb = fb, fnb
-						f.err = noEOF(err)
-						return
+					if pos >= len(pbuf) {
+						fr.Discard(pos)
+						var err error
+						pbuf, err = peekBufio(fr)
+						pos = 0
+						if len(pbuf) == 0 {
+							f.b, f.nb = fb, fnb
+							f.err = noEOF(err)
+
+							return
+						}
 					}
+					c := pbuf[pos]
+					pos++
 					f.roffset++
 					fb |= uint32(c) << (fnb & regSizeMaskUint32)
 					fnb += 8
@@ -678,6 +735,7 @@ readLiteral:
 				}
 				if n <= fnb {
 					if n == 0 {
+						fr.Discard(pos)
 						f.b, f.nb = fb, fnb
 						if debugDecode {
 							fmt.Println("huffsym: n==0")
@@ -701,15 +759,23 @@ readLiteral:
 			// have 1 bit in bottom of dist, need nb more.
 			extra := (dist & 1) << (nb & regSizeMaskUint32)
 			for fnb < nb {
-				c, err := fr.ReadByte()
-				if err != nil {
-					f.b, f.nb = fb, fnb
-					if debugDecode {
-						fmt.Println("morebits f.nb<nb:", err)
+				if pos >= len(pbuf) {
+					fr.Discard(pos)
+					var err error
+					pbuf, err = peekBufio(fr)
+					pos = 0
+					if len(pbuf) == 0 {
+						f.b, f.nb = fb, fnb
+						if debugDecode {
+							fmt.Println("morebits f.nb<nb:", err)
+						}
+						f.err = err
+
+						return
 					}
-					f.err = err
-					return
 				}
+				c := pbuf[pos]
+				pos++
 				f.roffset++
 				fb |= uint32(c) << (fnb & regSizeMaskUint32)
 				fnb += 8
@@ -720,6 +786,7 @@ readLiteral:
 			dist = 1<<((nb+1)&regSizeMaskUint32) + 1 + extra
 			// slower: dist = bitMask32[nb+1] + 2 + extra
 		default:
+			fr.Discard(pos)
 			f.b, f.nb = fb, fnb
 			if debugDecode {
 				fmt.Println("dist too big:", dist, maxNumDist)
@@ -730,6 +797,7 @@ readLiteral:
 
 		// No check on length; encoding can be prescient.
 		if dist > uint32(dict.histSize()) {
+			fr.Discard(pos)
 			f.b, f.nb = fb, fnb
 			if debugDecode {
 				fmt.Println("dist > dict.histSize():", dist, dict.histSize())
@@ -752,6 +820,7 @@ copyHistory:
 		f.copyLen -= cnt
 
 		if dict.availWrite() == 0 || f.copyLen > 0 {
+			fr.Discard(pos)
 			f.toRead = dict.readFlush()
 			f.step = huffmanBufioReader // We need to continue this work
 			f.stepState = stateDict
@@ -803,6 +872,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -863,6 +933,7 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -891,6 +962,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -915,6 +987,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -959,6 +1032,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -1054,6 +1128,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -1114,6 +1189,7 @@ readLiteral:
 						fmt.Println("morebits n>0:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -1142,6 +1218,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<5:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++
@@ -1166,6 +1243,7 @@ readLiteral:
 					if err != nil {
 						f.b, f.nb = fb, fnb
 						f.err = noEOF(err)
+
 						return
 					}
 					f.roffset++
@@ -1210,6 +1288,7 @@ readLiteral:
 						fmt.Println("morebits f.nb<nb:", err)
 					}
 					f.err = err
+
 					return
 				}
 				f.roffset++


### PR DESCRIPTION
## Problem

`huffmanBufioReader` fills the bit buffer with `fr.ReadByte()` per input byte. `bufio.Reader.ReadByte` doesn't inline, so each byte is a call barrier that spills the fill loop's registers — ~1.85× slower than the `*bytes.Reader` variant, whose `ReadByte` inlines to a slice index.

## Change

Read via `Peek` instead: index bufio's buffered slice directly (`pbuf[pos]`), refilling when drained. `Peek` only views the buffer, so consumed bytes are `Discard`ed before every return, keeping the reader positioned for `nextBlock`/`moreBits`/the gzip trailer. `peekBufio` refills from at most one `Read` (not `Peek(Size())`, which would block a sync writer).

Only the `*bufio.Reader` variant changes (in `_gen/gen_inflate.go`); the other four stay byte-identical.

## Validation

- flate/gzip/zip suites + `-race` pass on linux/amd64, linux/386, darwin/arm64.
- `FuzzInflateBufio` (forces the bufio path, byte-exact round-trip): ~110k execs, no mismatch.

## Numbers

`*bufio.Reader` decode, 8 MiB literal-heavy (median of 3):

| arch | before | after |
| --- | --- | --- |
| linux/amd64 | 128 MB/s | 151 MB/s (~1.18×) |
| darwin/arm64 | 219 MB/s | 287 MB/s (~1.31×) |

Match-heavy data ~1.05–1.07× (huffman-table-load bound, unchanged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compressed-data decompression when input arrives in very small or irregular buffered reads.
  * Ensured decompressed output remains accurate across buffered-reader boundary conditions and error scenarios.

* **Tests**
  * Added fuzz testing covering compressed and decompressed data across multiple compression levels and reader behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->