### PR TITLE
xxhash: bound input of non-preemptive assembly

### DIFF
--- a/zstd/internal/xxhash/bench_test.go
+++ b/zstd/internal/xxhash/bench_test.go
@@ -14,8 +14,9 @@ var benchmarks = []struct {
 	{"4B", 4},
 	{"100B", 100},
 	{"4KB", 4e3},
-	{"64KB", 64e3},   // just under maxAsmSize: one call into writeBlocks
-	{"128KB", 128e3}, // just over: Write feeds writeBlocks in chunks
+	{"64KB", 64e3},
+	{"128KB", 128e3}, // just under maxAsmSize: one call into writeBlocks
+	{"256KB", 256e3}, // just over: Write feeds writeBlocks in chunks
 	{"10MB", 10e6},
 }
 

--- a/zstd/internal/xxhash/bench_test.go
+++ b/zstd/internal/xxhash/bench_test.go
@@ -72,7 +72,11 @@ func BenchmarkDigestSTW(b *testing.B) {
 		b.SetBytes(n)
 		for b.Loop() {
 			done := make(chan struct{})
-			go func() { defer close(done); work() }()
+			hashing := make(chan struct{})
+			go func() { defer close(done); close(hashing); work() }()
+			// Wait until the hash goroutine is running, so the collection below
+			// cannot finish before the hash has even started.
+			<-hashing
 			start := time.Now()
 			runtime.GC() // one per iteration, so the mean is well defined
 			total += time.Since(start)

--- a/zstd/internal/xxhash/bench_test.go
+++ b/zstd/internal/xxhash/bench_test.go
@@ -2,6 +2,7 @@ package xxhash
 
 import (
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -67,23 +68,42 @@ func BenchmarkDigestSTW(b *testing.B) {
 	// reports the mean wall time of one collection.
 	gcWaitPerOp := func(b *testing.B, n int64, work func()) {
 		var total time.Duration
-		var iters int
+		var iters, missed int
 
 		b.SetBytes(n)
 		for b.Loop() {
 			done := make(chan struct{})
-			hashing := make(chan struct{})
-			go func() { defer close(done); close(hashing); work() }()
-			// Wait until the hash goroutine is running, so the collection below
-			// cannot finish before the hash has even started.
-			<-hashing
+			var began atomic.Int64
+			go func() {
+				defer close(done)
+				began.Store(time.Now().UnixNano())
+				work()
+			}()
 			start := time.Now()
 			runtime.GC() // one per iteration, so the mean is well defined
-			total += time.Since(start)
-			iters++
+			end := time.Now()
 			<-done
+
+			// Only count the iteration if the work had started before the
+			// collection finished. Otherwise there was nothing to overlap and
+			// the sample says nothing about preemptibility. Verifying beats
+			// handshaking: a signal sent just before work() begins still leaves
+			// a window, and this closes it for both the bounded and unbounded
+			// build.
+			if b := began.Load(); b != 0 && b < end.UnixNano() {
+				total += end.Sub(start)
+				iters++
+			} else {
+				missed++
+			}
+		}
+		if iters == 0 {
+			b.Skip("no iteration overlapped the collection")
 		}
 		b.ReportMetric(float64(total.Nanoseconds())/float64(iters), "gcwait-ns/op")
+		if missed > 0 {
+			b.ReportMetric(float64(missed), "missed-overlap")
+		}
 	}
 
 	for _, bb := range []struct {

--- a/zstd/internal/xxhash/bench_test.go
+++ b/zstd/internal/xxhash/bench_test.go
@@ -1,0 +1,109 @@
+package xxhash
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+var benchmarks = []struct {
+	name string
+	n    int64
+}{
+	{"4B", 4},
+	{"100B", 100},
+	{"4KB", 4e3},
+	{"64KB", 64e3},   // just under maxAsmSize: one call into writeBlocks
+	{"128KB", 128e3}, // just over: Write feeds writeBlocks in chunks
+	{"10MB", 10e6},
+}
+
+func BenchmarkSum64(b *testing.B) {
+	for _, bb := range benchmarks {
+		in := make([]byte, bb.n)
+		for i := range in {
+			in[i] = byte(i)
+		}
+		b.Run(bb.name, func(b *testing.B) {
+			b.SetBytes(bb.n)
+			for b.Loop() {
+				sink = Sum64(in)
+			}
+		})
+	}
+}
+
+// BenchmarkDigestBytes covers the path this change touches: Write feeds
+// writeBlocks in chunks, so the per-call cost has to stay small.
+func BenchmarkDigestBytes(b *testing.B) {
+	for _, bb := range benchmarks {
+		in := make([]byte, bb.n)
+		for i := range in {
+			in[i] = byte(i)
+		}
+		b.Run(bb.name, func(b *testing.B) {
+			b.SetBytes(bb.n)
+			for b.Loop() {
+				var d Digest
+				d.Reset()
+				d.Write(in)
+				sink = d.Sum64()
+			}
+		})
+	}
+}
+
+// BenchmarkDigestSTW reports how long a GC took while other work ran alongside
+// it. The GC runs on this goroutine and the work on another, so they always
+// overlap; a background collector would only sometimes catch the stall.
+//
+// Each size has a "goloop" case doing the same pass over the same buffer in
+// ordinary Go, which is always preemptible. That is the floor: it measures the
+// collector's own work, so it says how much of a hash case is the collector
+// rather than the stall -- and its error bar says how much of the noise is too.
+// Use -benchtime=5s, the collector needs a few thousand cycles to average out.
+func BenchmarkDigestSTW(b *testing.B) {
+	// gcWaitPerOp collects on this goroutine while work runs on another, and
+	// reports the mean wall time of one collection.
+	gcWaitPerOp := func(b *testing.B, n int64, work func()) {
+		var total time.Duration
+		var iters int
+
+		b.SetBytes(n)
+		for b.Loop() {
+			done := make(chan struct{})
+			go func() { defer close(done); work() }()
+			start := time.Now()
+			runtime.GC() // one per iteration, so the mean is well defined
+			total += time.Since(start)
+			iters++
+			<-done
+		}
+		b.ReportMetric(float64(total.Nanoseconds())/float64(iters), "gcwait-ns/op")
+	}
+
+	for _, bb := range []struct {
+		name string
+		n    int64
+	}{{"10MB", 10e6}, {"128MB", 128e6}} {
+		// Allocated once, outside b.Run: the closure runs once per -count, and a
+		// fresh buffer per run would give each run different sweep work.
+		in := make([]byte, bb.n)
+		var d Digest
+
+		b.Run(bb.name, func(b *testing.B) {
+			gcWaitPerOp(b, bb.n, func() {
+				d.Reset()
+				d.Write(in)
+				sink = d.Sum64()
+			})
+		})
+		b.Run(bb.name+"-goloop", func(b *testing.B) {
+			gcWaitPerOp(b, bb.n, func() {
+				for _, c := range in {
+					sink += uint64(c)
+				}
+			})
+		})
+	}
+}

--- a/zstd/internal/xxhash/xxhash.go
+++ b/zstd/internal/xxhash/xxhash.go
@@ -55,7 +55,7 @@ func (d *Digest) Reset() {
 // maxAsmSize bounds the input handed to a single writeBlocks call. Assembly is
 // never preemptible, so an unbounded call holds every P in stop-the-world for
 // its duration. Whole 32-byte blocks, so Write can feed it in pieces.
-const maxAsmSize = 64 * 1024 // 2048 whole 32-byte blocks
+const maxAsmSize = 128 << 10 // 4096 whole 32-byte blocks
 
 // Size always returns 8 bytes.
 func (d *Digest) Size() int { return 8 }

--- a/zstd/internal/xxhash/xxhash.go
+++ b/zstd/internal/xxhash/xxhash.go
@@ -52,6 +52,11 @@ func (d *Digest) Reset() {
 	d.n = 0
 }
 
+// maxAsmSize bounds the input handed to a single writeBlocks call. Assembly is
+// never preemptible, so an unbounded call holds every P in stop-the-world for
+// its duration. Whole 32-byte blocks, so Write can feed it in pieces.
+const maxAsmSize = 64 * 1024 // 2048 whole 32-byte blocks
+
 // Size always returns 8 bytes.
 func (d *Digest) Size() int { return 8 }
 
@@ -81,6 +86,13 @@ func (d *Digest) Write(b []byte) (n int, err error) {
 		d.v4 = round(d.v4, u64(d.mem[24:32]))
 		b = b[c:]
 		d.n = 0
+	}
+
+	for len(b) >= maxAsmSize {
+		// Assembly is not preemptible, so hashing a large buffer in one call
+		// blocks every stop-the-world for the whole call. Feed it in chunks.
+		writeBlocks(d, b[:maxAsmSize])
+		b = b[maxAsmSize:]
 	}
 
 	if len(b) >= 32 {

--- a/zstd/internal/xxhash/xxhash_amd64.s
+++ b/zstd/internal/xxhash/xxhash_amd64.s
@@ -175,7 +175,11 @@ finalize:
 	RET
 
 // func writeBlocks(d *Digest, b []byte) int
-TEXT ·writeBlocks(SB), NOSPLIT|NOFRAME, $0-40
+//
+// Deliberately not NOSPLIT: the stack check is the preemption point that lets a
+// stop-the-world proceed between chunks. The frame must be >= abi.StackSmall
+// (128), or the assembler marks this leaf NOSPLIT anyway and drops that check.
+TEXT ·writeBlocks(SB), $128-40
 	// Load fixed primes needed for round.
 	MOVQ ·primes+0(SB), prime1
 	MOVQ ·primes+8(SB), prime2

--- a/zstd/internal/xxhash/xxhash_arm64.s
+++ b/zstd/internal/xxhash/xxhash_arm64.s
@@ -163,7 +163,11 @@ finalize:
 	RET
 
 // func writeBlocks(s *Digest, b []byte) int
-TEXT ·writeBlocks(SB), NOSPLIT|NOFRAME, $0-40
+//
+// Deliberately not NOSPLIT: the stack check is the preemption point that lets a
+// stop-the-world proceed between chunks. The frame must be >= abi.StackSmall
+// (128), or the assembler marks this leaf NOSPLIT anyway and drops that check.
+TEXT ·writeBlocks(SB), $128-40
 	LDP ·primes+0(SB), (prime1, prime2)
 
 	// Load state. Assume v[1-4] are stored contiguously.

--- a/zstd/internal/xxhash/xxhash_test.go
+++ b/zstd/internal/xxhash/xxhash_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAll(t *testing.T) {
@@ -162,5 +165,67 @@ func testAllocs(t *testing.T, fn func()) {
 	t.Helper()
 	if allocs := int(testing.AllocsPerRun(10, fn)); allocs > 0 {
 		t.Fatalf("got %d allocation(s) (want zero)", allocs)
+	}
+}
+
+// gcWait collects while work runs in another goroutine, and reports the longest
+// a GC had to wait along with how long the work itself took. Work the runtime
+// cannot preempt shows up as a wait that is a large fraction of the work.
+func gcWait(work func()) (worst, elapsed time.Duration) {
+	done := make(chan struct{})
+	begin := time.Now()
+	go func() { defer close(done); work() }()
+	for {
+		select {
+		case <-done:
+			return worst, time.Since(begin)
+		default:
+		}
+		start := time.Now()
+		runtime.GC()
+		worst = max(worst, time.Since(start))
+	}
+}
+
+// TestDigestIsPreemptible fails on two counts, so that neither a fast machine
+// nor a loaded one decides the outcome. Both bars are relative, never absolute:
+// how long a GC waited against the hash it overlapped, and against a plain Go
+// loop, which is always preemptible and so gives this runner's noise floor.
+func TestDigestIsPreemptible(t *testing.T) {
+	if testing.Short() || runtime.GOMAXPROCS(0) < 2 {
+		t.Skip("hashes 64 MiB, and needs GOMAXPROCS >= 2 to see a stalled GC")
+	}
+	// One Write, so an unbounded writeBlocks is a single call and the GC waits
+	// out the whole hash rather than one chunk of it.
+	buf := make([]byte, 64*1024*1024)
+
+	// Three rounds each, keeping the reading that most favours a pass: the best
+	// hash and the worst plain-Go loop. A loaded runner can stall any single
+	// measurement, but only unpreemptible code stalls every one of them.
+	got, hash := time.Duration(math.MaxInt64), time.Duration(0)
+	var floor time.Duration
+	for range 3 {
+		w, _ := gcWait(func() {
+			for _, b := range buf {
+				sink += uint64(b)
+			}
+		})
+		floor = max(floor, w)
+
+		w, e := gcWait(func() {
+			var d Digest
+			d.Reset()
+			d.Write(buf)
+			sink = d.Sum64()
+		})
+		if w < got {
+			got, hash = w, e
+		}
+	}
+
+	t.Logf("worst GC wait: %v of a %v Digest.Write, against %v on a plain Go loop", got, hash, floor)
+	if got > hash/4 && got > 4*floor {
+		t.Fatalf("a GC waited %v of a %v Digest.Write, against %v on a plain Go "+
+			"loop: writeBlocks is running unbounded", got, hash, floor)
 	}
 }


### PR DESCRIPTION
## Problem

GC stop-the-world is slow if pass large input to `Digest.Write` (**6.5 ms** on 128 MiB). Every goroutine in the process is frozen for that window.

Root cause: `Write` passes unbounded input to assembly, and the runtime cannot preempt assembly.

## Fix

1. `Write` feeds `writeBlocks` 64 KiB at a time.
2. `writeBlocks` gets a stack frame (`$128-40`, no `NOSPLIT`) — the stack check is the preemption point

## GC (stop-the-world improved)

```
GOMAXPROCS=2 go test -run='^$' -bench='DigestSTW/[0-9]+MB$' -count=10 -benchtime=5s ./zstd/internal/xxhash/

                     │ gcwait-sec/op │ gcwait-sec/op  vs base                │
DigestSTW/10MB-2        588.8µ ± 1%     105.8µ ±  8%  -82.03% (p=0.000 n=10)
DigestSTW/128MB-2      6462.1µ ± 0%     137.1µ ± 13%  -97.88% (p=0.000 n=10)
```

## Throughput (no degradations)

```
GOMAXPROCS=2 go test -run='^$' -bench='Sum64|DigestBytes' -count=10 -benchtime=1s ./zstd/internal/xxhash/

                    │   sec/op    │   sec/op     vs base               │
Sum64/4B-2            2.250n ± 0%   2.223n ± 0%  -1.18% (p=0.000 n=10)
Sum64/100B-2          9.060n ± 0%   9.074n ± 0%       ~ (p=0.752 n=10)
Sum64/4KB-2           198.2n ± 0%   198.3n ± 0%       ~ (p=0.166 n=10)
Sum64/64KB-2          3.114µ ± 0%   3.118µ ± 0%  +0.13% (p=0.001 n=10)
Sum64/128KB-2         6.223µ ± 0%   6.235µ ± 0%  +0.19% (p=0.037 n=10)
Sum64/10MB-2          487.4µ ± 0%   488.9µ ± 1%  +0.31% (p=0.001 n=10)
DigestBytes/4B-2      5.196n ± 0%   5.202n ± 0%  +0.11% (p=0.028 n=10)
DigestBytes/100B-2    12.80n ± 0%   13.17n ± 0%  +2.81% (p=0.000 n=10)
DigestBytes/4KB-2     201.7n ± 2%   203.0n ± 1%       ~ (p=0.304 n=10)
DigestBytes/64KB-2    3.123µ ± 0%   3.138µ ± 0%  +0.46% (p=0.000 n=10)
DigestBytes/128KB-2   6.229µ ± 0%   6.263µ ± 0%  +0.55% (p=0.000 n=10)
DigestBytes/10MB-2    487.9µ ± 0%   491.4µ ± 0%  +0.72% (p=0.000 n=10)
```

References:
- similar work in go stdlib's `sha256`:  https://github.com/golang/go/commit/698f86139bf72bcf7cbf08accc1c34394cb57acb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness when hashing large inputs by processing data in bounded chunks.
  * Reduced potential garbage-collection pauses during hashing on supported architectures.

* **Tests**
  * Added coverage for large-input hashing, runtime preemptibility, and garbage-collection behavior.
  * Added benchmarks across multiple input sizes and hashing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->