### PR TITLE
zstd: keep BuildDict recent-offsets positive and loadable

### DIFF
--- a/zstd/dict.go
+++ b/zstd/dict.go
@@ -296,40 +296,81 @@ func BuildDict(o BuildDictOptions) ([]byte, error) {
 			if offset > 3 {
 				newOffsets[offset-3]++
 			} else {
-				newOffsets[uint32(o.Offsets[offset-1])]++
+				// Repeat codes reference the training Offsets. Skip unset
+				// (zero) entries so they are not ranked as real offsets.
+				prev := o.Offsets[offset-1]
+				if prev > 0 {
+					newOffsets[uint32(prev)]++
+				}
 			}
 		}
 	}
 	// Find most used offsets.
 	var sortedOffsets []uint32
 	for k := range newOffsets {
+		if k == 0 {
+			continue
+		}
 		sortedOffsets = append(sortedOffsets, k)
 	}
 	sort.Slice(sortedOffsets, func(i, j int) bool {
 		a, b := sortedOffsets[i], sortedOffsets[j]
-		if a == b {
+		ca, cb := newOffsets[a], newOffsets[b]
+		if ca == cb {
 			// Prefer the longer offset
-			return sortedOffsets[i] > sortedOffsets[j]
+			return a > b
 		}
-		return newOffsets[sortedOffsets[i]] > newOffsets[sortedOffsets[j]]
+		return ca > cb
 	})
-	if len(sortedOffsets) > 3 {
-		if debug {
-			print("Offsets:")
-			for i, v := range sortedOffsets {
-				if i > 20 {
-					break
-				}
-				printf("[%d: %d],", v, newOffsets[v])
+	if debug {
+		print("Offsets:")
+		for i, v := range sortedOffsets {
+			if i > 20 {
+				break
 			}
-			println("")
+			printf("[%d: %d],", v, newOffsets[v])
 		}
-
-		sortedOffsets = sortedOffsets[:3]
+		println("")
 	}
-	for i, v := range sortedOffsets {
-		o.Offsets[i] = int(v)
+	// Dictionary recent-offsets must be three positive values within the
+	// history. Ranked matches may be fewer (or empty when only unset
+	// repeat codes were seen), so fill remaining slots with defaults.
+	used := make(map[int]bool, 3)
+	var finalOffsets [3]int
+	nOff := 0
+	for _, v := range sortedOffsets {
+		iv := int(v)
+		if iv <= 0 || iv > len(hist) || used[iv] {
+			continue
+		}
+		finalOffsets[nOff] = iv
+		used[iv] = true
+		nOff++
+		if nOff == 3 {
+			break
+		}
 	}
+	for _, def := range []int{1, 4, 8} {
+		if nOff == 3 {
+			break
+		}
+		if def <= len(hist) && !used[def] {
+			finalOffsets[nOff] = def
+			used[def] = true
+			nOff++
+		}
+	}
+	for def := 1; nOff < 3 && def <= len(hist); def++ {
+		if !used[def] {
+			finalOffsets[nOff] = def
+			used[def] = true
+			nOff++
+		}
+	}
+	if nOff < 3 {
+		return nil, fmt.Errorf("could not determine 3 valid dictionary offsets (history size %d)", len(hist))
+	}
+	o.Offsets = finalOffsets
 	if debug {
 		println("New repeat offsets", o.Offsets)
 	}
@@ -517,11 +558,10 @@ func BuildDict(o BuildDictOptions) ([]byte, error) {
 	out.Write(binary.LittleEndian.AppendUint32(nil, uint32(o.Offsets[1])))
 	out.Write(binary.LittleEndian.AppendUint32(nil, uint32(o.Offsets[2])))
 	out.Write(hist)
+	if _, err := loadDict(out.Bytes()); err != nil {
+		return nil, fmt.Errorf("built dictionary failed validation: %w", err)
+	}
 	if debug {
-		_, err := loadDict(out.Bytes())
-		if err != nil {
-			panic(err)
-		}
 		i, err := InspectDictionary(out.Bytes())
 		if err != nil {
 			panic(err)

--- a/zstd/dict_test.go
+++ b/zstd/dict_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -104,6 +105,62 @@ func TestBuildDictLevelPathsRoundTrip(t *testing.T) {
 				t.Fatalf("decoded output mismatch: got %q want %q", decoded, src)
 			}
 		})
+	}
+}
+
+// Regression for https://github.com/klauspost/compress/issues/1179:
+// a homogeneous corpus with default (zero) Offsets used to emit a dictionary
+// whose recent-offsets table contained 0, which WithEncoderDict rejects.
+func TestBuildDictHomogeneousCorpusValidOffsets(t *testing.T) {
+	sample := func(seed int64) []byte {
+		const boiler = `<div class="card-grid" data-template="responsive"><style>.card-grid{display:grid;gap:6px;background:#0a0a0a;padding:4px}.card-item{color:#333;display:grid}</style><script>(function(){var n=document.querySelectorAll('[data-src]');for(var i=0;i<n.length;i++){var u=n[i].getAttribute('data-src');}})();</script>`
+		rng := rand.New(rand.NewSource(seed))
+		out := boiler
+		for i := 0; i < 8; i++ {
+			p := make([]byte, 32)
+			rng.Read(p)
+			out += fmt.Sprintf(`{"url":"https://example.com/t?id=%d&p=%x"}`, i, p)
+		}
+		return []byte(out)
+	}
+	const sampleCount, historyLimit = 16, 8 << 10
+	samples := make([][]byte, sampleCount)
+	for i := range samples {
+		samples[i] = sample(12000 + int64(i))
+	}
+	var hist []byte
+	for _, s := range samples {
+		if len(hist)+len(s) > historyLimit {
+			break
+		}
+		hist = append(hist, s...)
+	}
+
+	dict, err := BuildDict(BuildDictOptions{
+		ID:       1,
+		Contents: samples,
+		History:  hist,
+		Level:    SpeedBetterCompression,
+	})
+	if err != nil {
+		t.Fatalf("BuildDict failed: %v", err)
+	}
+	enc, err := NewWriter(nil, WithEncoderDict(dict))
+	if err != nil {
+		t.Fatalf("WithEncoderDict rejected dictionary: %v", err)
+	}
+	enc.Close()
+	info, err := InspectDictionary(dict)
+	if err != nil {
+		t.Fatalf("InspectDictionary: %v", err)
+	}
+	for i, off := range info.Offsets() {
+		if off <= 0 {
+			t.Fatalf("offset[%d]=%d; want positive", i, off)
+		}
+		if off > info.ContentSize() {
+			t.Fatalf("offset[%d]=%d > content size %d", i, off, info.ContentSize())
+		}
 	}
 }
 

--- a/zstd/dict_test.go
+++ b/zstd/dict_test.go
@@ -115,13 +115,14 @@ func TestBuildDictHomogeneousCorpusValidOffsets(t *testing.T) {
 	sample := func(seed int64) []byte {
 		const boiler = `<div class="card-grid" data-template="responsive"><style>.card-grid{display:grid;gap:6px;background:#0a0a0a;padding:4px}.card-item{color:#333;display:grid}</style><script>(function(){var n=document.querySelectorAll('[data-src]');for(var i=0;i<n.length;i++){var u=n[i].getAttribute('data-src');}})();</script>`
 		rng := rand.New(rand.NewSource(seed))
-		out := boiler
-		for i := 0; i < 8; i++ {
+		var out strings.Builder
+		out.WriteString(boiler)
+		for i := range 8 {
 			p := make([]byte, 32)
 			rng.Read(p)
-			out += fmt.Sprintf(`{"url":"https://example.com/t?id=%d&p=%x"}`, i, p)
+			out.WriteString(fmt.Sprintf(`{"url":"https://example.com/t?id=%d&p=%x"}`, i, p))
 		}
-		return []byte(out)
+		return []byte(out.String())
 	}
 	const sampleCount, historyLimit = 16, 8 << 10
 	samples := make([][]byte, sampleCount)


### PR DESCRIPTION
## Summary

`BuildDict` on a homogeneous corpus with default (zero) `Offsets` could emit a dictionary whose recent-offsets table contained `0`. `WithEncoderDict` then rejected it with `invalid offset in dictionary`.

Root cause: repeat codes (offset 1/2/3) counted `o.Offsets[i]` even when those were still `0`, so `0` ranked as a "most used" offset and was written into the dictionary.

Fix:
- skip zero targets when counting repeat-code hits
- require three positive in-range offsets (pad with `1,4,8` / sequential defaults when ranking alone is short)
- always validate the built blob with `loadDict` before returning

Fixes #1179

## Test plan

- [x] Fail-before / pass-after on `TestBuildDictHomogeneousCorpusValidOffsets` (issue repro corpus)
- [x] `go test ./zstd -run 'TestBuildDict(HomogeneousCorpusValidOffsets|LevelPathsRoundTrip)' -count=1`
- [x] `go test ./zstd -count=1` (full package)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictionary offset selection for more reliable compression.
  * Prevented invalid or missing offsets from being used.
  * Added validation to catch invalid dictionaries and return clear errors instead of causing crashes.
  * Improved handling of dictionaries trained on uniform HTML and JSON content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->