### PR TITLE
zstd: stream a small buffer when its in-memory decode exceeds the size limit

### DIFF
--- a/zstd/decoder.go
+++ b/zstd/decoder.go
@@ -7,6 +7,7 @@ package zstd
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"sync"
 
@@ -193,18 +194,30 @@ func (d *Decoder) Reset(r io.Reader) error {
 		}
 
 		dst, err := d.DecodeAll(b, dst)
-		if err == nil {
-			err = io.EOF
+		if !errors.Is(err, ErrDecoderSizeExceeded) {
+			if err == nil {
+				err = io.EOF
+			}
+			// Save output buffer
+			d.syncStream.dstBuf = dst
+			d.current.b = dst
+			d.current.err = err
+			d.current.flushed = true
+			if debugDecoder {
+				println("sync decode to", len(dst), "bytes, err:", err)
+			}
+			return nil
 		}
-		// Save output buffer
-		d.syncStream.dstBuf = dst
-		d.current.b = dst
-		d.current.err = err
-		d.current.flushed = true
+		// The output does not fit WithDecoderMaxMemory, which caps the total
+		// decoded size when decoding in memory. A Reader follows the
+		// streaming contract, where the option caps the window instead, so
+		// decode this input as a stream after all; the shortcut has not
+		// consumed the reader. Drop the oversized buffer rather than keep it
+		// for reuse.
 		if debugDecoder {
-			println("sync decode to", len(dst), "bytes, err:", err)
+			println("sync decode exceeded max memory after", len(dst), "bytes; streaming instead")
 		}
-		return nil
+		d.syncStream.dstBuf = nil
 	}
 	// Remove current block.
 	d.stashDecoder()

--- a/zstd/decoder_test.go
+++ b/zstd/decoder_test.go
@@ -2337,3 +2337,67 @@ func TestDecoderDictDeleteMultiple(t *testing.T) {
 		t.Error("dict 200 should still exist")
 	}
 }
+
+// TestDecoderBufferShortcutFallsBackToStreaming covers #1206. A Reader over a
+// source with Bytes and Len shorter than WithDecodeBuffersBelow is decoded in
+// memory, where WithDecoderMaxMemory caps the total decoded size; a Reader is
+// documented with the streaming contract, where the option caps the window.
+// When the in-memory decode exceeds the cap, Reset must fall back to streaming
+// so the Reader behaves the same as over a plain io.Reader.
+func TestDecoderBufferShortcutFallsBackToStreaming(t *testing.T) {
+	// 4 MiB of zeros with a 64 KiB window compresses to a few hundred bytes,
+	// far below the buffers-below threshold, and streams back within a
+	// 1 MiB window cap while exceeding a 1 MiB total-size cap.
+	input := make([]byte, 4<<20)
+	var buf bytes.Buffer
+	enc, err := NewWriter(&buf, WithWindowSize(64<<10), WithEncoderCRC(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := enc.Write(input); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compressed := buf.Bytes()
+	if len(compressed) >= 128<<10 {
+		t.Fatalf("compressed input is %d bytes, not below the buffers-below threshold", len(compressed))
+	}
+	const limit = 1 << 20
+
+	// In-memory decoding is documented to cap the total decoded size.
+	dec, err := NewReader(nil, WithDecoderMaxMemory(limit))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dec.DecodeAll(compressed, nil); !errors.Is(err, ErrDecoderSizeExceeded) {
+		t.Fatalf("DecodeAll: got %v, want %v", err, ErrDecoderSizeExceeded)
+	}
+	dec.Close()
+
+	// A Reader must succeed regardless of whether the source takes the
+	// in-memory shortcut.
+	for _, tc := range []struct {
+		name string
+		r    io.Reader
+	}{
+		{"bytes.Buffer (shortcut)", bytes.NewBuffer(compressed)},
+		{"plain reader (streaming)", struct{ io.Reader }{bytes.NewReader(compressed)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dec, err := NewReader(tc.r, WithDecoderMaxMemory(limit))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer dec.Close()
+			got, err := io.ReadAll(dec)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if !bytes.Equal(got, input) {
+				t.Fatalf("output mismatch: got %d bytes, want %d", len(got), len(input))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1206.

`Decoder.Reset` decodes a `Bytes()`/`Len()` source shorter than `WithDecodeBuffersBelow` in one go through `DecodeAll`, where `WithDecoderMaxMemory` caps the total decoded size. A Reader is documented with the streaming contract, where the option caps the window, so the same Reader followed one rule or the other depending on input length.

**Change:** when the shortcut's `DecodeAll` reports `ErrDecoderSizeExceeded`, fall through to the normal streaming decode of the same reader (the shortcut has not consumed its bytes). Memory stays bounded as documented: the in-memory attempt stops at the cap, its buffer is dropped rather than kept for reuse, and streaming holds a window.

**Test:** `TestDecoderBufferShortcutFallsBackToStreaming` encodes 4 MiB with a 64 KiB window (a few hundred compressed bytes), sets a 1 MiB limit, asserts `DecodeAll` still fails as documented, and asserts a Reader over a `bytes.Buffer` and over a plain `io.Reader` both produce the full output. It fails on master with `decompressed size exceeds configured limit` on the buffer case. The original 1740-byte fuzz reproducer from #1206 also passes the differential harness with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Decoding now automatically falls back to streaming when an optimized in-memory decode exceeds the configured maximum memory limit.
  - Readers backed by in-memory byte sources now behave consistently with standard readers, allowing oversized compressed data to decode successfully without exceeding the configured memory cap.
  - Added coverage to verify successful decoding and output integrity across both decoding paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->