### PR TITLE
zstd: avoid racing MaxDecodedSize write on shared dict litEnc

### DIFF
--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -400,8 +400,9 @@ func (b *blockDec) decodeLiterals(in []byte, hist *history) (remain []byte, err 
 			}
 		}
 		var err error
-		// Use our out buffer.
-		huff.MaxDecodedSize = litRegenSize
+		// Decoder.Decompress* uses cap(dst) for the size limit. Do not write
+		// MaxDecodedSize on hist.huffTree: with a trained dictionary that
+		// pointer aliases the shared dict.litEnc and concurrent DecodeAll races.
 		if fourStreams {
 			literals, err = huff.Decoder().Decompress4X(b.literalBuf[:0:litRegenSize], literals)
 		} else {

--- a/zstd/dict_test.go
+++ b/zstd/dict_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/klauspost/compress/zip"
@@ -885,4 +887,87 @@ func TestEncoderDictAddViaReset(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSharedDecoderTrainedDictRace verifies concurrent DecodeAll on one Decoder
+// that holds a trained dictionary does not race on dict.litEnc (gh-1180).
+func TestSharedDecoderTrainedDictRace(t *testing.T) {
+	weights := map[byte]int{'e': 40, 't': 20, 'a': 12, 'o': 8, 'i': 6, 'n': 5, 's': 4, 'h': 3, 'r': 2}
+	var alphabet []byte
+	for c, n := range weights {
+		for i := 0; i < n; i++ {
+			alphabet = append(alphabet, c)
+		}
+	}
+	sample := func(rng *rand.Rand, n int) []byte {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+		return b
+	}
+
+	rng := rand.New(rand.NewSource(2000))
+	samples := make([][]byte, 2000)
+	for i := range samples {
+		samples[i] = sample(rng, 32+rng.Intn(200))
+	}
+	dict, err := BuildDict(BuildDictOptions{
+		ID:       12345,
+		Contents: samples,
+		History:  sample(rng, 12<<10),
+		Offsets:  [3]int{1, 4, 8},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	enc, err := NewWriter(nil, WithEncoderDict(dict), WithEncoderConcurrency(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nFrames := 400
+	iters := 3000
+	goroutines := 48
+	if testing.Short() {
+		nFrames = 80
+		iters = 200
+		goroutines = 8
+	}
+	frames := make([][]byte, nFrames)
+	plains := make([][]byte, nFrames)
+	for i := 0; i < nFrames; i++ {
+		pt := sample(rng, 200+rng.Intn(800))
+		frames[i] = enc.EncodeAll(pt, nil)
+		plains[i] = pt
+	}
+	enc.Close()
+
+	dec, err := NewReader(nil, WithDecoderDicts(dict))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dec.Close()
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(seed)))
+			for i := 0; i < iters; i++ {
+				idx := r.Intn(len(frames))
+				out, err := dec.DecodeAll(frames[idx], nil)
+				if err != nil {
+					t.Errorf("decode error: %v", err)
+					return
+				}
+				if !bytes.Equal(out, plains[idx]) {
+					t.Errorf("output mismatch")
+					return
+				}
+			}
+		}(g + 1)
+	}
+	wg.Wait()
 }

--- a/zstd/dict_test.go
+++ b/zstd/dict_test.go
@@ -895,7 +895,7 @@ func TestSharedDecoderTrainedDictRace(t *testing.T) {
 	weights := map[byte]int{'e': 40, 't': 20, 'a': 12, 'o': 8, 'i': 6, 'n': 5, 's': 4, 'h': 3, 'r': 2}
 	var alphabet []byte
 	for c, n := range weights {
-		for i := 0; i < n; i++ {
+		for range n {
 			alphabet = append(alphabet, c)
 		}
 	}


### PR DESCRIPTION
## Summary
Concurrent `DecodeAll` on a shared Decoder with a trained dictionary raced on `dict.litEnc.MaxDecodedSize` in the treeless literals path. `Decoder.Decompress*` already uses `cap(dst)` for the size limit, so the write was removed.

Fixes #1180

## Test plan
- [x] `go test -race -short -run TestSharedDecoderTrainedDictRace ./zstd/` fails before the fix, passes after


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decompression reliability for treeless data when using shared trained dictionaries.
  * Prevented shared dictionary state from being modified during concurrent decoding.
  * Improved consistency of round-trip decoding when multiple operations run simultaneously.

* **Tests**
  * Added coverage for concurrent decoding with trained dictionaries, including output validation and race detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->