### PR TITLE
huff0: regenerate the Decompress1X asm loop with a branch-free refill

### DIFF
--- a/huff0/_generate/gen.go
+++ b/huff0/_generate/gen.go
@@ -47,14 +47,8 @@ func main() {
 	Generate()
 }
 
-// sentinelLoop holds the per-symbol decode and the container reload shared
-// by the 4X and 1X loops, and the twin (generic or BMI2) being generated.
-type sentinelLoop struct {
-	bmi2 bool
-}
-
 type decompress4x struct {
-	sentinelLoop
+	bmi2 bool
 }
 
 // TODO [wmu]: I believe it's doable in avo, but can't figure out how to deal
@@ -65,7 +59,7 @@ const bitReader_value = bitReader_off + 8
 const bitReader_bitsRead = bitReader_value + 8
 const bitReader__size = bitReader_bitsRead + 8
 
-// Symbols decoded from a stream between reloads. The bit container holds
+// Symbols decoded from a stream between reloads (4X) or refills (1X). The bit container holds
 // a sentinel bit just below the unread bits, so the consumed count is its
 // trailing zero count and no separate bitsRead register is needed. A reload
 // leaves at most 7 consumed bits, so n symbols of at most b bits each need
@@ -239,7 +233,7 @@ func (d decompress4x) generateProcedure(name string, nSyms int) {
 // decodeSymbol decodes one symbol from bits into op[k]: peek the top
 // peekBits bits, look the entry up, shift the container by the entry's low
 // byte (its bit length) and store the entry's high byte (the symbol).
-func (d sentinelLoop) decodeSymbol(k int, bits, op, peekBits, table reg.GPVirtual) {
+func (d decompress4x) decodeSymbol(k int, bits, op, peekBits, table reg.GPVirtual) {
 	val := GP64()
 	if d.bmi2 {
 		SHRXQ(peekBits, bits, val)
@@ -261,11 +255,10 @@ func (d sentinelLoop) decodeSymbol(k int, bits, op, peekBits, table reg.GPVirtua
 }
 
 // reload tops up one bit container from its input pointer ip (a memory
-// operand or a register): the trailing zero count is the number of consumed
-// bits, whole bytes move the pointer back, the fresh 8-byte window gets a
-// new sentinel in bit 0, and the 0-7 leftover bits are re-applied as a
-// shift.
-func (d sentinelLoop) reload(bits reg.GPVirtual, ip Op) {
+// operand): the trailing zero count is the number of consumed bits, whole
+// bytes move the pointer back, the fresh 8-byte window gets a new sentinel
+// in bit 0, and the 0-7 leftover bits are re-applied as a shift.
+func (d decompress4x) reload(bits reg.GPVirtual, ip Mem) {
 	consumed := GP64()
 	// TZCNT rather than BSF in both twins: the sentinel guarantees a set
 	// bit, for which pre-BMI1 CPUs execute TZCNT (REP BSF) as BSF with the
@@ -281,17 +274,12 @@ func (d sentinelLoop) reload(bits reg.GPVirtual, ip Op) {
 	MOVQ(consumed, nb)
 	ANDQ(U8(7), nb)
 	SHRQ(U8(3), consumed)
-	if ipReg, ok := ip.(reg.GPVirtual); ok {
-		SUBQ(consumed, ipReg)
-		MOVQ(Mem{Base: ipReg}, bits)
-	} else {
-		// The old container is dead once its zero count is taken, so it
-		// holds the input pointer until the fresh load overwrites it.
-		MOVQ(ip, bits)
-		SUBQ(consumed, bits)
-		MOVQ(bits, ip)
-		MOVQ(Mem{Base: bits}, bits)
-	}
+	// The old container is dead once its zero count is taken, so it holds
+	// the input pointer until the fresh load overwrites it.
+	MOVQ(ip, bits)
+	SUBQ(consumed, bits)
+	MOVQ(bits, ip)
+	MOVQ(Mem{Base: bits}, bits)
 	ORQ(U8(1), bits)
 	if d.bmi2 {
 		SHLXQ(nb, bits, bits)
@@ -300,26 +288,37 @@ func (d sentinelLoop) reload(bits reg.GPVirtual, ip Op) {
 	}
 }
 
-// decompress1x emits the Decompress1X main loops. A single stream, so the
-// container, the input pointer, the output pointer and both loop limits all
-// live in registers; otherwise it is the 4X loop with one stream.
+// decompress1x emits the Decompress1X main loops. A single stream is one
+// serial dependency chain (peek, table load, shift), so unlike the 4X loop
+// there is no other stream to hide a reload behind: the sentinel reload
+// (trailing zero count, pointer math, load, shift) would sit on that chain
+// once per group. Instead the 1X loop keeps the consumed count in its own
+// register, as the Go bit reader does, and refills by ORing the consumed
+// whole bytes back in from below the window with shift counts computed off
+// the chain, so a refill joins the chain with a single OR. Every value is
+// register resident.
 type decompress1x struct {
-	sentinelLoop
+	bmi2 bool
 }
 
 // generateProcedure emits the Decompress1X main loop for one symbols-per-
-// reload count. See decompress4x.generateProcedure for the bit container
-// layout and the reload; the bounds work the same way, except that the
-// output limit is the end of the buffer (one stream, no interleaving) and
-// the input bound is the start of the stream itself.
+// refill count.
+//
+// Container invariant: bits == load64(in[ip:ip+8]) << bitsRead with the low
+// bitsRead bits zero, which is bitReaderShifted's own invariant, so the
+// state hands back to Go as it is. bitsRead is kept as the low byte of a
+// running sum of table entries (nBits in the low byte, the symbol above it),
+// which saves masking the entry per symbol: the symbol halves never carry
+// into the low byte because a group consumes fewer than 256 bits.
+//
+// Bounds work as in the 4X loop: a batch of inner iterations is bounded by
+// the output capacity (divided by the next power of two at or above nSyms)
+// and by the distance to the stream start (each refill reads the 8 bytes
+// below the window and moves it down by at most 7 bytes).
 func (d decompress1x) generateProcedure(name string, nSyms int) {
 	Package("github.com/klauspost/compress/huff0")
 	TEXT(name, 0, "func(ctx* decompress1xContext)")
-	doc := []string{fmt.Sprintf("%s decodes %d symbols per reload from one huff0 stream.", name, nSyms)}
-	if !d.bmi2 {
-		doc = append(doc, "avo stamps it as requiring BMI because of TZCNT, but it runs as BSF on CPUs without BMI1 (see reload).")
-	}
-	Doc(doc...)
+	Doc(fmt.Sprintf("%s decodes %d symbols per refill from one huff0 stream.", name, nSyms))
 	Pragma("noescape")
 
 	ctx := Dereference(Param("ctx"))
@@ -330,6 +329,7 @@ func (d decompress1x) generateProcedure(name string, nSyms int) {
 	ip := GP64()
 	ilowest := GP64()
 	bits := GP64()
+	bitsRead := GP64()
 
 	Comment("Preload values")
 	Load(ctx.Field("peekBits"), peekBits)
@@ -339,15 +339,11 @@ func (d decompress1x) generateProcedure(name string, nSyms int) {
 	ADDQ(op, limit)
 	Load(ctx.Field("ip"), ip)
 	Load(ctx.Field("ilowest"), ilowest)
-
-	Comment("Convert the bit reader to sentinel form: bits = value | 1<<bitsRead")
 	{
 		br := GP64()
 		Load(ctx.Field("pbr"), br)
-		tmp := GP64()
 		MOVQ(Mem{Base: br, Disp: bitReader_value}, bits)
-		MOVBQZX(Mem{Base: br, Disp: bitReader_bitsRead}, tmp)
-		BTSQ(tmp, bits)
+		MOVBQZX(Mem{Base: br, Disp: bitReader_bitsRead}, bitsRead)
 	}
 
 	inner := GP64()
@@ -364,8 +360,9 @@ func (d decompress1x) generateProcedure(name string, nSyms int) {
 		JLE(LabelRef("done"))
 		SHRQ(U8(outShift), iters)
 
-		Comment("Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes")
-		Comment("(whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.")
+		Comment("Iterations allowed by the input: a refill reads the 8 bytes below the window and")
+		Comment("moves it down by at most 7, so every read stays inside the stream while ip stays")
+		Comment("at least 8 above ilowest.")
 		t := GP64()
 		MOVQ(ip, t)
 		SUBQ(ilowest, t)
@@ -381,24 +378,24 @@ func (d decompress1x) generateProcedure(name string, nSyms int) {
 	Label("inner_loop")
 	for k := range nSyms {
 		Commentf("symbol %d", k)
-		d.decodeSymbol(k, bits, op, peekBits, table)
+		d.decodeSymbol(k, bits, bitsRead, op, peekBits, table)
 	}
-	Comment("Reload the bit container")
-	d.reload(bits, ip)
+	Comment("Refill the whole bytes consumed from below the window")
+	d.refill(bits, bitsRead, ip)
 	ADDQ(U8(nSyms), op)
 	CMPQ(op, inner)
 	JB(LabelRef("inner_loop"))
 	JMP(LabelRef("outer_loop"))
 
 	Label("done")
-	Comment("Hand the state back: off = ip - in, value = the sentinel-form container.")
-	Comment("bitReaderShifted.restoreFromAsm normalizes both.")
+	Comment("Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.")
 	{
 		br := GP64()
 		Load(ctx.Field("pbr"), br)
 		SUBQ(Mem{Base: br, Disp: bitReader_in}, ip)
 		MOVQ(ip, Mem{Base: br, Disp: bitReader_off})
 		MOVQ(bits, Mem{Base: br, Disp: bitReader_value})
+		MOVB(bitsRead.As8(), Mem{Base: br, Disp: bitReader_bitsRead})
 	}
 	{
 		ctxout, _ := ctx.Field("out").Resolve()
@@ -406,4 +403,66 @@ func (d decompress1x) generateProcedure(name string, nSyms int) {
 		Store(op, ctx.Field("decoded"))
 	}
 	RET()
+}
+
+// decodeSymbol decodes one symbol from bits into op[k]: peek the top
+// peekBits bits, look the entry up, shift the container by the entry's low
+// byte (its bit length; a shift count is taken mod 64, so the symbol half is
+// harmless), add the whole entry to the running consumed count and store
+// the entry's high byte (the symbol).
+func (d decompress1x) decodeSymbol(k int, bits, bitsRead, op, peekBits, table reg.GPVirtual) {
+	val := GP64()
+	if d.bmi2 {
+		SHRXQ(peekBits, bits, val)
+		MOVWQZX(Mem{Base: table, Index: val, Scale: 2}, val)
+		SHLXQ(val, bits, bits)
+		ADDQ(val, bitsRead)
+		SHRQ(U8(8), val)
+		MOVB(val.As8(), Mem{Base: op, Disp: k})
+		return
+	}
+	// x86 variable shifts take their count in CL, so the generic twin
+	// routes both counts through RCX.
+	MOVQ(peekBits, reg.RCX)
+	MOVQ(bits, val)
+	SHRQ(reg.CL, val)
+	MOVWQZX(Mem{Base: table, Index: val, Scale: 2}, reg.RCX)
+	SHLQ(reg.CL, bits)
+	ADDQ(reg.RCX, bitsRead)
+	SHRQ(U8(8), reg.RCX)
+	MOVB(reg.CL, Mem{Base: op, Disp: k})
+}
+
+// refill ORs the r = bitsRead&^7 consumed whole-byte bits back into the
+// container from the 8 bytes below the window: their top r bits, shifted
+// down to bit 0 and back up to sit just below the unread bits, which is
+// bitsRead&7. The window then moves down by r/8 bytes and bitsRead drops to
+// bitsRead&7. The right shift by 64-r is done as two shifts (1, then 63-r)
+// so that r == 0 contributes nothing; 63-r is 63^r because r is a multiple
+// of 8. Only the final OR depends on the container, so the refill costs the
+// serial chain one instruction.
+func (d decompress1x) refill(bits, bitsRead, ip reg.GPVirtual) {
+	r := GP64()
+	t := GP64()
+	MOVQ(bitsRead, r)
+	ANDQ(U8(56), r)
+	MOVQ(Mem{Base: ip, Disp: -8}, t)
+	SHRQ(U8(1), t)
+	ANDQ(U8(7), bitsRead)
+	if d.bmi2 {
+		s := GP64()
+		MOVQ(r, s)
+		XORQ(U8(63), s)
+		SHRXQ(s, t, t)
+		SHLXQ(bitsRead, t, t)
+	} else {
+		MOVQ(r, reg.RCX)
+		XORQ(U8(63), reg.RCX)
+		SHRQ(reg.CL, t)
+		MOVQ(bitsRead, reg.RCX)
+		SHLQ(reg.CL, t)
+	}
+	ORQ(t, bits)
+	SHRQ(U8(3), r)
+	SUBQ(r, ip)
 }

--- a/huff0/_generate/gen.go
+++ b/huff0/_generate/gen.go
@@ -7,12 +7,10 @@ import (
 	"flag"
 	"fmt"
 	mbits "math/bits"
-	"strconv"
 
 	_ "github.com/klauspost/compress"
 
 	. "github.com/mmcloughlin/avo/build"
-	"github.com/mmcloughlin/avo/gotypes"
 	. "github.com/mmcloughlin/avo/operand"
 	"github.com/mmcloughlin/avo/reg"
 )
@@ -24,29 +22,39 @@ func main() {
 
 	{
 		decompress := decompress4x{}
-		decompress.generateProcedure("decompress4x_main_loop_amd64", fast4XSymbols)
-		decompress.generateProcedure("decompress4x_8b_main_loop_amd64", fast4X8bSymbols)
-		decompress.generateProcedure("decompress4x_4b_main_loop_amd64", fast4X4bSymbols)
+		decompress.generateProcedure("decompress4x_main_loop_amd64", fastSymbols)
+		decompress.generateProcedure("decompress4x_8b_main_loop_amd64", fast8bSymbols)
+		decompress.generateProcedure("decompress4x_4b_main_loop_amd64", fast4bSymbols)
 
 		decompress.bmi2 = true
-		decompress.generateProcedure("decompress4x_main_loop_bmi2", fast4XSymbols)
-		decompress.generateProcedure("decompress4x_8b_main_loop_bmi2", fast4X8bSymbols)
-		decompress.generateProcedure("decompress4x_4b_main_loop_bmi2", fast4X4bSymbols)
+		decompress.generateProcedure("decompress4x_main_loop_bmi2", fastSymbols)
+		decompress.generateProcedure("decompress4x_8b_main_loop_bmi2", fast8bSymbols)
+		decompress.generateProcedure("decompress4x_4b_main_loop_bmi2", fast4bSymbols)
 	}
 
 	{
 		decompress := decompress1x{}
-		decompress.generateProcedure("decompress1x_main_loop_amd64")
+		decompress.generateProcedure("decompress1x_main_loop_amd64", fastSymbols)
+		decompress.generateProcedure("decompress1x_8b_main_loop_amd64", fast8bSymbols)
+		decompress.generateProcedure("decompress1x_4b_main_loop_amd64", fast4bSymbols)
 
 		decompress.bmi2 = true
-		decompress.generateProcedure("decompress1x_main_loop_bmi2")
+		decompress.generateProcedure("decompress1x_main_loop_bmi2", fastSymbols)
+		decompress.generateProcedure("decompress1x_8b_main_loop_bmi2", fast8bSymbols)
+		decompress.generateProcedure("decompress1x_4b_main_loop_bmi2", fast4bSymbols)
 	}
 
 	Generate()
 }
 
-type decompress4x struct {
+// sentinelLoop holds the per-symbol decode and the container reload shared
+// by the 4X and 1X loops, and the twin (generic or BMI2) being generated.
+type sentinelLoop struct {
 	bmi2 bool
+}
+
+type decompress4x struct {
+	sentinelLoop
 }
 
 // TODO [wmu]: I believe it's doable in avo, but can't figure out how to deal
@@ -57,16 +65,16 @@ const bitReader_value = bitReader_off + 8
 const bitReader_bitsRead = bitReader_value + 8
 const bitReader__size = bitReader_bitsRead + 8
 
-// Symbols decoded from each stream between reloads. The bit container holds
+// Symbols decoded from a stream between reloads. The bit container holds
 // a sentinel bit just below the unread bits, so the consumed count is its
 // trailing zero count and no separate bitsRead register is needed. A reload
 // leaves at most 7 consumed bits, so n symbols of at most b bits each need
 // 7+n*b <= 63 for the sentinel to survive and 64-(7+(n-1)*b) >= b valid bits
 // ahead of the last symbol: n*b <= 56.
 const (
-	fast4XSymbols   = 5  // tablelog 9..11: 5*11 = 55
-	fast4X8bSymbols = 7  // tablelog 5..8: 7*8 = 56
-	fast4X4bSymbols = 14 // tablelog <= 4: 14*4 = 56
+	fastSymbols   = 5  // tablelog 9..11: 5*11 = 55
+	fast8bSymbols = 7  // tablelog 5..8: 7*8 = 56
+	fast4bSymbols = 14 // tablelog <= 4: 14*4 = 56
 )
 
 // generateProcedure emits the Decompress4X main loop for one symbols-per-
@@ -231,7 +239,7 @@ func (d decompress4x) generateProcedure(name string, nSyms int) {
 // decodeSymbol decodes one symbol from bits into op[k]: peek the top
 // peekBits bits, look the entry up, shift the container by the entry's low
 // byte (its bit length) and store the entry's high byte (the symbol).
-func (d decompress4x) decodeSymbol(k int, bits, op, peekBits, table reg.GPVirtual) {
+func (d sentinelLoop) decodeSymbol(k int, bits, op, peekBits, table reg.GPVirtual) {
 	val := GP64()
 	if d.bmi2 {
 		SHRXQ(peekBits, bits, val)
@@ -253,10 +261,11 @@ func (d decompress4x) decodeSymbol(k int, bits, op, peekBits, table reg.GPVirtua
 }
 
 // reload tops up one bit container from its input pointer ip (a memory
-// operand): the trailing zero count is the number of consumed bits, whole
-// bytes move the pointer back, the fresh 8-byte window gets a new sentinel
-// in bit 0, and the 0-7 leftover bits are re-applied as a shift.
-func (d decompress4x) reload(bits reg.GPVirtual, ip Mem) {
+// operand or a register): the trailing zero count is the number of consumed
+// bits, whole bytes move the pointer back, the fresh 8-byte window gets a
+// new sentinel in bit 0, and the 0-7 leftover bits are re-applied as a
+// shift.
+func (d sentinelLoop) reload(bits reg.GPVirtual, ip Op) {
 	consumed := GP64()
 	// TZCNT rather than BSF in both twins: the sentinel guarantees a set
 	// bit, for which pre-BMI1 CPUs execute TZCNT (REP BSF) as BSF with the
@@ -272,12 +281,17 @@ func (d decompress4x) reload(bits reg.GPVirtual, ip Mem) {
 	MOVQ(consumed, nb)
 	ANDQ(U8(7), nb)
 	SHRQ(U8(3), consumed)
-	// The old container is dead once its zero count is taken, so it holds
-	// the input pointer until the fresh load overwrites it.
-	MOVQ(ip, bits)
-	SUBQ(consumed, bits)
-	MOVQ(bits, ip)
-	MOVQ(Mem{Base: bits}, bits)
+	if ipReg, ok := ip.(reg.GPVirtual); ok {
+		SUBQ(consumed, ipReg)
+		MOVQ(Mem{Base: ipReg}, bits)
+	} else {
+		// The old container is dead once its zero count is taken, so it
+		// holds the input pointer until the fresh load overwrites it.
+		MOVQ(ip, bits)
+		SUBQ(consumed, bits)
+		MOVQ(bits, ip)
+		MOVQ(Mem{Base: bits}, bits)
+	}
 	ORQ(U8(1), bits)
 	if d.bmi2 {
 		SHLXQ(nb, bits, bits)
@@ -286,193 +300,110 @@ func (d decompress4x) reload(bits reg.GPVirtual, ip Mem) {
 	}
 }
 
-type bitReader struct {
-	in       reg.GPVirtual
-	off      reg.GPVirtual
-	value    reg.GPVirtual
-	bitsRead reg.GPVirtual
-	id       int
-	bmi2     bool
-}
-
-func (b *bitReader) uniqId() string {
-	b.id += 1
-	return strconv.Itoa(b.id)
-}
-
-func (b *bitReader) load(pointer gotypes.Component) {
-	b.in = GP64()
-	b.off = GP64()
-	b.value = GP64()
-	b.bitsRead = GP64()
-
-	Load(pointer.Field("in").Base(), b.in)
-	Load(pointer.Field("off"), b.off)
-	Load(pointer.Field("value"), b.value)
-	Load(pointer.Field("bitsRead"), b.bitsRead)
-}
-
-func (b *bitReader) store(pointer gotypes.Component) {
-	Store(b.off, pointer.Field("off"))
-	Store(b.value, pointer.Field("value"))
-	// Note: explicit As8(), without this avo reports: "could not deduce mov instruction"
-	Store(b.bitsRead.As8(), pointer.Field("bitsRead"))
-}
-
-func (b *bitReader) fillFast() {
-	label := "bitReader_fillFast_" + b.uniqId() + "_end"
-	CMPQ(b.bitsRead, U8(32))
-	JL(LabelRef(label))
-
-	SUBQ(U8(32), b.bitsRead)
-	SUBQ(U8(4), b.off)
-
-	tmp := GP64()
-	MOVL(Mem{Base: b.in, Index: b.off, Scale: 1}, tmp.As32())
-	if b.bmi2 {
-		SHLXQ(b.bitsRead, tmp, tmp)
-	} else {
-		MOVQ(b.bitsRead, reg.RCX)
-		SHLQ(reg.CL, tmp)
-	}
-	ORQ(tmp, b.value)
-	Label(label)
-}
-
-func (b *bitReader) peekTopBits(n reg.GPVirtual) reg.GPVirtual {
-	res := GP64()
-	if b.bmi2 {
-		SHRXQ(n, b.value, res)
-	} else {
-		MOVQ(n, reg.RCX)
-		MOVQ(b.value, res)
-		SHRQ(reg.CL, res)
-	}
-
-	return res
-}
-
-func (b *bitReader) advance(n reg.Register) {
-	ADDQ(n, b.bitsRead)
-	if b.bmi2 {
-		SHLXQ(n, b.value, b.value)
-	} else {
-		MOVQ(n, reg.RCX)
-		SHLQ(reg.CL, b.value)
-	}
-}
-
+// decompress1x emits the Decompress1X main loops. A single stream, so the
+// container, the input pointer, the output pointer and both loop limits all
+// live in registers; otherwise it is the 4X loop with one stream.
 type decompress1x struct {
-	bmi2 bool
+	sentinelLoop
 }
 
-func (d decompress1x) generateProcedure(name string) {
+// generateProcedure emits the Decompress1X main loop for one symbols-per-
+// reload count. See decompress4x.generateProcedure for the bit container
+// layout and the reload; the bounds work the same way, except that the
+// output limit is the end of the buffer (one stream, no interleaving) and
+// the input bound is the start of the stream itself.
+func (d decompress1x) generateProcedure(name string, nSyms int) {
 	Package("github.com/klauspost/compress/huff0")
 	TEXT(name, 0, "func(ctx* decompress1xContext)")
-	Doc(name+" is an x86 assembler implementation of Decompress1X", "")
+	doc := []string{fmt.Sprintf("%s decodes %d symbols per reload from one huff0 stream.", name, nSyms)}
+	if !d.bmi2 {
+		doc = append(doc, "avo stamps it as requiring BMI because of TZCNT, but it runs as BSF on CPUs without BMI1 (see reload).")
+	}
+	Doc(doc...)
 	Pragma("noescape")
 
-	br := bitReader{}
-	br.bmi2 = d.bmi2
-
-	buffer := GP64()
-	bufferEnd := GP64() // the past-end address of buffer
-	dt := GP64()
+	ctx := Dereference(Param("ctx"))
 	peekBits := GP64()
+	table := GP64()
+	op := GP64()
+	limit := GP64()
+	ip := GP64()
+	ilowest := GP64()
+	bits := GP64()
 
+	Comment("Preload values")
+	Load(ctx.Field("peekBits"), peekBits)
+	Load(ctx.Field("tbl"), table)
+	Load(ctx.Field("out"), op)
+	Load(ctx.Field("outCap"), limit)
+	ADDQ(op, limit)
+	Load(ctx.Field("ip"), ip)
+	Load(ctx.Field("ilowest"), ilowest)
+
+	Comment("Convert the bit reader to sentinel form: bits = value | 1<<bitsRead")
 	{
-		ctx := Dereference(Param("ctx"))
-		Load(ctx.Field("out"), buffer)
-
-		outCap := GP64()
-		Load(ctx.Field("outCap"), outCap)
-		CMPQ(outCap, U8(4))
-		JB(LabelRef("error_max_decoded_size_exceeded"))
-
-		LEAQ(Mem{Base: buffer, Index: outCap, Scale: 1}, bufferEnd)
-
-		// load bitReader struct
-		pbr := Dereference(ctx.Field("pbr"))
-		br.load(pbr)
-
-		Load(ctx.Field("tbl"), dt)
-		Load(ctx.Field("peekBits"), peekBits)
-	}
-
-	JMP(LabelRef("loop_condition"))
-
-	Label("main_loop")
-
-	out := reg.AX // Fixed, as we need an 8H part
-
-	Comment("Check if we have room for 4 bytes in the output buffer")
-	{
+		br := GP64()
+		Load(ctx.Field("pbr"), br)
 		tmp := GP64()
-		LEAQ(Mem{Base: buffer, Disp: 4}, tmp)
-		CMPQ(tmp, bufferEnd)
-		JGE(LabelRef("error_max_decoded_size_exceeded"))
+		MOVQ(Mem{Base: br, Disp: bitReader_value}, bits)
+		MOVBQZX(Mem{Base: br, Disp: bitReader_bitsRead}, tmp)
+		BTSQ(tmp, bits)
 	}
 
-	decompress := func(id int, out reg.Register) {
-		d.decompress(id, &br, peekBits, dt, out)
-	}
-
-	Comment("Decode 4 values")
-	br.fillFast()
-	decompress(0, out.As8L())
-	decompress(1, out.As8H())
-	BSWAPL(out.As32())
-
-	br.fillFast()
-	decompress(2, out.As8H())
-	decompress(3, out.As8L())
-	BSWAPL(out.As32())
-
-	Comment("Store the decoded values")
-	MOVL(out.As32(), Mem{Base: buffer})
-	ADDQ(U8(4), buffer)
-
-	Label("loop_condition")
-	CMPQ(br.off, U8(8))
-	JGE(LabelRef("main_loop"))
-
-	Comment("Update ctx structure")
+	inner := GP64()
+	Label("outer_loop")
 	{
-		// calculate decoded as current `out` - initial `out`
-		ctx := Dereference(Param("ctx"))
+		outShift := mbits.Len(uint(nSyms - 1))
+		if nSyms > 1<<outShift {
+			panic("output bound does not cover nSyms")
+		}
+		Commentf("Iterations allowed by the output: (limit - op) / %d", 1<<outShift)
+		iters := GP64()
+		MOVQ(limit, iters)
+		SUBQ(op, iters)
+		JLE(LabelRef("done"))
+		SHRQ(U8(outShift), iters)
+
+		Comment("Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes")
+		Comment("(whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.")
+		t := GP64()
+		MOVQ(ip, t)
+		SUBQ(ilowest, t)
+		SHRQ(U8(3), t)
+		CMPQ(t, iters)
+		CMOVQCS(t, iters)
+		TESTQ(iters, iters)
+		JZ(LabelRef("done"))
+		IMUL3Q(Imm(uint64(nSyms)), iters, inner)
+		ADDQ(op, inner)
+	}
+
+	Label("inner_loop")
+	for k := range nSyms {
+		Commentf("symbol %d", k)
+		d.decodeSymbol(k, bits, op, peekBits, table)
+	}
+	Comment("Reload the bit container")
+	d.reload(bits, ip)
+	ADDQ(U8(nSyms), op)
+	CMPQ(op, inner)
+	JB(LabelRef("inner_loop"))
+	JMP(LabelRef("outer_loop"))
+
+	Label("done")
+	Comment("Hand the state back: off = ip - in, value = the sentinel-form container.")
+	Comment("bitReaderShifted.restoreFromAsm normalizes both.")
+	{
+		br := GP64()
+		Load(ctx.Field("pbr"), br)
+		SUBQ(Mem{Base: br, Disp: bitReader_in}, ip)
+		MOVQ(ip, Mem{Base: br, Disp: bitReader_off})
+		MOVQ(bits, Mem{Base: br, Disp: bitReader_value})
+	}
+	{
 		ctxout, _ := ctx.Field("out").Resolve()
-		decoded := buffer
-		SUBQ(ctxout.Addr, decoded)
-		Store(decoded, ctx.Field("decoded"))
-
-		pbr := Dereference(ctx.Field("pbr"))
-		br.store(pbr)
+		SUBQ(ctxout.Addr, op)
+		Store(op, ctx.Field("decoded"))
 	}
-
 	RET()
-
-	Comment("Report error")
-	Label("error_max_decoded_size_exceeded")
-	{
-		ctx := Dereference(Param("ctx"))
-		tmp := GP64()
-		MOVQ(I64(-1), tmp)
-		Store(tmp, ctx.Field("decoded"))
-	}
-
-	RET()
-}
-
-func (d decompress1x) decompress(id int, br *bitReader, peekBits, dt reg.GPVirtual, out reg.Register) {
-	// v := dt[br.peekBitsFast(d.actualTableLog)&tlMask]
-	k := br.peekTopBits(peekBits)
-	v := reg.RCX // Fixed, as we need 8H part
-	MOVWQZX(Mem{Base: dt, Index: k, Scale: 2}, v.As64())
-
-	// buf[id] = uint8(v.entry >> 8)
-	MOVB(v.As8H(), out)
-
-	// br.advance(uint8(v.entry))
-	MOVBQZX(v.As8L(), v)
-	br.advance(v)
 }

--- a/huff0/_generate/gen.go
+++ b/huff0/_generate/gen.go
@@ -71,6 +71,19 @@ const (
 	fast4bSymbols = 14 // tablelog <= 4: 14*4 = 56
 )
 
+// outputBoundShift returns the shift that divides an output byte budget by
+// the next power of two at or above nSyms, a cheap conservative bound on
+// the iterations a batch may run (5 and 7 -> 8, 14 -> 16). It panics if
+// the shift would not cover nSyms, since the loops write nSyms bytes per
+// iteration without further checks.
+func outputBoundShift(nSyms int) int {
+	shift := mbits.Len(uint(nSyms - 1))
+	if nSyms > 1<<shift {
+		panic("output bound does not cover nSyms")
+	}
+	return shift
+}
+
 // generateProcedure emits the Decompress4X main loop for one symbols-per-
 // reload count. It follows zstd's HUF_decompress4X1 fast loop.
 //
@@ -151,13 +164,8 @@ func (d decompress4x) generateProcedure(name string, nSyms int) {
 	{
 		// The outer loop only re-checks bounds after a whole batch of
 		// iterations, and each iteration writes nSyms bytes per stream, so
-		// the batch must satisfy iters*nSyms <= limit-op0. Dividing the byte
-		// budget by the next power of two at or above nSyms is a cheap
-		// conservative bound (5 and 7 -> 8, 14 -> 16).
-		outShift := mbits.Len(uint(nSyms - 1))
-		if nSyms > 1<<outShift {
-			panic("output bound does not cover nSyms")
-		}
+		// the batch must satisfy iters*nSyms <= limit-op0.
+		outShift := outputBoundShift(nSyms)
 		Commentf("Iterations allowed by the output: (limit - op0) / %d", 1<<outShift)
 		iters := GP64()
 		Load(ctx.Field("limit"), iters)
@@ -349,10 +357,7 @@ func (d decompress1x) generateProcedure(name string, nSyms int) {
 	inner := GP64()
 	Label("outer_loop")
 	{
-		outShift := mbits.Len(uint(nSyms - 1))
-		if nSyms > 1<<outShift {
-			panic("output bound does not cover nSyms")
-		}
+		outShift := outputBoundShift(nSyms)
 		Commentf("Iterations allowed by the output: (limit - op) / %d", 1<<outShift)
 		iters := GP64()
 		MOVQ(limit, iters)

--- a/huff0/decompress_amd64.go
+++ b/huff0/decompress_amd64.go
@@ -8,21 +8,21 @@ import (
 )
 
 // decompress4x_main_loop_amd64 is an x86 assembler implementation
-// of Decompress4X when tablelog > 8, decoding fast4XSymbols symbols per
+// of Decompress4X when tablelog > 8, decoding fastSymbols symbols per
 // stream between bit container reloads.
 //
 //go:noescape
 func decompress4x_main_loop_amd64(ctx *decompress4xContext)
 
 // decompress4x_8b_main_loop_amd64 is an x86 assembler implementation
-// of Decompress4X when tablelog <= 8, decoding fast4X8bSymbols symbols
+// of Decompress4X when tablelog <= 8, decoding fast8bSymbols symbols
 // per stream between bit container reloads.
 //
 //go:noescape
 func decompress4x_8b_main_loop_amd64(ctx *decompress4xContext)
 
 // decompress4x_4b_main_loop_amd64 is an x86 assembler implementation
-// of Decompress4X when tablelog <= 4, decoding fast4X4bSymbols symbols
+// of Decompress4X when tablelog <= 4, decoding fast4bSymbols symbols
 // per stream between bit container reloads.
 //
 //go:noescape
@@ -44,16 +44,40 @@ func decompress4x_main_loop_bmi2(ctx *decompress4xContext)
 func decompress4x_8b_main_loop_bmi2(ctx *decompress4xContext)
 
 // decompress1x_main_loop_amd64 is an x86 assembler implementation
-// of Decompress1X when tablelog > 8.
+// of Decompress1X when tablelog > 8, decoding fastSymbols symbols
+// between bit container reloads.
 //
 //go:noescape
 func decompress1x_main_loop_amd64(ctx *decompress1xContext)
 
-// decompress1x_main_loop_bmi2 is an x86 with BMI2 assembler implementation
-// of Decompress1X when tablelog > 8.
+// decompress1x_8b_main_loop_amd64 is an x86 assembler implementation
+// of Decompress1X when tablelog <= 8, decoding fast8bSymbols symbols
+// between bit container reloads.
+//
+//go:noescape
+func decompress1x_8b_main_loop_amd64(ctx *decompress1xContext)
+
+// decompress1x_4b_main_loop_amd64 is an x86 assembler implementation
+// of Decompress1X when tablelog <= 4, decoding fast4bSymbols symbols
+// between bit container reloads.
+//
+//go:noescape
+func decompress1x_4b_main_loop_amd64(ctx *decompress1xContext)
+
+// decompress1x_main_loop_bmi2 is the BMI2 twin of decompress1x_main_loop_amd64.
 //
 //go:noescape
 func decompress1x_main_loop_bmi2(ctx *decompress1xContext)
+
+// decompress1x_8b_main_loop_bmi2 is the BMI2 twin of decompress1x_8b_main_loop_amd64.
+//
+//go:noescape
+func decompress1x_8b_main_loop_bmi2(ctx *decompress1xContext)
+
+// decompress1x_4b_main_loop_bmi2 is the BMI2 twin of decompress1x_4b_main_loop_amd64.
+//
+//go:noescape
+func decompress1x_4b_main_loop_bmi2(ctx *decompress1xContext)
 
 func decompress4x_main_loop_asm(ctx *decompress4xContext) {
 	if cpuinfo.HasBMI2() {
@@ -84,5 +108,21 @@ func decompress1x_main_loop_asm(ctx *decompress1xContext) {
 		decompress1x_main_loop_bmi2(ctx)
 	} else {
 		decompress1x_main_loop_amd64(ctx)
+	}
+}
+
+func decompress1x_8b_main_loop_asm(ctx *decompress1xContext) {
+	if cpuinfo.HasBMI2() {
+		decompress1x_8b_main_loop_bmi2(ctx)
+	} else {
+		decompress1x_8b_main_loop_amd64(ctx)
+	}
+}
+
+func decompress1x_4b_main_loop_asm(ctx *decompress1xContext) {
+	if cpuinfo.HasBMI2() {
+		decompress1x_4b_main_loop_bmi2(ctx)
+	} else {
+		decompress1x_4b_main_loop_amd64(ctx)
 	}
 }

--- a/huff0/decompress_amd64.s
+++ b/huff0/decompress_amd64.s
@@ -2513,200 +2513,807 @@ done:
 	RET
 
 // func decompress1x_main_loop_amd64(ctx *decompress1xContext)
+// Requires: BMI, CMOV
 TEXT ·decompress1x_main_loop_amd64(SB), $0-8
-	MOVQ    ctx+0(FP), CX
-	MOVQ    16(CX), DX
-	MOVQ    24(CX), BX
-	CMPQ    BX, $0x04
-	JB      error_max_decoded_size_exceeded
-	LEAQ    (DX)(BX*1), BX
-	MOVQ    (CX), SI
-	MOVQ    (SI), R8
-	MOVQ    24(SI), R9
-	MOVQ    32(SI), R10
-	MOVBQZX 40(SI), R11
-	MOVQ    32(CX), SI
-	MOVBQZX 8(CX), DI
-	JMP     loop_condition
-
-main_loop:
-	// Check if we have room for 4 bytes in the output buffer
-	LEAQ 4(DX), CX
-	CMPQ CX, BX
-	JGE  error_max_decoded_size_exceeded
-
-	// Decode 4 values
-	CMPQ R11, $0x20
-	JL   bitReader_fillFast_1_end
-	SUBQ $0x20, R11
-	SUBQ $0x04, R9
-	MOVL (R8)(R9*1), R12
-	MOVQ R11, CX
-	SHLQ CL, R12
-	ORQ  R12, R10
-
-bitReader_fillFast_1_end:
-	MOVQ    DI, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (SI)(R12*2), CX
-	MOVB    CH, AL
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLQ    CL, R10
-	MOVQ    DI, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (SI)(R12*2), CX
-	MOVB    CH, AH
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLQ    CL, R10
-	BSWAPL  AX
-	CMPQ    R11, $0x20
-	JL      bitReader_fillFast_2_end
-	SUBQ    $0x20, R11
-	SUBQ    $0x04, R9
-	MOVL    (R8)(R9*1), R12
-	MOVQ    R11, CX
-	SHLQ    CL, R12
-	ORQ     R12, R10
-
-bitReader_fillFast_2_end:
-	MOVQ    DI, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (SI)(R12*2), CX
-	MOVB    CH, AH
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLQ    CL, R10
-	MOVQ    DI, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (SI)(R12*2), CX
-	MOVB    CH, AL
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLQ    CL, R10
-	BSWAPL  AX
-
-	// Store the decoded values
-	MOVL AX, (DX)
-	ADDQ $0x04, DX
-
-loop_condition:
-	CMPQ R9, $0x08
-	JGE  main_loop
-
-	// Update ctx structure
 	MOVQ ctx+0(FP), AX
-	SUBQ 16(AX), DX
-	MOVQ DX, 40(AX)
-	MOVQ (AX), AX
-	MOVQ R9, 24(AX)
-	MOVQ R10, 32(AX)
-	MOVB R11, 40(AX)
+
+	// Preload values
+	MOVBQZX 8(AX), DX
+	MOVQ    32(AX), BX
+	MOVQ    16(AX), SI
+	MOVQ    24(AX), DI
+	ADDQ    SI, DI
+	MOVQ    56(AX), R8
+	MOVQ    48(AX), R9
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVQ    (AX), CX
+	MOVQ    32(CX), R10
+	MOVBQZX 40(CX), CX
+	BTSQ    CX, R10
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 8
+	MOVQ DI, CX
+	SUBQ SI, CX
+	JLE  done
+	SHRQ $0x03, CX
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVQ    R8, R11
+	SUBQ    R9, R11
+	SHRQ    $0x03, R11
+	CMPQ    R11, CX
+	CMOVQCS R11, CX
+	TESTQ   CX, CX
+	JZ      done
+	IMUL3Q  $0x05, CX, R11
+	ADDQ    SI, R11
+
+inner_loop:
+	// symbol 0
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, (SI)
+
+	// symbol 1
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 1(SI)
+
+	// symbol 2
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 2(SI)
+
+	// symbol 3
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 3(SI)
+
+	// symbol 4
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 4(SI)
+
+	// Reload the bit container
+	TZCNTQ R10, R10
+	MOVQ   R10, CX
+	ANDQ   $0x07, CX
+	SHRQ   $0x03, R10
+	SUBQ   R10, R8
+	MOVQ   (R8), R10
+	ORQ    $0x01, R10
+	SHLQ   CL, R10
+	ADDQ   $0x05, SI
+	CMPQ   SI, R11
+	JB     inner_loop
+	JMP    outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVQ (AX), CX
+	SUBQ (CX), R8
+	MOVQ R8, 24(CX)
+	MOVQ R10, 32(CX)
+	SUBQ 16(AX), SI
+	MOVQ SI, 40(AX)
 	RET
 
-	// Report error
-error_max_decoded_size_exceeded:
+// func decompress1x_8b_main_loop_amd64(ctx *decompress1xContext)
+// Requires: BMI, CMOV
+TEXT ·decompress1x_8b_main_loop_amd64(SB), $0-8
 	MOVQ ctx+0(FP), AX
-	MOVQ $-1, CX
-	MOVQ CX, 40(AX)
+
+	// Preload values
+	MOVBQZX 8(AX), DX
+	MOVQ    32(AX), BX
+	MOVQ    16(AX), SI
+	MOVQ    24(AX), DI
+	ADDQ    SI, DI
+	MOVQ    56(AX), R8
+	MOVQ    48(AX), R9
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVQ    (AX), CX
+	MOVQ    32(CX), R10
+	MOVBQZX 40(CX), CX
+	BTSQ    CX, R10
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 8
+	MOVQ DI, CX
+	SUBQ SI, CX
+	JLE  done
+	SHRQ $0x03, CX
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVQ    R8, R11
+	SUBQ    R9, R11
+	SHRQ    $0x03, R11
+	CMPQ    R11, CX
+	CMOVQCS R11, CX
+	TESTQ   CX, CX
+	JZ      done
+	IMUL3Q  $0x07, CX, R11
+	ADDQ    SI, R11
+
+inner_loop:
+	// symbol 0
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, (SI)
+
+	// symbol 1
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 1(SI)
+
+	// symbol 2
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 2(SI)
+
+	// symbol 3
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 3(SI)
+
+	// symbol 4
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 4(SI)
+
+	// symbol 5
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 5(SI)
+
+	// symbol 6
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 6(SI)
+
+	// Reload the bit container
+	TZCNTQ R10, R10
+	MOVQ   R10, CX
+	ANDQ   $0x07, CX
+	SHRQ   $0x03, R10
+	SUBQ   R10, R8
+	MOVQ   (R8), R10
+	ORQ    $0x01, R10
+	SHLQ   CL, R10
+	ADDQ   $0x07, SI
+	CMPQ   SI, R11
+	JB     inner_loop
+	JMP    outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVQ (AX), CX
+	SUBQ (CX), R8
+	MOVQ R8, 24(CX)
+	MOVQ R10, 32(CX)
+	SUBQ 16(AX), SI
+	MOVQ SI, 40(AX)
+	RET
+
+// func decompress1x_4b_main_loop_amd64(ctx *decompress1xContext)
+// Requires: BMI, CMOV
+TEXT ·decompress1x_4b_main_loop_amd64(SB), $0-8
+	MOVQ ctx+0(FP), AX
+
+	// Preload values
+	MOVBQZX 8(AX), DX
+	MOVQ    32(AX), BX
+	MOVQ    16(AX), SI
+	MOVQ    24(AX), DI
+	ADDQ    SI, DI
+	MOVQ    56(AX), R8
+	MOVQ    48(AX), R9
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVQ    (AX), CX
+	MOVQ    32(CX), R10
+	MOVBQZX 40(CX), CX
+	BTSQ    CX, R10
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 16
+	MOVQ DI, CX
+	SUBQ SI, CX
+	JLE  done
+	SHRQ $0x04, CX
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVQ    R8, R11
+	SUBQ    R9, R11
+	SHRQ    $0x03, R11
+	CMPQ    R11, CX
+	CMOVQCS R11, CX
+	TESTQ   CX, CX
+	JZ      done
+	IMUL3Q  $0x0e, CX, R11
+	ADDQ    SI, R11
+
+inner_loop:
+	// symbol 0
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, (SI)
+
+	// symbol 1
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 1(SI)
+
+	// symbol 2
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 2(SI)
+
+	// symbol 3
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 3(SI)
+
+	// symbol 4
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 4(SI)
+
+	// symbol 5
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 5(SI)
+
+	// symbol 6
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 6(SI)
+
+	// symbol 7
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 7(SI)
+
+	// symbol 8
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 8(SI)
+
+	// symbol 9
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 9(SI)
+
+	// symbol 10
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 10(SI)
+
+	// symbol 11
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 11(SI)
+
+	// symbol 12
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 12(SI)
+
+	// symbol 13
+	MOVQ    DX, CX
+	MOVQ    R10, R12
+	SHRQ    CL, R12
+	MOVWQZX (BX)(R12*2), CX
+	SHLQ    CL, R10
+	SHRQ    $0x08, CX
+	MOVB    CL, 13(SI)
+
+	// Reload the bit container
+	TZCNTQ R10, R10
+	MOVQ   R10, CX
+	ANDQ   $0x07, CX
+	SHRQ   $0x03, R10
+	SUBQ   R10, R8
+	MOVQ   (R8), R10
+	ORQ    $0x01, R10
+	SHLQ   CL, R10
+	ADDQ   $0x0e, SI
+	CMPQ   SI, R11
+	JB     inner_loop
+	JMP    outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVQ (AX), CX
+	SUBQ (CX), R8
+	MOVQ R8, 24(CX)
+	MOVQ R10, 32(CX)
+	SUBQ 16(AX), SI
+	MOVQ SI, 40(AX)
 	RET
 
 // func decompress1x_main_loop_bmi2(ctx *decompress1xContext)
-// Requires: BMI2
+// Requires: BMI, BMI2, CMOV
 TEXT ·decompress1x_main_loop_bmi2(SB), $0-8
-	MOVQ    ctx+0(FP), CX
-	MOVQ    16(CX), DX
-	MOVQ    24(CX), BX
-	CMPQ    BX, $0x04
-	JB      error_max_decoded_size_exceeded
-	LEAQ    (DX)(BX*1), BX
-	MOVQ    (CX), SI
-	MOVQ    (SI), R8
-	MOVQ    24(SI), R9
-	MOVQ    32(SI), R10
-	MOVBQZX 40(SI), R11
-	MOVQ    32(CX), SI
-	MOVBQZX 8(CX), DI
-	JMP     loop_condition
-
-main_loop:
-	// Check if we have room for 4 bytes in the output buffer
-	LEAQ 4(DX), CX
-	CMPQ CX, BX
-	JGE  error_max_decoded_size_exceeded
-
-	// Decode 4 values
-	CMPQ  R11, $0x20
-	JL    bitReader_fillFast_1_end
-	SUBQ  $0x20, R11
-	SUBQ  $0x04, R9
-	MOVL  (R8)(R9*1), CX
-	SHLXQ R11, CX, CX
-	ORQ   CX, R10
-
-bitReader_fillFast_1_end:
-	SHRXQ   DI, R10, CX
-	MOVWQZX (SI)(CX*2), CX
-	MOVB    CH, AL
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLXQ   CX, R10, R10
-	SHRXQ   DI, R10, CX
-	MOVWQZX (SI)(CX*2), CX
-	MOVB    CH, AH
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLXQ   CX, R10, R10
-	BSWAPL  AX
-	CMPQ    R11, $0x20
-	JL      bitReader_fillFast_2_end
-	SUBQ    $0x20, R11
-	SUBQ    $0x04, R9
-	MOVL    (R8)(R9*1), CX
-	SHLXQ   R11, CX, CX
-	ORQ     CX, R10
-
-bitReader_fillFast_2_end:
-	SHRXQ   DI, R10, CX
-	MOVWQZX (SI)(CX*2), CX
-	MOVB    CH, AH
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLXQ   CX, R10, R10
-	SHRXQ   DI, R10, CX
-	MOVWQZX (SI)(CX*2), CX
-	MOVB    CH, AL
-	MOVBQZX CL, CX
-	ADDQ    CX, R11
-	SHLXQ   CX, R10, R10
-	BSWAPL  AX
-
-	// Store the decoded values
-	MOVL AX, (DX)
-	ADDQ $0x04, DX
-
-loop_condition:
-	CMPQ R9, $0x08
-	JGE  main_loop
-
-	// Update ctx structure
 	MOVQ ctx+0(FP), AX
-	SUBQ 16(AX), DX
-	MOVQ DX, 40(AX)
-	MOVQ (AX), AX
-	MOVQ R9, 24(AX)
-	MOVQ R10, 32(AX)
-	MOVB R11, 40(AX)
+
+	// Preload values
+	MOVBQZX 8(AX), CX
+	MOVQ    32(AX), DX
+	MOVQ    16(AX), BX
+	MOVQ    24(AX), SI
+	ADDQ    BX, SI
+	MOVQ    56(AX), DI
+	MOVQ    48(AX), R8
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVQ    (AX), R10
+	MOVQ    32(R10), R9
+	MOVBQZX 40(R10), R10
+	BTSQ    R10, R9
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 8
+	MOVQ SI, R10
+	SUBQ BX, R10
+	JLE  done
+	SHRQ $0x03, R10
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVQ    DI, R11
+	SUBQ    R8, R11
+	SHRQ    $0x03, R11
+	CMPQ    R11, R10
+	CMOVQCS R11, R10
+	TESTQ   R10, R10
+	JZ      done
+	IMUL3Q  $0x05, R10, R10
+	ADDQ    BX, R10
+
+inner_loop:
+	// symbol 0
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, (BX)
+
+	// symbol 1
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 1(BX)
+
+	// symbol 2
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 2(BX)
+
+	// symbol 3
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 3(BX)
+
+	// symbol 4
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 4(BX)
+
+	// Reload the bit container
+	TZCNTQ R9, R9
+	MOVQ   R9, R11
+	ANDQ   $0x07, R11
+	SHRQ   $0x03, R9
+	SUBQ   R9, DI
+	MOVQ   (DI), R9
+	ORQ    $0x01, R9
+	SHLXQ  R11, R9, R9
+	ADDQ   $0x05, BX
+	CMPQ   BX, R10
+	JB     inner_loop
+	JMP    outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVQ (AX), CX
+	SUBQ (CX), DI
+	MOVQ DI, 24(CX)
+	MOVQ R9, 32(CX)
+	SUBQ 16(AX), BX
+	MOVQ BX, 40(AX)
 	RET
 
-	// Report error
-error_max_decoded_size_exceeded:
+// func decompress1x_8b_main_loop_bmi2(ctx *decompress1xContext)
+// Requires: BMI, BMI2, CMOV
+TEXT ·decompress1x_8b_main_loop_bmi2(SB), $0-8
 	MOVQ ctx+0(FP), AX
-	MOVQ $-1, CX
-	MOVQ CX, 40(AX)
+
+	// Preload values
+	MOVBQZX 8(AX), CX
+	MOVQ    32(AX), DX
+	MOVQ    16(AX), BX
+	MOVQ    24(AX), SI
+	ADDQ    BX, SI
+	MOVQ    56(AX), DI
+	MOVQ    48(AX), R8
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVQ    (AX), R10
+	MOVQ    32(R10), R9
+	MOVBQZX 40(R10), R10
+	BTSQ    R10, R9
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 8
+	MOVQ SI, R10
+	SUBQ BX, R10
+	JLE  done
+	SHRQ $0x03, R10
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVQ    DI, R11
+	SUBQ    R8, R11
+	SHRQ    $0x03, R11
+	CMPQ    R11, R10
+	CMOVQCS R11, R10
+	TESTQ   R10, R10
+	JZ      done
+	IMUL3Q  $0x07, R10, R10
+	ADDQ    BX, R10
+
+inner_loop:
+	// symbol 0
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, (BX)
+
+	// symbol 1
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 1(BX)
+
+	// symbol 2
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 2(BX)
+
+	// symbol 3
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 3(BX)
+
+	// symbol 4
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 4(BX)
+
+	// symbol 5
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 5(BX)
+
+	// symbol 6
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 6(BX)
+
+	// Reload the bit container
+	TZCNTQ R9, R9
+	MOVQ   R9, R11
+	ANDQ   $0x07, R11
+	SHRQ   $0x03, R9
+	SUBQ   R9, DI
+	MOVQ   (DI), R9
+	ORQ    $0x01, R9
+	SHLXQ  R11, R9, R9
+	ADDQ   $0x07, BX
+	CMPQ   BX, R10
+	JB     inner_loop
+	JMP    outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVQ (AX), CX
+	SUBQ (CX), DI
+	MOVQ DI, 24(CX)
+	MOVQ R9, 32(CX)
+	SUBQ 16(AX), BX
+	MOVQ BX, 40(AX)
+	RET
+
+// func decompress1x_4b_main_loop_bmi2(ctx *decompress1xContext)
+// Requires: BMI, BMI2, CMOV
+TEXT ·decompress1x_4b_main_loop_bmi2(SB), $0-8
+	MOVQ ctx+0(FP), AX
+
+	// Preload values
+	MOVBQZX 8(AX), CX
+	MOVQ    32(AX), DX
+	MOVQ    16(AX), BX
+	MOVQ    24(AX), SI
+	ADDQ    BX, SI
+	MOVQ    56(AX), DI
+	MOVQ    48(AX), R8
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVQ    (AX), R10
+	MOVQ    32(R10), R9
+	MOVBQZX 40(R10), R10
+	BTSQ    R10, R9
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 16
+	MOVQ SI, R10
+	SUBQ BX, R10
+	JLE  done
+	SHRQ $0x04, R10
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVQ    DI, R11
+	SUBQ    R8, R11
+	SHRQ    $0x03, R11
+	CMPQ    R11, R10
+	CMOVQCS R11, R10
+	TESTQ   R10, R10
+	JZ      done
+	IMUL3Q  $0x0e, R10, R10
+	ADDQ    BX, R10
+
+inner_loop:
+	// symbol 0
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, (BX)
+
+	// symbol 1
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 1(BX)
+
+	// symbol 2
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 2(BX)
+
+	// symbol 3
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 3(BX)
+
+	// symbol 4
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 4(BX)
+
+	// symbol 5
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 5(BX)
+
+	// symbol 6
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 6(BX)
+
+	// symbol 7
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 7(BX)
+
+	// symbol 8
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 8(BX)
+
+	// symbol 9
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 9(BX)
+
+	// symbol 10
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 10(BX)
+
+	// symbol 11
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 11(BX)
+
+	// symbol 12
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 12(BX)
+
+	// symbol 13
+	SHRXQ   CX, R9, R11
+	MOVWQZX (DX)(R11*2), R11
+	SHLXQ   R11, R9, R9
+	SHRQ    $0x08, R11
+	MOVB    R11, 13(BX)
+
+	// Reload the bit container
+	TZCNTQ R9, R9
+	MOVQ   R9, R11
+	ANDQ   $0x07, R11
+	SHRQ   $0x03, R9
+	SUBQ   R9, DI
+	MOVQ   (DI), R9
+	ORQ    $0x01, R9
+	SHLXQ  R11, R9, R9
+	ADDQ   $0x0e, BX
+	CMPQ   BX, R10
+	JB     inner_loop
+	JMP    outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVQ (AX), CX
+	SUBQ (CX), DI
+	MOVQ DI, 24(CX)
+	MOVQ R9, 32(CX)
+	SUBQ 16(AX), BX
+	MOVQ BX, 40(AX)
 	RET

--- a/huff0/decompress_amd64.s
+++ b/huff0/decompress_amd64.s
@@ -2513,7 +2513,7 @@ done:
 	RET
 
 // func decompress1x_main_loop_amd64(ctx *decompress1xContext)
-// Requires: BMI, CMOV
+// Requires: CMOV
 TEXT ·decompress1x_main_loop_amd64(SB), $0-8
 	MOVQ ctx+0(FP), AX
 
@@ -2525,12 +2525,9 @@ TEXT ·decompress1x_main_loop_amd64(SB), $0-8
 	ADDQ    SI, DI
 	MOVQ    56(AX), R8
 	MOVQ    48(AX), R9
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVQ    (AX), CX
 	MOVQ    32(CX), R10
-	MOVBQZX 40(CX), CX
-	BTSQ    CX, R10
+	MOVBQZX 40(CX), R11
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 8
@@ -2539,91 +2536,102 @@ outer_loop:
 	JLE  done
 	SHRQ $0x03, CX
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVQ    R8, R11
-	SUBQ    R9, R11
-	SHRQ    $0x03, R11
-	CMPQ    R11, CX
-	CMOVQCS R11, CX
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVQ    R8, R12
+	SUBQ    R9, R12
+	SHRQ    $0x03, R12
+	CMPQ    R12, CX
+	CMOVQCS R12, CX
 	TESTQ   CX, CX
 	JZ      done
-	IMUL3Q  $0x05, CX, R11
-	ADDQ    SI, R11
+	IMUL3Q  $0x05, CX, R12
+	ADDQ    SI, R12
 
 inner_loop:
 	// symbol 0
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, (SI)
 
 	// symbol 1
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 1(SI)
 
 	// symbol 2
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 2(SI)
 
 	// symbol 3
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 3(SI)
 
 	// symbol 4
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 4(SI)
 
-	// Reload the bit container
-	TZCNTQ R10, R10
-	MOVQ   R10, CX
-	ANDQ   $0x07, CX
-	SHRQ   $0x03, R10
-	SUBQ   R10, R8
-	MOVQ   (R8), R10
-	ORQ    $0x01, R10
-	SHLQ   CL, R10
-	ADDQ   $0x05, SI
-	CMPQ   SI, R11
-	JB     inner_loop
-	JMP    outer_loop
+	// Refill the whole bytes consumed from below the window
+	MOVQ R11, R13
+	ANDQ $0x38, R13
+	MOVQ -8(R8), R14
+	SHRQ $0x01, R14
+	ANDQ $0x07, R11
+	MOVQ R13, CX
+	XORQ $0x3f, CX
+	SHRQ CL, R14
+	MOVQ R11, CX
+	SHLQ CL, R14
+	ORQ  R14, R10
+	SHRQ $0x03, R13
+	SUBQ R13, R8
+	ADDQ $0x05, SI
+	CMPQ SI, R12
+	JB   inner_loop
+	JMP  outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVQ (AX), CX
 	SUBQ (CX), R8
 	MOVQ R8, 24(CX)
 	MOVQ R10, 32(CX)
+	MOVB R11, 40(CX)
 	SUBQ 16(AX), SI
 	MOVQ SI, 40(AX)
 	RET
 
 // func decompress1x_8b_main_loop_amd64(ctx *decompress1xContext)
-// Requires: BMI, CMOV
+// Requires: CMOV
 TEXT ·decompress1x_8b_main_loop_amd64(SB), $0-8
 	MOVQ ctx+0(FP), AX
 
@@ -2635,12 +2643,9 @@ TEXT ·decompress1x_8b_main_loop_amd64(SB), $0-8
 	ADDQ    SI, DI
 	MOVQ    56(AX), R8
 	MOVQ    48(AX), R9
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVQ    (AX), CX
 	MOVQ    32(CX), R10
-	MOVBQZX 40(CX), CX
-	BTSQ    CX, R10
+	MOVBQZX 40(CX), R11
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 8
@@ -2649,109 +2654,122 @@ outer_loop:
 	JLE  done
 	SHRQ $0x03, CX
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVQ    R8, R11
-	SUBQ    R9, R11
-	SHRQ    $0x03, R11
-	CMPQ    R11, CX
-	CMOVQCS R11, CX
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVQ    R8, R12
+	SUBQ    R9, R12
+	SHRQ    $0x03, R12
+	CMPQ    R12, CX
+	CMOVQCS R12, CX
 	TESTQ   CX, CX
 	JZ      done
-	IMUL3Q  $0x07, CX, R11
-	ADDQ    SI, R11
+	IMUL3Q  $0x07, CX, R12
+	ADDQ    SI, R12
 
 inner_loop:
 	// symbol 0
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, (SI)
 
 	// symbol 1
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 1(SI)
 
 	// symbol 2
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 2(SI)
 
 	// symbol 3
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 3(SI)
 
 	// symbol 4
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 4(SI)
 
 	// symbol 5
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 5(SI)
 
 	// symbol 6
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 6(SI)
 
-	// Reload the bit container
-	TZCNTQ R10, R10
-	MOVQ   R10, CX
-	ANDQ   $0x07, CX
-	SHRQ   $0x03, R10
-	SUBQ   R10, R8
-	MOVQ   (R8), R10
-	ORQ    $0x01, R10
-	SHLQ   CL, R10
-	ADDQ   $0x07, SI
-	CMPQ   SI, R11
-	JB     inner_loop
-	JMP    outer_loop
+	// Refill the whole bytes consumed from below the window
+	MOVQ R11, R13
+	ANDQ $0x38, R13
+	MOVQ -8(R8), R14
+	SHRQ $0x01, R14
+	ANDQ $0x07, R11
+	MOVQ R13, CX
+	XORQ $0x3f, CX
+	SHRQ CL, R14
+	MOVQ R11, CX
+	SHLQ CL, R14
+	ORQ  R14, R10
+	SHRQ $0x03, R13
+	SUBQ R13, R8
+	ADDQ $0x07, SI
+	CMPQ SI, R12
+	JB   inner_loop
+	JMP  outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVQ (AX), CX
 	SUBQ (CX), R8
 	MOVQ R8, 24(CX)
 	MOVQ R10, 32(CX)
+	MOVB R11, 40(CX)
 	SUBQ 16(AX), SI
 	MOVQ SI, 40(AX)
 	RET
 
 // func decompress1x_4b_main_loop_amd64(ctx *decompress1xContext)
-// Requires: BMI, CMOV
+// Requires: CMOV
 TEXT ·decompress1x_4b_main_loop_amd64(SB), $0-8
 	MOVQ ctx+0(FP), AX
 
@@ -2763,12 +2781,9 @@ TEXT ·decompress1x_4b_main_loop_amd64(SB), $0-8
 	ADDQ    SI, DI
 	MOVQ    56(AX), R8
 	MOVQ    48(AX), R9
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVQ    (AX), CX
 	MOVQ    32(CX), R10
-	MOVBQZX 40(CX), CX
-	BTSQ    CX, R10
+	MOVBQZX 40(CX), R11
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 16
@@ -2777,172 +2792,192 @@ outer_loop:
 	JLE  done
 	SHRQ $0x04, CX
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVQ    R8, R11
-	SUBQ    R9, R11
-	SHRQ    $0x03, R11
-	CMPQ    R11, CX
-	CMOVQCS R11, CX
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVQ    R8, R12
+	SUBQ    R9, R12
+	SHRQ    $0x03, R12
+	CMPQ    R12, CX
+	CMOVQCS R12, CX
 	TESTQ   CX, CX
 	JZ      done
-	IMUL3Q  $0x0e, CX, R11
-	ADDQ    SI, R11
+	IMUL3Q  $0x0e, CX, R12
+	ADDQ    SI, R12
 
 inner_loop:
 	// symbol 0
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, (SI)
 
 	// symbol 1
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 1(SI)
 
 	// symbol 2
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 2(SI)
 
 	// symbol 3
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 3(SI)
 
 	// symbol 4
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 4(SI)
 
 	// symbol 5
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 5(SI)
 
 	// symbol 6
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 6(SI)
 
 	// symbol 7
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 7(SI)
 
 	// symbol 8
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 8(SI)
 
 	// symbol 9
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 9(SI)
 
 	// symbol 10
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 10(SI)
 
 	// symbol 11
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 11(SI)
 
 	// symbol 12
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 12(SI)
 
 	// symbol 13
 	MOVQ    DX, CX
-	MOVQ    R10, R12
-	SHRQ    CL, R12
-	MOVWQZX (BX)(R12*2), CX
+	MOVQ    R10, R13
+	SHRQ    CL, R13
+	MOVWQZX (BX)(R13*2), CX
 	SHLQ    CL, R10
+	ADDQ    CX, R11
 	SHRQ    $0x08, CX
 	MOVB    CL, 13(SI)
 
-	// Reload the bit container
-	TZCNTQ R10, R10
-	MOVQ   R10, CX
-	ANDQ   $0x07, CX
-	SHRQ   $0x03, R10
-	SUBQ   R10, R8
-	MOVQ   (R8), R10
-	ORQ    $0x01, R10
-	SHLQ   CL, R10
-	ADDQ   $0x0e, SI
-	CMPQ   SI, R11
-	JB     inner_loop
-	JMP    outer_loop
+	// Refill the whole bytes consumed from below the window
+	MOVQ R11, R13
+	ANDQ $0x38, R13
+	MOVQ -8(R8), R14
+	SHRQ $0x01, R14
+	ANDQ $0x07, R11
+	MOVQ R13, CX
+	XORQ $0x3f, CX
+	SHRQ CL, R14
+	MOVQ R11, CX
+	SHLQ CL, R14
+	ORQ  R14, R10
+	SHRQ $0x03, R13
+	SUBQ R13, R8
+	ADDQ $0x0e, SI
+	CMPQ SI, R12
+	JB   inner_loop
+	JMP  outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVQ (AX), CX
 	SUBQ (CX), R8
 	MOVQ R8, 24(CX)
 	MOVQ R10, 32(CX)
+	MOVB R11, 40(CX)
 	SUBQ 16(AX), SI
 	MOVQ SI, 40(AX)
 	RET
 
 // func decompress1x_main_loop_bmi2(ctx *decompress1xContext)
-// Requires: BMI, BMI2, CMOV
+// Requires: BMI2, CMOV
 TEXT ·decompress1x_main_loop_bmi2(SB), $0-8
 	MOVQ ctx+0(FP), AX
 
@@ -2954,95 +2989,102 @@ TEXT ·decompress1x_main_loop_bmi2(SB), $0-8
 	ADDQ    BX, SI
 	MOVQ    56(AX), DI
 	MOVQ    48(AX), R8
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVQ    (AX), R10
 	MOVQ    32(R10), R9
 	MOVBQZX 40(R10), R10
-	BTSQ    R10, R9
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 8
-	MOVQ SI, R10
-	SUBQ BX, R10
+	MOVQ SI, R11
+	SUBQ BX, R11
 	JLE  done
-	SHRQ $0x03, R10
+	SHRQ $0x03, R11
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVQ    DI, R11
-	SUBQ    R8, R11
-	SHRQ    $0x03, R11
-	CMPQ    R11, R10
-	CMOVQCS R11, R10
-	TESTQ   R10, R10
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVQ    DI, R12
+	SUBQ    R8, R12
+	SHRQ    $0x03, R12
+	CMPQ    R12, R11
+	CMOVQCS R12, R11
+	TESTQ   R11, R11
 	JZ      done
-	IMUL3Q  $0x05, R10, R10
-	ADDQ    BX, R10
+	IMUL3Q  $0x05, R11, R11
+	ADDQ    BX, R11
 
 inner_loop:
 	// symbol 0
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, (BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, (BX)
 
 	// symbol 1
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 1(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 1(BX)
 
 	// symbol 2
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 2(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 2(BX)
 
 	// symbol 3
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 3(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 3(BX)
 
 	// symbol 4
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 4(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 4(BX)
 
-	// Reload the bit container
-	TZCNTQ R9, R9
-	MOVQ   R9, R11
-	ANDQ   $0x07, R11
-	SHRQ   $0x03, R9
-	SUBQ   R9, DI
-	MOVQ   (DI), R9
-	ORQ    $0x01, R9
-	SHLXQ  R11, R9, R9
-	ADDQ   $0x05, BX
-	CMPQ   BX, R10
-	JB     inner_loop
-	JMP    outer_loop
+	// Refill the whole bytes consumed from below the window
+	MOVQ  R10, R12
+	ANDQ  $0x38, R12
+	MOVQ  -8(DI), R13
+	SHRQ  $0x01, R13
+	ANDQ  $0x07, R10
+	MOVQ  R12, R14
+	XORQ  $0x3f, R14
+	SHRXQ R14, R13, R13
+	SHLXQ R10, R13, R13
+	ORQ   R13, R9
+	SHRQ  $0x03, R12
+	SUBQ  R12, DI
+	ADDQ  $0x05, BX
+	CMPQ  BX, R11
+	JB    inner_loop
+	JMP   outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVQ (AX), CX
 	SUBQ (CX), DI
 	MOVQ DI, 24(CX)
 	MOVQ R9, 32(CX)
+	MOVB R10, 40(CX)
 	SUBQ 16(AX), BX
 	MOVQ BX, 40(AX)
 	RET
 
 // func decompress1x_8b_main_loop_bmi2(ctx *decompress1xContext)
-// Requires: BMI, BMI2, CMOV
+// Requires: BMI2, CMOV
 TEXT ·decompress1x_8b_main_loop_bmi2(SB), $0-8
 	MOVQ ctx+0(FP), AX
 
@@ -3054,109 +3096,118 @@ TEXT ·decompress1x_8b_main_loop_bmi2(SB), $0-8
 	ADDQ    BX, SI
 	MOVQ    56(AX), DI
 	MOVQ    48(AX), R8
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVQ    (AX), R10
 	MOVQ    32(R10), R9
 	MOVBQZX 40(R10), R10
-	BTSQ    R10, R9
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 8
-	MOVQ SI, R10
-	SUBQ BX, R10
+	MOVQ SI, R11
+	SUBQ BX, R11
 	JLE  done
-	SHRQ $0x03, R10
+	SHRQ $0x03, R11
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVQ    DI, R11
-	SUBQ    R8, R11
-	SHRQ    $0x03, R11
-	CMPQ    R11, R10
-	CMOVQCS R11, R10
-	TESTQ   R10, R10
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVQ    DI, R12
+	SUBQ    R8, R12
+	SHRQ    $0x03, R12
+	CMPQ    R12, R11
+	CMOVQCS R12, R11
+	TESTQ   R11, R11
 	JZ      done
-	IMUL3Q  $0x07, R10, R10
-	ADDQ    BX, R10
+	IMUL3Q  $0x07, R11, R11
+	ADDQ    BX, R11
 
 inner_loop:
 	// symbol 0
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, (BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, (BX)
 
 	// symbol 1
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 1(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 1(BX)
 
 	// symbol 2
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 2(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 2(BX)
 
 	// symbol 3
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 3(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 3(BX)
 
 	// symbol 4
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 4(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 4(BX)
 
 	// symbol 5
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 5(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 5(BX)
 
 	// symbol 6
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 6(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 6(BX)
 
-	// Reload the bit container
-	TZCNTQ R9, R9
-	MOVQ   R9, R11
-	ANDQ   $0x07, R11
-	SHRQ   $0x03, R9
-	SUBQ   R9, DI
-	MOVQ   (DI), R9
-	ORQ    $0x01, R9
-	SHLXQ  R11, R9, R9
-	ADDQ   $0x07, BX
-	CMPQ   BX, R10
-	JB     inner_loop
-	JMP    outer_loop
+	// Refill the whole bytes consumed from below the window
+	MOVQ  R10, R12
+	ANDQ  $0x38, R12
+	MOVQ  -8(DI), R13
+	SHRQ  $0x01, R13
+	ANDQ  $0x07, R10
+	MOVQ  R12, R14
+	XORQ  $0x3f, R14
+	SHRXQ R14, R13, R13
+	SHLXQ R10, R13, R13
+	ORQ   R13, R9
+	SHRQ  $0x03, R12
+	SUBQ  R12, DI
+	ADDQ  $0x07, BX
+	CMPQ  BX, R11
+	JB    inner_loop
+	JMP   outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVQ (AX), CX
 	SUBQ (CX), DI
 	MOVQ DI, 24(CX)
 	MOVQ R9, 32(CX)
+	MOVB R10, 40(CX)
 	SUBQ 16(AX), BX
 	MOVQ BX, 40(AX)
 	RET
 
 // func decompress1x_4b_main_loop_bmi2(ctx *decompress1xContext)
-// Requires: BMI, BMI2, CMOV
+// Requires: BMI2, CMOV
 TEXT ·decompress1x_4b_main_loop_bmi2(SB), $0-8
 	MOVQ ctx+0(FP), AX
 
@@ -3168,152 +3219,168 @@ TEXT ·decompress1x_4b_main_loop_bmi2(SB), $0-8
 	ADDQ    BX, SI
 	MOVQ    56(AX), DI
 	MOVQ    48(AX), R8
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVQ    (AX), R10
 	MOVQ    32(R10), R9
 	MOVBQZX 40(R10), R10
-	BTSQ    R10, R9
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 16
-	MOVQ SI, R10
-	SUBQ BX, R10
+	MOVQ SI, R11
+	SUBQ BX, R11
 	JLE  done
-	SHRQ $0x04, R10
+	SHRQ $0x04, R11
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVQ    DI, R11
-	SUBQ    R8, R11
-	SHRQ    $0x03, R11
-	CMPQ    R11, R10
-	CMOVQCS R11, R10
-	TESTQ   R10, R10
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVQ    DI, R12
+	SUBQ    R8, R12
+	SHRQ    $0x03, R12
+	CMPQ    R12, R11
+	CMOVQCS R12, R11
+	TESTQ   R11, R11
 	JZ      done
-	IMUL3Q  $0x0e, R10, R10
-	ADDQ    BX, R10
+	IMUL3Q  $0x0e, R11, R11
+	ADDQ    BX, R11
 
 inner_loop:
 	// symbol 0
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, (BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, (BX)
 
 	// symbol 1
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 1(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 1(BX)
 
 	// symbol 2
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 2(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 2(BX)
 
 	// symbol 3
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 3(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 3(BX)
 
 	// symbol 4
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 4(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 4(BX)
 
 	// symbol 5
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 5(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 5(BX)
 
 	// symbol 6
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 6(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 6(BX)
 
 	// symbol 7
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 7(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 7(BX)
 
 	// symbol 8
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 8(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 8(BX)
 
 	// symbol 9
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 9(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 9(BX)
 
 	// symbol 10
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 10(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 10(BX)
 
 	// symbol 11
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 11(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 11(BX)
 
 	// symbol 12
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 12(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 12(BX)
 
 	// symbol 13
-	SHRXQ   CX, R9, R11
-	MOVWQZX (DX)(R11*2), R11
-	SHLXQ   R11, R9, R9
-	SHRQ    $0x08, R11
-	MOVB    R11, 13(BX)
+	SHRXQ   CX, R9, R12
+	MOVWQZX (DX)(R12*2), R12
+	SHLXQ   R12, R9, R9
+	ADDQ    R12, R10
+	SHRQ    $0x08, R12
+	MOVB    R12, 13(BX)
 
-	// Reload the bit container
-	TZCNTQ R9, R9
-	MOVQ   R9, R11
-	ANDQ   $0x07, R11
-	SHRQ   $0x03, R9
-	SUBQ   R9, DI
-	MOVQ   (DI), R9
-	ORQ    $0x01, R9
-	SHLXQ  R11, R9, R9
-	ADDQ   $0x0e, BX
-	CMPQ   BX, R10
-	JB     inner_loop
-	JMP    outer_loop
+	// Refill the whole bytes consumed from below the window
+	MOVQ  R10, R12
+	ANDQ  $0x38, R12
+	MOVQ  -8(DI), R13
+	SHRQ  $0x01, R13
+	ANDQ  $0x07, R10
+	MOVQ  R12, R14
+	XORQ  $0x3f, R14
+	SHRXQ R14, R13, R13
+	SHLXQ R10, R13, R13
+	ORQ   R13, R9
+	SHRQ  $0x03, R12
+	SUBQ  R12, DI
+	ADDQ  $0x0e, BX
+	CMPQ  BX, R11
+	JB    inner_loop
+	JMP   outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVQ (AX), CX
 	SUBQ (CX), DI
 	MOVQ DI, 24(CX)
 	MOVQ R9, 32(CX)
+	MOVB R10, 40(CX)
 	SUBQ 16(AX), BX
 	MOVQ BX, 40(AX)
 	RET

--- a/huff0/decompress_arm64.go
+++ b/huff0/decompress_arm64.go
@@ -6,31 +6,46 @@
 package huff0
 
 // decompress4x_main_loop_arm64 is an arm64 assembler implementation
-// of Decompress4X when tablelog > 8, decoding fast4XSymbols symbols per
+// of Decompress4X when tablelog > 8, decoding fastSymbols symbols per
 // stream between bit container reloads.
 //
 //go:noescape
 func decompress4x_main_loop_arm64(ctx *decompress4xContext)
 
 // decompress4x_8b_main_loop_arm64 is an arm64 assembler implementation
-// of Decompress4X when tablelog <= 8, decoding fast4X8bSymbols symbols
+// of Decompress4X when tablelog <= 8, decoding fast8bSymbols symbols
 // per stream between bit container reloads.
 //
 //go:noescape
 func decompress4x_8b_main_loop_arm64(ctx *decompress4xContext)
 
 // decompress4x_4b_main_loop_arm64 is an arm64 assembler implementation
-// of Decompress4X when tablelog <= 4, decoding fast4X4bSymbols symbols
+// of Decompress4X when tablelog <= 4, decoding fast4bSymbols symbols
 // per stream between bit container reloads.
 //
 //go:noescape
 func decompress4x_4b_main_loop_arm64(ctx *decompress4xContext)
 
 // decompress1x_main_loop_arm64 is an arm64 assembler implementation
-// of Decompress1X when tablelog > 8.
+// of Decompress1X when tablelog > 8, decoding fastSymbols symbols
+// between bit container reloads.
 //
 //go:noescape
 func decompress1x_main_loop_arm64(ctx *decompress1xContext)
+
+// decompress1x_8b_main_loop_arm64 is an arm64 assembler implementation
+// of Decompress1X when tablelog <= 8, decoding fast8bSymbols symbols
+// between bit container reloads.
+//
+//go:noescape
+func decompress1x_8b_main_loop_arm64(ctx *decompress1xContext)
+
+// decompress1x_4b_main_loop_arm64 is an arm64 assembler implementation
+// of Decompress1X when tablelog <= 4, decoding fast4bSymbols symbols
+// between bit container reloads.
+//
+//go:noescape
+func decompress1x_4b_main_loop_arm64(ctx *decompress1xContext)
 
 func decompress4x_main_loop_asm(ctx *decompress4xContext) {
 	decompress4x_main_loop_arm64(ctx)
@@ -46,4 +61,12 @@ func decompress4x_4b_main_loop_asm(ctx *decompress4xContext) {
 
 func decompress1x_main_loop_asm(ctx *decompress1xContext) {
 	decompress1x_main_loop_arm64(ctx)
+}
+
+func decompress1x_8b_main_loop_asm(ctx *decompress1xContext) {
+	decompress1x_8b_main_loop_arm64(ctx)
+}
+
+func decompress1x_4b_main_loop_asm(ctx *decompress1xContext) {
+	decompress1x_4b_main_loop_arm64(ctx)
 }

--- a/huff0/decompress_arm64.s
+++ b/huff0/decompress_arm64.s
@@ -1230,104 +1230,402 @@ done:
 // skipped decompress4x_4b_main_loop_bmi2 (generic twin preferred on arm64)
 
 // func decompress1x_main_loop_amd64(ctx *decompress1xContext)
+// Requires: BMI, CMOV
 TEXT ·decompress1x_main_loop_arm64(SB), $0-8
-	MOVD  ctx+0(FP), R1
-	MOVD  16(R1), R2
-	MOVD  24(R1), R3
-	CMP   $0x04, R3
-	BLO   error_max_decoded_size_exceeded
-	ADD   R3, R2, R3
-	MOVD  (R1), R5
-	MOVD  (R5), R7
-	MOVD  24(R5), R8
-	MOVD  32(R5), R9
-	MOVBU 40(R5), R10
-	MOVD  32(R1), R5
-	MOVBU 8(R1), R6
-	JMP   loop_condition
-
-main_loop:
-	// Check if we have room for 4 bytes in the output buffer
-	ADD $4, R2, R1
-	CMP R3, R1
-	BGE error_max_decoded_size_exceeded
-
-	// Decode 4 values
-	CMP   $0x20, R10
-	BLT   bitReader_fillFast_1_end
-	SUB   $0x20, R10, R10
-	SUB   $0x04, R8, R8
-	MOVWU (R7)(R8), R11
-	MOVD  R10, R1
-	LSL   R1, R11, R11
-	ORR   R11, R9, R9
-
-bitReader_fillFast_1_end:
-	LSR   R6, R9, R11
-	MOVHU (R5)(R11<<1), R1
-	UBFX  $8, R1, $8, R16
-	BFI   $0, R16, $8, R0
-	MOVBU R1, R1
-	ADD   R1, R10, R10
-	LSL   R1, R9, R9
-	LSR   R6, R9, R11
-	MOVHU (R5)(R11<<1), R1
-	UBFX  $8, R1, $8, R16
-	BFI   $8, R16, $8, R0
-	MOVBU R1, R1
-	ADD   R1, R10, R10
-	LSL   R1, R9, R9
-	REVW  R0, R0
-	CMP   $0x20, R10
-	BLT   bitReader_fillFast_2_end
-	SUB   $0x20, R10, R10
-	SUB   $0x04, R8, R8
-	MOVWU (R7)(R8), R11
-	MOVD  R10, R1
-	LSL   R1, R11, R11
-	ORR   R11, R9, R9
-
-bitReader_fillFast_2_end:
-	LSR   R6, R9, R11
-	MOVHU (R5)(R11<<1), R1
-	UBFX  $8, R1, $8, R16
-	BFI   $8, R16, $8, R0
-	MOVBU R1, R1
-	ADD   R1, R10, R10
-	LSL   R1, R9, R9
-	LSR   R6, R9, R11
-	MOVHU (R5)(R11<<1), R1
-	UBFX  $8, R1, $8, R16
-	BFI   $0, R16, $8, R0
-	MOVBU R1, R1
-	ADD   R1, R10, R10
-	LSL   R1, R9, R9
-	REVW  R0, R0
-
-	// Store the decoded values
-	MOVW R0, (R2)
-	ADD  $0x04, R2, R2
-
-loop_condition:
-	CMP $0x08, R8
-	BGE main_loop
-
-	// Update ctx structure
 	MOVD ctx+0(FP), R0
+
+	// Preload values
+	MOVBU 8(R0), R2
+	MOVD  32(R0), R3
+	MOVD  16(R0), R5
+	MOVD  24(R0), R6
+	ADD   R5, R6, R6
+	MOVD  56(R0), R7
+	MOVD  48(R0), R8
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVD  (R0), R1
+	MOVD  32(R1), R9
+	MOVBU 40(R1), R1
+	MOVD  $1, R16
+	LSL   R1, R16, R16
+	ORR   R16, R9, R9
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 8
+	MOVD R6, R1
+	SUBS R5, R1, R1
+	BLE  done
+	LSR  $0x03, R1, R1
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVD R7, R10
+	SUB  R8, R10, R10
+	LSR  $0x03, R10, R10
+	CMP  R1, R10
+	CSEL LO, R10, R1, R1
+	TST  R1, R1
+	BEQ  done
+	MOVD $5, R16
+	MUL  R16, R1, R10
+	ADD  R5, R10, R10
+
+inner_loop:
+	// symbol 0
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, (R5)
+
+	// symbol 1
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 1(R5)
+
+	// symbol 2
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 2(R5)
+
+	// symbol 3
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 3(R5)
+
+	// symbol 4
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 4(R5)
+
+	// Reload the bit container
+	RBIT R9, R9
+	CLZ  R9, R9
+	MOVD R9, R1
+	AND  $0x07, R1, R1
+	LSR  $0x03, R9, R9
+	SUB  R9, R7, R7
+	MOVD (R7), R9
+	ORR  $0x01, R9, R9
+	LSL  R1, R9, R9
+	ADD  $0x05, R5, R5
+	CMP  R10, R5
+	BLO  inner_loop
+	JMP  outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVD (R0), R1
+	MOVD (R1), R16
+	SUB  R16, R7, R7
+	MOVD R7, 24(R1)
+	MOVD R9, 32(R1)
 	MOVD 16(R0), R16
-	SUB  R16, R2, R2
-	MOVD R2, 40(R0)
-	MOVD (R0), R0
-	MOVD R8, 24(R0)
-	MOVD R9, 32(R0)
-	MOVB R10, 40(R0)
+	SUB  R16, R5, R5
+	MOVD R5, 40(R0)
 	RET
 
-	// Report error
-error_max_decoded_size_exceeded:
+// func decompress1x_8b_main_loop_amd64(ctx *decompress1xContext)
+// Requires: BMI, CMOV
+TEXT ·decompress1x_8b_main_loop_arm64(SB), $0-8
 	MOVD ctx+0(FP), R0
-	MOVD $-1, R1
-	MOVD R1, 40(R0)
+
+	// Preload values
+	MOVBU 8(R0), R2
+	MOVD  32(R0), R3
+	MOVD  16(R0), R5
+	MOVD  24(R0), R6
+	ADD   R5, R6, R6
+	MOVD  56(R0), R7
+	MOVD  48(R0), R8
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVD  (R0), R1
+	MOVD  32(R1), R9
+	MOVBU 40(R1), R1
+	MOVD  $1, R16
+	LSL   R1, R16, R16
+	ORR   R16, R9, R9
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 8
+	MOVD R6, R1
+	SUBS R5, R1, R1
+	BLE  done
+	LSR  $0x03, R1, R1
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVD R7, R10
+	SUB  R8, R10, R10
+	LSR  $0x03, R10, R10
+	CMP  R1, R10
+	CSEL LO, R10, R1, R1
+	TST  R1, R1
+	BEQ  done
+	MOVD $7, R16
+	MUL  R16, R1, R10
+	ADD  R5, R10, R10
+
+inner_loop:
+	// symbol 0
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, (R5)
+
+	// symbol 1
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 1(R5)
+
+	// symbol 2
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 2(R5)
+
+	// symbol 3
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 3(R5)
+
+	// symbol 4
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 4(R5)
+
+	// symbol 5
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 5(R5)
+
+	// symbol 6
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 6(R5)
+
+	// Reload the bit container
+	RBIT R9, R9
+	CLZ  R9, R9
+	MOVD R9, R1
+	AND  $0x07, R1, R1
+	LSR  $0x03, R9, R9
+	SUB  R9, R7, R7
+	MOVD (R7), R9
+	ORR  $0x01, R9, R9
+	LSL  R1, R9, R9
+	ADD  $0x07, R5, R5
+	CMP  R10, R5
+	BLO  inner_loop
+	JMP  outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVD (R0), R1
+	MOVD (R1), R16
+	SUB  R16, R7, R7
+	MOVD R7, 24(R1)
+	MOVD R9, 32(R1)
+	MOVD 16(R0), R16
+	SUB  R16, R5, R5
+	MOVD R5, 40(R0)
+	RET
+
+// func decompress1x_4b_main_loop_amd64(ctx *decompress1xContext)
+// Requires: BMI, CMOV
+TEXT ·decompress1x_4b_main_loop_arm64(SB), $0-8
+	MOVD ctx+0(FP), R0
+
+	// Preload values
+	MOVBU 8(R0), R2
+	MOVD  32(R0), R3
+	MOVD  16(R0), R5
+	MOVD  24(R0), R6
+	ADD   R5, R6, R6
+	MOVD  56(R0), R7
+	MOVD  48(R0), R8
+
+	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
+	MOVD  (R0), R1
+	MOVD  32(R1), R9
+	MOVBU 40(R1), R1
+	MOVD  $1, R16
+	LSL   R1, R16, R16
+	ORR   R16, R9, R9
+
+outer_loop:
+	// Iterations allowed by the output: (limit - op) / 16
+	MOVD R6, R1
+	SUBS R5, R1, R1
+	BLE  done
+	LSR  $0x04, R1, R1
+
+	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
+	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
+	MOVD R7, R10
+	SUB  R8, R10, R10
+	LSR  $0x03, R10, R10
+	CMP  R1, R10
+	CSEL LO, R10, R1, R1
+	TST  R1, R1
+	BEQ  done
+	MOVD $14, R16
+	MUL  R16, R1, R10
+	ADD  R5, R10, R10
+
+inner_loop:
+	// symbol 0
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, (R5)
+
+	// symbol 1
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 1(R5)
+
+	// symbol 2
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 2(R5)
+
+	// symbol 3
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 3(R5)
+
+	// symbol 4
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 4(R5)
+
+	// symbol 5
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 5(R5)
+
+	// symbol 6
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 6(R5)
+
+	// symbol 7
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 7(R5)
+
+	// symbol 8
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 8(R5)
+
+	// symbol 9
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 9(R5)
+
+	// symbol 10
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 10(R5)
+
+	// symbol 11
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 11(R5)
+
+	// symbol 12
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 12(R5)
+
+	// symbol 13
+	LSR   R2, R9, R11
+	MOVHU (R3)(R11<<1), R1
+	LSL   R1, R9, R9
+	LSR   $0x08, R1, R1
+	MOVB  R1, 13(R5)
+
+	// Reload the bit container
+	RBIT R9, R9
+	CLZ  R9, R9
+	MOVD R9, R1
+	AND  $0x07, R1, R1
+	LSR  $0x03, R9, R9
+	SUB  R9, R7, R7
+	MOVD (R7), R9
+	ORR  $0x01, R9, R9
+	LSL  R1, R9, R9
+	ADD  $0x0e, R5, R5
+	CMP  R10, R5
+	BLO  inner_loop
+	JMP  outer_loop
+
+done:
+	// Hand the state back: off = ip - in, value = the sentinel-form container.
+	// bitReaderShifted.restoreFromAsm normalizes both.
+	MOVD (R0), R1
+	MOVD (R1), R16
+	SUB  R16, R7, R7
+	MOVD R7, 24(R1)
+	MOVD R9, 32(R1)
+	MOVD 16(R0), R16
+	SUB  R16, R5, R5
+	MOVD R5, 40(R0)
 	RET
 
 // skipped decompress1x_main_loop_bmi2 (generic twin preferred on arm64)
+
+// skipped decompress1x_8b_main_loop_bmi2 (generic twin preferred on arm64)
+
+// skipped decompress1x_4b_main_loop_bmi2 (generic twin preferred on arm64)

--- a/huff0/decompress_arm64.s
+++ b/huff0/decompress_arm64.s
@@ -1230,7 +1230,7 @@ done:
 // skipped decompress4x_4b_main_loop_bmi2 (generic twin preferred on arm64)
 
 // func decompress1x_main_loop_amd64(ctx *decompress1xContext)
-// Requires: BMI, CMOV
+// Requires: CMOV
 TEXT ·decompress1x_main_loop_arm64(SB), $0-8
 	MOVD ctx+0(FP), R0
 
@@ -1242,14 +1242,9 @@ TEXT ·decompress1x_main_loop_arm64(SB), $0-8
 	ADD   R5, R6, R6
 	MOVD  56(R0), R7
 	MOVD  48(R0), R8
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVD  (R0), R1
 	MOVD  32(R1), R9
-	MOVBU 40(R1), R1
-	MOVD  $1, R16
-	LSL   R1, R16, R16
-	ORR   R16, R9, R9
+	MOVBU 40(R1), R10
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 8
@@ -1258,85 +1253,95 @@ outer_loop:
 	BLE  done
 	LSR  $0x03, R1, R1
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVD R7, R10
-	SUB  R8, R10, R10
-	LSR  $0x03, R10, R10
-	CMP  R1, R10
-	CSEL LO, R10, R1, R1
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVD R7, R11
+	SUB  R8, R11, R11
+	LSR  $0x03, R11, R11
+	CMP  R1, R11
+	CSEL LO, R11, R1, R1
 	TST  R1, R1
 	BEQ  done
 	MOVD $5, R16
-	MUL  R16, R1, R10
-	ADD  R5, R10, R10
+	MUL  R16, R1, R11
+	ADD  R5, R11, R11
 
 inner_loop:
 	// symbol 0
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, (R5)
 
 	// symbol 1
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 1(R5)
 
 	// symbol 2
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 2(R5)
 
 	// symbol 3
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 3(R5)
 
 	// symbol 4
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 4(R5)
 
-	// Reload the bit container
-	RBIT R9, R9
-	CLZ  R9, R9
-	MOVD R9, R1
-	AND  $0x07, R1, R1
-	LSR  $0x03, R9, R9
-	SUB  R9, R7, R7
-	MOVD (R7), R9
-	ORR  $0x01, R9, R9
-	LSL  R1, R9, R9
+	// Refill the whole bytes consumed from below the window
+	MOVD R10, R12
+	AND  $0x38, R12, R12
+	MOVD -8(R7), R13
+	LSR  $0x01, R13, R13
+	AND  $0x07, R10, R10
+	MOVD R12, R1
+	EOR  $0x3f, R1, R1
+	LSR  R1, R13, R13
+	MOVD R10, R1
+	LSL  R1, R13, R13
+	ORR  R13, R9, R9
+	LSR  $0x03, R12, R12
+	SUB  R12, R7, R7
 	ADD  $0x05, R5, R5
-	CMP  R10, R5
+	CMP  R11, R5
 	BLO  inner_loop
 	JMP  outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVD (R0), R1
 	MOVD (R1), R16
 	SUB  R16, R7, R7
 	MOVD R7, 24(R1)
 	MOVD R9, 32(R1)
+	MOVB R10, 40(R1)
 	MOVD 16(R0), R16
 	SUB  R16, R5, R5
 	MOVD R5, 40(R0)
 	RET
 
 // func decompress1x_8b_main_loop_amd64(ctx *decompress1xContext)
-// Requires: BMI, CMOV
+// Requires: CMOV
 TEXT ·decompress1x_8b_main_loop_arm64(SB), $0-8
 	MOVD ctx+0(FP), R0
 
@@ -1348,14 +1353,9 @@ TEXT ·decompress1x_8b_main_loop_arm64(SB), $0-8
 	ADD   R5, R6, R6
 	MOVD  56(R0), R7
 	MOVD  48(R0), R8
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVD  (R0), R1
 	MOVD  32(R1), R9
-	MOVBU 40(R1), R1
-	MOVD  $1, R16
-	LSL   R1, R16, R16
-	ORR   R16, R9, R9
+	MOVBU 40(R1), R10
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 8
@@ -1364,99 +1364,111 @@ outer_loop:
 	BLE  done
 	LSR  $0x03, R1, R1
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVD R7, R10
-	SUB  R8, R10, R10
-	LSR  $0x03, R10, R10
-	CMP  R1, R10
-	CSEL LO, R10, R1, R1
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVD R7, R11
+	SUB  R8, R11, R11
+	LSR  $0x03, R11, R11
+	CMP  R1, R11
+	CSEL LO, R11, R1, R1
 	TST  R1, R1
 	BEQ  done
 	MOVD $7, R16
-	MUL  R16, R1, R10
-	ADD  R5, R10, R10
+	MUL  R16, R1, R11
+	ADD  R5, R11, R11
 
 inner_loop:
 	// symbol 0
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, (R5)
 
 	// symbol 1
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 1(R5)
 
 	// symbol 2
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 2(R5)
 
 	// symbol 3
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 3(R5)
 
 	// symbol 4
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 4(R5)
 
 	// symbol 5
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 5(R5)
 
 	// symbol 6
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 6(R5)
 
-	// Reload the bit container
-	RBIT R9, R9
-	CLZ  R9, R9
-	MOVD R9, R1
-	AND  $0x07, R1, R1
-	LSR  $0x03, R9, R9
-	SUB  R9, R7, R7
-	MOVD (R7), R9
-	ORR  $0x01, R9, R9
-	LSL  R1, R9, R9
+	// Refill the whole bytes consumed from below the window
+	MOVD R10, R12
+	AND  $0x38, R12, R12
+	MOVD -8(R7), R13
+	LSR  $0x01, R13, R13
+	AND  $0x07, R10, R10
+	MOVD R12, R1
+	EOR  $0x3f, R1, R1
+	LSR  R1, R13, R13
+	MOVD R10, R1
+	LSL  R1, R13, R13
+	ORR  R13, R9, R9
+	LSR  $0x03, R12, R12
+	SUB  R12, R7, R7
 	ADD  $0x07, R5, R5
-	CMP  R10, R5
+	CMP  R11, R5
 	BLO  inner_loop
 	JMP  outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVD (R0), R1
 	MOVD (R1), R16
 	SUB  R16, R7, R7
 	MOVD R7, 24(R1)
 	MOVD R9, 32(R1)
+	MOVB R10, 40(R1)
 	MOVD 16(R0), R16
 	SUB  R16, R5, R5
 	MOVD R5, 40(R0)
 	RET
 
 // func decompress1x_4b_main_loop_amd64(ctx *decompress1xContext)
-// Requires: BMI, CMOV
+// Requires: CMOV
 TEXT ·decompress1x_4b_main_loop_arm64(SB), $0-8
 	MOVD ctx+0(FP), R0
 
@@ -1468,14 +1480,9 @@ TEXT ·decompress1x_4b_main_loop_arm64(SB), $0-8
 	ADD   R5, R6, R6
 	MOVD  56(R0), R7
 	MOVD  48(R0), R8
-
-	// Convert the bit reader to sentinel form: bits = value | 1<<bitsRead
 	MOVD  (R0), R1
 	MOVD  32(R1), R9
-	MOVBU 40(R1), R1
-	MOVD  $1, R16
-	LSL   R1, R16, R16
-	ORR   R16, R9, R9
+	MOVBU 40(R1), R10
 
 outer_loop:
 	// Iterations allowed by the output: (limit - op) / 16
@@ -1484,141 +1491,160 @@ outer_loop:
 	BLE  done
 	LSR  $0x04, R1, R1
 
-	// Iterations allowed by the input: a reload backs the pointer up by at most 7 bytes
-	// (whatever nSyms is), so every read stays inside the stream while ip stays above ilowest.
-	MOVD R7, R10
-	SUB  R8, R10, R10
-	LSR  $0x03, R10, R10
-	CMP  R1, R10
-	CSEL LO, R10, R1, R1
+	// Iterations allowed by the input: a refill reads the 8 bytes below the window and
+	// moves it down by at most 7, so every read stays inside the stream while ip stays
+	// at least 8 above ilowest.
+	MOVD R7, R11
+	SUB  R8, R11, R11
+	LSR  $0x03, R11, R11
+	CMP  R1, R11
+	CSEL LO, R11, R1, R1
 	TST  R1, R1
 	BEQ  done
 	MOVD $14, R16
-	MUL  R16, R1, R10
-	ADD  R5, R10, R10
+	MUL  R16, R1, R11
+	ADD  R5, R11, R11
 
 inner_loop:
 	// symbol 0
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, (R5)
 
 	// symbol 1
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 1(R5)
 
 	// symbol 2
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 2(R5)
 
 	// symbol 3
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 3(R5)
 
 	// symbol 4
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 4(R5)
 
 	// symbol 5
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 5(R5)
 
 	// symbol 6
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 6(R5)
 
 	// symbol 7
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 7(R5)
 
 	// symbol 8
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 8(R5)
 
 	// symbol 9
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 9(R5)
 
 	// symbol 10
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 10(R5)
 
 	// symbol 11
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 11(R5)
 
 	// symbol 12
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 12(R5)
 
 	// symbol 13
-	LSR   R2, R9, R11
-	MOVHU (R3)(R11<<1), R1
+	LSR   R2, R9, R12
+	MOVHU (R3)(R12<<1), R1
 	LSL   R1, R9, R9
+	ADD   R1, R10, R10
 	LSR   $0x08, R1, R1
 	MOVB  R1, 13(R5)
 
-	// Reload the bit container
-	RBIT R9, R9
-	CLZ  R9, R9
-	MOVD R9, R1
-	AND  $0x07, R1, R1
-	LSR  $0x03, R9, R9
-	SUB  R9, R7, R7
-	MOVD (R7), R9
-	ORR  $0x01, R9, R9
-	LSL  R1, R9, R9
+	// Refill the whole bytes consumed from below the window
+	MOVD R10, R12
+	AND  $0x38, R12, R12
+	MOVD -8(R7), R13
+	LSR  $0x01, R13, R13
+	AND  $0x07, R10, R10
+	MOVD R12, R1
+	EOR  $0x3f, R1, R1
+	LSR  R1, R13, R13
+	MOVD R10, R1
+	LSL  R1, R13, R13
+	ORR  R13, R9, R9
+	LSR  $0x03, R12, R12
+	SUB  R12, R7, R7
 	ADD  $0x0e, R5, R5
-	CMP  R10, R5
+	CMP  R11, R5
 	BLO  inner_loop
 	JMP  outer_loop
 
 done:
-	// Hand the state back: off = ip - in, value = the sentinel-form container.
-	// bitReaderShifted.restoreFromAsm normalizes both.
+	// Hand the state back in the Go bit reader's own form: off = ip - in, value, bitsRead.
 	MOVD (R0), R1
 	MOVD (R1), R16
 	SUB  R16, R7, R7
 	MOVD R7, 24(R1)
 	MOVD R9, 32(R1)
+	MOVB R10, 40(R1)
 	MOVD 16(R0), R16
 	SUB  R16, R5, R5
 	MOVD R5, 40(R0)

--- a/huff0/decompress_asm.go
+++ b/huff0/decompress_asm.go
@@ -210,7 +210,9 @@ func (d *Decoder) Decompress1X(dst, src []byte) ([]byte, error) {
 	// The asm decodes whole batches of symbols and only re-checks its
 	// bounds between them, so it needs at least one batch of room (the
 	// output bound rounds nSyms up to 16, see _generate/gen.go) and a full
-	// 8-byte window ahead of the read pointer to enter the loop.
+	// 8-byte window ahead of the read pointer to enter the loop. It also
+	// needs at most 7 bits consumed on entry so that a batch cannot run
+	// the container dry, which prepareForAsm establishes.
 	decoded := 0
 	if maxDecodedSize >= 16 && br.canUseAsm() {
 		br.prepareForAsm()
@@ -231,9 +233,6 @@ func (d *Decoder) Decompress1X(dst, src []byte) ([]byte, error) {
 			decompress1x_main_loop_asm(&ctx)
 		}
 		decoded = ctx.decoded
-		if err := br.restoreFromAsm(); err != nil {
-			return nil, err
-		}
 	}
 	dst = dst[:decoded]
 

--- a/huff0/decompress_asm.go
+++ b/huff0/decompress_asm.go
@@ -34,9 +34,9 @@ type decompress4xContext struct {
 // Symbols decoded per stream between reloads by the 4X asm loops; must
 // match the constants of the same names in _generate/gen.go.
 const (
-	fast4XSymbols   = 5  // tablelog 9..11
-	fast4X8bSymbols = 7  // tablelog 5..8
-	fast4X4bSymbols = 14 // tablelog <= 4
+	fastSymbols   = 5  // tablelog 9..11
+	fast8bSymbols = 7  // tablelog 5..8
+	fast4bSymbols = 14 // tablelog <= 4
 )
 
 // Decompress4X will decompress a 4X encoded stream.
@@ -87,11 +87,11 @@ func (d *Decoder) Decompress4X(dst, src []byte) ([]byte, error) {
 
 	var decoded int
 
-	nSyms := fast4XSymbols
+	nSyms := fastSymbols
 	if d.actualTableLog <= 4 {
-		nSyms = fast4X4bSymbols
+		nSyms = fast4bSymbols
 	} else if use8BitTables {
-		nSyms = fast4X8bSymbols
+		nSyms = fast8bSymbols
 	}
 	// The asm writes nSyms bytes per stream per iteration and only re-checks
 	// its bounds between batches of iterations (the batch size is derived
@@ -121,9 +121,9 @@ func (d *Decoder) Decompress4X(dst, src []byte) ([]byte, error) {
 			ctx.ip[i] = &br[i].in[br[i].off]
 		}
 		switch nSyms {
-		case fast4X4bSymbols:
+		case fast4bSymbols:
 			decompress4x_4b_main_loop_asm(&ctx)
-		case fast4X8bSymbols:
+		case fast8bSymbols:
 			decompress4x_8b_main_loop_asm(&ctx)
 		default:
 			decompress4x_main_loop_asm(&ctx)
@@ -175,17 +175,19 @@ func (d *Decoder) Decompress4X(dst, src []byte) ([]byte, error) {
 	return dst, nil
 }
 
+// decompress1xContext is the argument block of the Decompress1X asm loops.
+// Go fills every field but decoded; the asm advances ip, and on return
+// leaves the bit reader in the form bitReaderShifted.restoreFromAsm expects.
 type decompress1xContext struct {
 	pbr      *bitReaderShifted
 	peekBits uint8
 	out      *byte
-	outCap   int
+	outCap   int // no write reaches out[outCap]
 	tbl      *dEntrySingle
 	decoded  int
+	ilowest  *byte // start of the stream; no read goes below it
+	ip       *byte // the 8-byte input window, advanced by the asm
 }
-
-// Error reported by asm implementations
-const error_max_decoded_size_exeeded = -1
 
 // Decompress1X will decompress a 1X encoded stream.
 // The cap of the output buffer will be the maximum decompressed size.
@@ -205,25 +207,37 @@ func (d *Decoder) Decompress1X(dst, src []byte) ([]byte, error) {
 	const tlSize = 1 << tableLogMax
 	const tlMask = tlSize - 1
 
-	if maxDecodedSize >= 4 {
+	// The asm decodes whole batches of symbols and only re-checks its
+	// bounds between them, so it needs at least one batch of room (the
+	// output bound rounds nSyms up to 16, see _generate/gen.go) and a full
+	// 8-byte window ahead of the read pointer to enter the loop.
+	decoded := 0
+	if maxDecodedSize >= 16 && br.canUseAsm() {
+		br.prepareForAsm()
 		ctx := decompress1xContext{
 			pbr:      &br,
 			out:      &dst[0],
 			outCap:   maxDecodedSize,
 			peekBits: uint8((64 - d.actualTableLog) & 63), // see: bitReaderShifted.peekBitsFast()
 			tbl:      &d.dt.single[0],
+			ilowest:  &src[0],
+			ip:       &br.in[br.off],
 		}
-
-		decompress1x_main_loop_asm(&ctx)
-		if ctx.decoded == error_max_decoded_size_exeeded {
-			return nil, ErrMaxDecodedSizeExceeded
+		if d.actualTableLog <= 4 {
+			decompress1x_4b_main_loop_asm(&ctx)
+		} else if d.actualTableLog <= 8 {
+			decompress1x_8b_main_loop_asm(&ctx)
+		} else {
+			decompress1x_main_loop_asm(&ctx)
 		}
-
-		dst = dst[:ctx.decoded]
+		decoded = ctx.decoded
+		if err := br.restoreFromAsm(); err != nil {
+			return nil, err
+		}
 	}
+	dst = dst[:decoded]
 
-	// br < 8, so uint8 is fine
-	bitsLeft := uint8(br.off)*8 + 64 - br.bitsRead
+	bitsLeft := br.remaining()
 	for bitsLeft > 0 {
 		br.fill()
 		if len(dst) >= maxDecodedSize {
@@ -233,7 +247,7 @@ func (d *Decoder) Decompress1X(dst, src []byte) ([]byte, error) {
 		v := d.dt.single[br.peekBitsFast(d.actualTableLog)&tlMask]
 		nBits := uint8(v.entry)
 		br.advance(nBits)
-		bitsLeft -= nBits
+		bitsLeft -= uint(nBits)
 		dst = append(dst, uint8(v.entry>>8))
 	}
 	return dst, br.close()

--- a/huff0/decompress_test.go
+++ b/huff0/decompress_test.go
@@ -247,29 +247,42 @@ func TestDecompress4X(t *testing.T) {
 // the asm loops exists for: a stream whose read pointer sits high keeps the
 // input bound large, so only the output bound stops the loop.
 func TestDecompress4XCorruptStaysInBounds(t *testing.T) {
-	testDecompress4XCorruptStaysInBounds(t)
+	testDecompressCorruptStaysInBounds(t, true)
 }
 
 // TestDecompress4XCorruptStaysInBoundsNoBMI2 is the same through the
 // generic asm twin on amd64 (a no-op elsewhere).
 func TestDecompress4XCorruptStaysInBoundsNoBMI2(t *testing.T) {
 	defer cpuinfo.DisableBMI2()()
-	testDecompress4XCorruptStaysInBounds(t)
+	testDecompressCorruptStaysInBounds(t, true)
 }
 
-// decompress4XGuarded decodes src into a buffer of exactly dstSize bytes of
-// capacity followed by guard bytes, and fails the test if the guard bytes
-// change. This is the only way a Go test can observe an assembly overrun:
-// the allocator rounds small buffers up to a size class, so an overrun of a
+// TestDecompress1XCorruptStaysInBounds is TestDecompress4XCorruptStaysInBounds
+// for the single-stream loops, which have the same batch bound.
+func TestDecompress1XCorruptStaysInBounds(t *testing.T) {
+	testDecompressCorruptStaysInBounds(t, false)
+}
+
+// TestDecompress1XCorruptStaysInBoundsNoBMI2 is the same through the
+// generic asm twin on amd64 (a no-op elsewhere).
+func TestDecompress1XCorruptStaysInBoundsNoBMI2(t *testing.T) {
+	defer cpuinfo.DisableBMI2()()
+	testDecompressCorruptStaysInBounds(t, false)
+}
+
+// decodeGuarded decodes into a buffer of exactly dstSize bytes of capacity
+// followed by guard bytes, and fails the test if the guard bytes change.
+// This is the only way a Go test can observe an assembly overrun: the
+// allocator rounds small buffers up to a size class, so an overrun of a
 // plain make([]byte, n) lands in slack that nothing checks.
-func decompress4XGuarded(t *testing.T, dec *Decoder, dstSize int, src []byte) ([]byte, error) {
+func decodeGuarded(t *testing.T, dstSize int, decode func(dst []byte) ([]byte, error)) ([]byte, error) {
 	t.Helper()
 	const guard = 4096
 	buf := make([]byte, dstSize+guard)
 	for i := dstSize; i < len(buf); i++ {
 		buf[i] = 0xAA
 	}
-	out, err := dec.Decompress4X(buf[:0:dstSize], src)
+	out, err := decode(buf[:0:dstSize])
 	for i := dstSize; i < len(buf); i++ {
 		if buf[i] != 0xAA {
 			t.Fatalf("dstSize %d: wrote past the output capacity at +%d", dstSize, i-dstSize)
@@ -278,7 +291,17 @@ func decompress4XGuarded(t *testing.T, dec *Decoder, dstSize int, src []byte) ([
 	return out, err
 }
 
-func testDecompress4XCorruptStaysInBounds(t *testing.T) {
+func decompress4XGuarded(t *testing.T, dec *Decoder, dstSize int, src []byte) ([]byte, error) {
+	t.Helper()
+	return decodeGuarded(t, dstSize, func(dst []byte) ([]byte, error) { return dec.Decompress4X(dst, src) })
+}
+
+func decompress1XGuarded(t *testing.T, dec *Decoder, dstSize int, src []byte) ([]byte, error) {
+	t.Helper()
+	return decodeGuarded(t, dstSize, func(dst []byte) ([]byte, error) { return dec.Decompress1X(dst, src) })
+}
+
+func testDecompressCorruptStaysInBounds(t *testing.T, fourStreams bool) {
 	// A uniform alphabet of 2^k symbols yields exactly k-bit codes; the
 	// skewed 256-symbol sample yields codes up to the maximum length.
 	tables := []struct {
@@ -294,6 +317,11 @@ func testDecompress4XCorruptStaysInBounds(t *testing.T) {
 		{name: "tablelog-11", symbols: 256, skewed: true, minLog: 9, maxLog: 11},
 	}
 	sizes := []int{800, 801, 1000, 4096, 65536, 262143}
+	if !fourStreams {
+		// The single-stream loops also take small outputs, down to the
+		// one-batch minimum, and drain the rest in Go.
+		sizes = append([]int{15, 16, 17, 31, 100}, sizes...)
+	}
 	seed := uint32(0x12345678)
 	next := func() byte {
 		seed = seed*1664525 + 1013904223
@@ -333,14 +361,25 @@ func testDecompress4XCorruptStaysInBounds(t *testing.T) {
 				}
 				enc := &Scratch{Reuse: ReusePolicyMust}
 				enc.TransferCTable(dec)
-				comp, reused, err := Compress4X(in, enc)
+				var comp []byte
+				var reused bool
+				if fourStreams {
+					comp, reused, err = Compress4X(in, enc)
+				} else {
+					comp, reused, err = Compress1X(in, enc)
+				}
 				if err != nil {
 					t.Fatalf("size %d: %v", size, err)
 				}
 				if !reused {
 					t.Fatalf("size %d: table was not reused", size)
 				}
-				out, err := decompress4XGuarded(t, dec.Decoder(), size, comp)
+				var out []byte
+				if fourStreams {
+					out, err = decompress4XGuarded(t, dec.Decoder(), size, comp)
+				} else {
+					out, err = decompress1XGuarded(t, dec.Decoder(), size, comp)
+				}
 				if err != nil {
 					t.Fatalf("size %d: %v", size, err)
 				}
@@ -348,22 +387,34 @@ func testDecompress4XCorruptStaysInBounds(t *testing.T) {
 					t.Fatalf("size %d: roundtrip mismatch", size)
 				}
 
-				// Then corrupt input: four equal streams as long as the jump
-				// table can express, far more bits than the output can hold,
-				// every byte random, marker in the top bit of the last byte.
-				stream := min(size, 65535)
-				src := make([]byte, 6+4*stream)
-				for i := range 3 {
-					src[i*2] = byte(stream)
-					src[i*2+1] = byte(stream >> 8)
+				// Then corrupt input: streams as long as the output, far more
+				// bits than the output can hold, every byte random, marker in
+				// the top bit of the last byte. Four equal streams as long as
+				// the jump table can express, or one stream.
+				var src []byte
+				if fourStreams {
+					stream := min(size, 65535)
+					src = make([]byte, 6+4*stream)
+					for i := range 3 {
+						src[i*2] = byte(stream)
+						src[i*2+1] = byte(stream >> 8)
+					}
+					for i := 6; i < len(src); i++ {
+						src[i] = next()
+					}
+					for i := range 4 {
+						src[6+(i+1)*stream-1] |= 0x80
+					}
+					_, err = decompress4XGuarded(t, dec.Decoder(), size, src)
+				} else {
+					src = make([]byte, size)
+					for i := range src {
+						src[i] = next()
+					}
+					src[len(src)-1] |= 0x80
+					_, err = decompress1XGuarded(t, dec.Decoder(), size, src)
 				}
-				for i := 6; i < len(src); i++ {
-					src[i] = next()
-				}
-				for i := range 4 {
-					src[6+(i+1)*stream-1] |= 0x80
-				}
-				if _, err := decompress4XGuarded(t, dec.Decoder(), size, src); err == nil {
+				if err == nil {
 					t.Errorf("size %d: expected a corruption error", size)
 				}
 			}
@@ -377,6 +428,16 @@ func testDecompress4XCorruptStaysInBounds(t *testing.T) {
 // tables both above and below 8 bits. This is the end-to-end counterpart of
 // TestBitReaderShiftedPrepareForAsm.
 func TestDecompress4XStreamEndsIn01(t *testing.T) {
+	testDecompressStreamEndsIn01(t, true)
+}
+
+// TestDecompress1XStreamEndsIn01 is TestDecompress4XStreamEndsIn01 through
+// Decompress1X.
+func TestDecompress1XStreamEndsIn01(t *testing.T) {
+	testDecompressStreamEndsIn01(t, false)
+}
+
+func testDecompressStreamEndsIn01(t *testing.T, fourStreams bool) {
 	seed := uint32(0xC0FFEE)
 	next := func() byte {
 		seed = seed*1664525 + 1013904223
@@ -396,7 +457,13 @@ func TestDecompress4XStreamEndsIn01(t *testing.T) {
 				in[i] = byte(v % symbols)
 			}
 			s := &Scratch{}
-			comp, _, err := Compress4X(in, s)
+			var comp []byte
+			var err error
+			if fourStreams {
+				comp, _, err = Compress4X(in, s)
+			} else {
+				comp, _, err = Compress1X(in, s)
+			}
 			if err != nil {
 				continue
 			}
@@ -404,24 +471,33 @@ func TestDecompress4XStreamEndsIn01(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Walk the jump table to find each stream's final byte.
-			start := 6
 			hit := false
-			for i := range 4 {
-				end := len(streams)
-				if i < 3 {
-					end = start + (int(streams[i*2]) | int(streams[i*2+1])<<8)
+			if fourStreams {
+				// Walk the jump table to find each stream's final byte.
+				start := 6
+				for i := range 4 {
+					end := len(streams)
+					if i < 3 {
+						end = start + (int(streams[i*2]) | int(streams[i*2+1])<<8)
+					}
+					if streams[end-1] == 0x01 {
+						hit = true
+					}
+					start = end
 				}
-				if streams[end-1] == 0x01 {
-					hit = true
-				}
-				start = end
+			} else {
+				hit = streams[len(streams)-1] == 0x01
 			}
 			if !hit {
 				continue
 			}
 			found++
-			out, err := decompress4XGuarded(t, dec.Decoder(), len(in), streams)
+			var out []byte
+			if fourStreams {
+				out, err = decompress4XGuarded(t, dec.Decoder(), len(in), streams)
+			} else {
+				out, err = decompress1XGuarded(t, dec.Decoder(), len(in), streams)
+			}
 			if err != nil {
 				t.Fatalf("symbols %d attempt %d: %v", symbols, attempt, err)
 			}
@@ -538,7 +614,18 @@ func testDecompress4X(t *testing.T) {
 	}
 }
 
+// TestRoundtrip1XFuzzNoBMI2 runs the same roundtrips through the generic
+// asm twin on amd64 (a no-op elsewhere).
+func TestRoundtrip1XFuzzNoBMI2(t *testing.T) {
+	defer cpuinfo.DisableBMI2()()
+	testRoundtrip1XFuzz(t)
+}
+
 func TestRoundtrip1XFuzz(t *testing.T) {
+	testRoundtrip1XFuzz(t)
+}
+
+func testRoundtrip1XFuzz(t *testing.T) {
 	for _, test := range testfilesExtended {
 		t.Run(test.name, func(t *testing.T) {
 			var s = &Scratch{}


### PR DESCRIPTION
`Decompress1X` main loop regenerated for amd64 (generic and BMI2 twins) and arm64, in the style of the #1209 4X loops but with a refill suited to a single stream.

Scope of the numbers below: the `Decompress1X` figures are huff0 microbenchmarks of the single-stream loop alone (6–12% geomean, up to 21% on large low-tablelog inputs). zstd end-to-end decode moves by under 1% on every box, because zstd uses one stream only for literal blocks of 17..1023 bytes; the win is for huff0 callers and for workloads dominated by small literal blocks.

## What changed

- **Per symbol: peek, table load, shift, count, store.** 6 instructions on both arches (the BMI2 twin) with no byte packing: the old loop packed pairs of symbols through `AL`/`AH`, swapped them with `BSWAP` and checked a 32-bit fill twice per four symbols; on arm64 that lowered to 7 instructions per symbol plus two fill branches and a `REVW` per four. The consumed-bit count is kept as the low byte of a running sum of whole table entries, so the entry is never masked: the symbol halves cannot carry into the low byte because a group consumes fewer than 256 bits.
- **Branch-free refill off the serial chain.** A single stream is one dependency chain (peek → table load → shift), and nothing else hides latency inserted into it. The 4X sentinel reload (trailing-zero count, pointer arithmetic, load, OR, shift) would sit on that chain once per group; the first revision of this PR did that and regressed 8–14% on Sapphire Rapids for tablelog 9–11 inputs while winning on N1. This revision refills the way the Go bit reader does, but without the branch: OR the `bitsRead&^7` consumed whole-byte bits back in from the 8 bytes below the window, with every shift count computed from `bitsRead` alone, so the container chain sees one `OR`. The right shift by `64-r` is done as `>>1` then `>>(63-r)` so that `r == 0` contributes nothing, and `63-r` is `63^r` because `r` is a multiple of 8.
- **Three variants** decode 5, 7 or 14 symbols per refill for tablelog 9..11, 5..8 and <= 4, chosen by `actualTableLog` as the 4X entry does; the constants are shared with 4X and renamed `fastSymbols`, `fast8bSymbols`, `fast4bSymbols`.
- **Everything in registers**: container, consumed count, input pointer, output pointer and both loop limits. The 4X loop has to keep its input pointers and inner limit in memory.
- **Same bounds discipline as 4X.** An outer loop bounds a batch of inner iterations by the output capacity (budget divided by the next power of two at or above the symbols per iteration) and by the distance from the input pointer to the start of the stream (each refill reads the 8 bytes below the window and moves it down by at most 7). Every write stays below `cap(dst)` and every read stays inside `src`, corrupt input included.
- **Hand-off.** The container invariant `value == load64(in[off:off+8]) << bitsRead` is `bitReaderShifted`'s own, so the asm stores `off`, `value` and `bitsRead` directly and the Go tail continues; `canUseAsm` and `prepareForAsm` from #1209 gate entry (a full window ahead, at most 7 bits consumed so a batch cannot run the container dry). The asm no longer reports `ErrMaxDecodedSizeExceeded` itself: it stops at the capacity and the Go tail reports the error when bits remain, the same error as before. The tail counts remaining bits with `remaining()` instead of `uint8` arithmetic that assumed fewer than 8 bytes were left.
- **Generator.** `decompress1x` gets its own `decodeSymbol` and `refill`; the 4X code is untouched apart from the constant rename. The old `bitReader` helper type is gone.

## Tests

- The guard-byte corrupt-input test and the stream-ends-in-`0x01` test from #1209 now run over both one and four streams (`TestDecompress1XCorruptStaysInBounds`, `TestDecompress1XStreamEndsIn01`, plus BMI2-disabled twins), with the small output sizes (15, 16, 17, 31, 100) that the 1X entry threshold and batch rounding produce.
- `TestRoundtrip1XFuzzNoBMI2` runs the 1X roundtrips through the generic amd64 twin.
- Coverage confirms all three 1X variants are entered by the corrupt-input test.

## Benchmarks

PCALIGN-pinned before/after trees, `-count 10 -cpu 1`, base/head alternated across 5 rounds. Base is the #1209 head. `Decompress4X` is the control.

### Neoverse N1 (oracle, arm64)

Only the `Decompress1X` cells are shown; every `Decompress4X` control cell is within ±0.3% (geomean +0.04%). The gain is bounded by the serial dependency chain of a single stream (peek, table load, shift), so it is smaller than the 4X reshape's: the old loop's extra instructions were mostly off that chain.

```
                                            │   sec/op    │   sec/op     vs base                │
Decompress1XTable/digits                      343.9µ ± 0%   279.0µ ± 0%  -18.86% (p=0.000 n=10)
Decompress1XTable/gettysburg                  6.950µ ± 0%   6.042µ ± 0%  -13.06% (p=0.000 n=10)
Decompress1XTable/twain                       947.0µ ± 0%   763.2µ ± 0%  -19.41% (p=0.000 n=10)
Decompress1XTable/low-ent.10k                 127.5µ ± 0%   104.9µ ± 0%  -17.72% (p=0.000 n=10)
Decompress1XTable/superlow-ent-10k            34.22µ ± 0%   28.34µ ± 0%  -17.20% (p=0.000 n=10)
Decompress1XTable/crash2                      872.5n ± 0%   862.8n ± 0%   -1.12% (p=0.000 n=10)
Decompress1XTable/endzerobits                 95.94n ± 0%   85.54n ± 0%  -10.84% (p=0.000 n=10)
Decompress1XTable/endnonzero                  616.2n ± 0%   608.5n ± 0%   -1.26% (p=0.000 n=10)
Decompress1XTable/case1                       2.547µ ± 0%   2.576µ ± 0%   +1.16% (p=0.000 n=10)
Decompress1XTable/case2                       2.586µ ± 0%   2.625µ ± 0%   +1.53% (p=0.000 n=10)
Decompress1XTable/case3                       2.534µ ± 0%   2.525µ ± 0%   -0.37% (p=0.000 n=10)
Decompress1XTable/pngdata.001                 169.1µ ± 0%   152.3µ ± 0%   -9.92% (p=0.000 n=10)
Decompress1XTable/normcount2                  1.600µ ± 0%   1.583µ ± 0%   -1.06% (p=0.000 n=10)
Decompress1XNoTable/digits/100                431.3n ± 0%   408.9n ± 2%   -5.21% (p=0.000 n=10)
Decompress1XNoTable/digits/10000              34.63µ ± 0%   27.93µ ± 0%  -19.35% (p=0.000 n=10)
Decompress1XNoTable/digits/262143             901.1µ ± 0%   729.4µ ± 0%  -19.06% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/100            434.1n ± 0%   404.8n ± 2%   -6.76% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/10000          35.11µ ± 0%   29.09µ ± 0%  -17.15% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/262143         921.7µ ± 0%   760.4µ ± 0%  -17.50% (p=0.000 n=10)
Decompress1XNoTable/twain/100                 454.7n ± 0%   433.5n ± 0%   -4.66% (p=0.000 n=10)
Decompress1XNoTable/twain/10000               35.44µ ± 0%   29.09µ ± 0%  -17.93% (p=0.000 n=10)
Decompress1XNoTable/twain/262143              944.9µ ± 0%   760.7µ ± 0%  -19.50% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/100           615.6n ± 0%   612.7n ± 0%   -0.47% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/10000         32.03µ ± 0%   26.41µ ± 0%  -17.54% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/262143        831.7µ ± 0%   680.6µ ± 0%  -18.16% (p=0.000 n=10)
Decompress1XNoTable/superlow-ent-10k/262143   831.8µ ± 0%   680.8µ ± 0%  -18.15% (p=0.000 n=10)
Decompress1XNoTable/crash2/100                443.1n ± 0%   400.1n ± 0%   -9.69% (p=0.000 n=10)
Decompress1XNoTable/crash2/10000              33.21µ ± 0%   26.11µ ± 0%  -21.38% (p=0.000 n=10)
Decompress1XNoTable/crash2/262143             867.9µ ± 0%   681.7µ ± 0%  -21.46% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/100           616.4n ± 0%   613.0n ± 0%   -0.54% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/10000         32.05µ ± 0%   26.41µ ± 0%  -17.59% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/262143        832.1µ ± 0%   680.5µ ± 0%  -18.22% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/100            615.4n ± 0%   612.8n ± 0%   -0.42% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/10000          32.03µ ± 0%   26.41µ ± 0%  -17.54% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/262143         831.8µ ± 0%   680.6µ ± 0%  -18.17% (p=0.000 n=10)
Decompress1XNoTable/case1/100                 427.7n ± 0%   409.7n ± 2%   -4.21% (p=0.000 n=10)
Decompress1XNoTable/case1/10000               33.37µ ± 0%   27.95µ ± 0%  -16.25% (p=0.000 n=10)
Decompress1XNoTable/case1/262143              873.5µ ± 0%   729.9µ ± 0%  -16.44% (p=0.000 n=10)
Decompress1XNoTable/case2/100                 451.1n ± 0%   462.6n ± 1%   +2.54% (p=0.000 n=10)
Decompress1XNoTable/case2/10000               33.38µ ± 0%   27.98µ ± 0%  -16.19% (p=0.000 n=10)
Decompress1XNoTable/case2/262143              877.4µ ± 0%   729.8µ ± 0%  -16.82% (p=0.000 n=10)
Decompress1XNoTable/case3/100                 458.3n ± 0%   433.7n ± 0%   -5.37% (p=0.000 n=10)
Decompress1XNoTable/case3/10000               33.03µ ± 0%   27.97µ ± 0%  -15.31% (p=0.000 n=10)
Decompress1XNoTable/case3/262143              874.9µ ± 0%   729.3µ ± 0%  -16.64% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/100           510.8n ± 0%   499.9n ± 1%   -2.12% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/10000         32.15µ ± 0%   29.06µ ± 0%   -9.62% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/262143        852.6µ ± 0%   759.7µ ± 0%  -10.90% (p=0.000 n=10)
Decompress1XNoTable/normcount2/100            434.1n ± 0%   413.8n ± 0%   -4.65% (p=0.000 n=10)
Decompress1XNoTable/normcount2/10000          34.93µ ± 0%   27.92µ ± 0%  -20.07% (p=0.000 n=10)
Decompress1XNoTable/normcount2/262143         924.1µ ± 0%   729.9µ ± 0%  -21.01% (p=0.000 n=10)
geomean                                       20.07µ        17.64µ       -12.08%
4X control geomean                                       13.60µ        13.59µ       -0.06%
```


### Sapphire Rapids (c7i.xlarge, amd64, BMI2 twin)

Only the `Decompress1X` cells are shown; the `Decompress4X` control geomean is in the last line of the summary.

```
                                            │   sec/op    │   sec/op     vs base                │
Decompress1XTable/digits                      272.1µ ± 0%   245.7µ ± 0%   -9.73% (p=0.000 n=10)
Decompress1XTable/gettysburg                  4.988µ ± 0%   4.864µ ± 0%   -2.49% (p=0.000 n=10)
Decompress1XTable/twain                       775.3µ ± 0%   644.5µ ± 0%  -16.87% (p=0.000 n=10)
Decompress1XTable/low-ent.10k                 98.39µ ± 0%   91.59µ ± 0%   -6.91% (p=0.000 n=10)
Decompress1XTable/superlow-ent-10k            26.18µ ± 0%   24.50µ ± 0%   -6.43% (p=0.000 n=10)
Decompress1XTable/crash2                      524.8n ± 0%   507.5n ± 0%   -3.31% (p=0.000 n=10)
Decompress1XTable/endzerobits                 55.81n ± 0%   47.42n ± 0%  -15.03% (p=0.000 n=10)
Decompress1XTable/endnonzero                  336.1n ± 0%   325.6n ± 0%   -3.14% (p=0.000 n=10)
Decompress1XTable/case1                       1.732µ ± 0%   1.724µ ± 0%   -0.46% (p=0.000 n=10)
Decompress1XTable/case2                       1.694µ ± 0%   1.708µ ± 0%   +0.80% (p=0.000 n=10)
Decompress1XTable/case3                       1.701µ ± 0%   1.676µ ± 0%   -1.47% (p=0.000 n=10)
Decompress1XTable/pngdata.001                 129.0µ ± 0%   129.9µ ± 1%   +0.64% (p=0.000 n=10)
Decompress1XTable/normcount2                  1.097µ ± 0%   1.092µ ± 0%   -0.41% (p=0.001 n=10)
Decompress1XNoTable/digits/100                307.0n ± 0%   288.9n ± 0%   -5.88% (p=0.000 n=10)
Decompress1XNoTable/digits/10000              25.49µ ± 1%   24.34µ ± 0%   -4.49% (p=0.000 n=10)
Decompress1XNoTable/digits/262143             723.0µ ± 0%   634.7µ ± 0%  -12.21% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/100            311.2n ± 0%   296.7n ± 0%   -4.68% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/10000          25.77µ ± 0%   24.87µ ± 0%   -3.47% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/262143         683.9µ ± 0%   642.8µ ± 0%   -6.00% (p=0.000 n=10)
Decompress1XNoTable/twain/100                 318.8n ± 0%   305.6n ± 0%   -4.11% (p=0.000 n=10)
Decompress1XNoTable/twain/10000               25.85µ ± 0%   24.89µ ± 0%   -3.68% (p=0.000 n=10)
Decompress1XNoTable/twain/262143              773.2µ ± 0%   642.6µ ± 0%  -16.89% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/100           355.2n ± 3%   303.8n ± 1%  -14.48% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/10000         24.56µ ± 0%   22.83µ ± 1%   -7.06% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/262143        641.7µ ± 0%   592.0µ ± 0%   -7.75% (p=0.000 n=10)
Decompress1XNoTable/superlow-ent-10k/262143   641.8µ ± 0%   591.9µ ± 0%   -7.77% (p=0.000 n=10)
Decompress1XNoTable/crash2/100                307.0n ± 0%   288.0n ± 0%   -6.19% (p=0.000 n=10)
Decompress1XNoTable/crash2/10000              25.31µ ± 0%   22.70µ ± 0%  -10.32% (p=0.000 n=10)
Decompress1XNoTable/crash2/262143             662.2µ ± 0%   589.2µ ± 0%  -11.03% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/100           353.5n ± 1%   303.4n ± 1%  -14.16% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/10000         24.55µ ± 0%   22.81µ ± 0%   -7.08% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/262143        641.4µ ± 0%   591.3µ ± 0%   -7.82% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/100            355.3n ± 1%   303.7n ± 1%  -14.54% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/10000          24.55µ ± 0%   22.81µ ± 0%   -7.08% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/262143         642.0µ ± 0%   592.0µ ± 0%   -7.79% (p=0.000 n=10)
Decompress1XNoTable/case1/100                 303.4n ± 0%   287.1n ± 0%   -5.39% (p=0.000 n=10)
Decompress1XNoTable/case1/10000               25.41µ ± 0%   24.36µ ± 0%   -4.13% (p=0.000 n=10)
Decompress1XNoTable/case1/262143              665.4µ ± 0%   634.9µ ± 0%   -4.58% (p=0.000 n=10)
Decompress1XNoTable/case2/100                 310.0n ± 0%   308.4n ± 0%   -0.52% (p=0.001 n=10)
Decompress1XNoTable/case2/10000               25.14µ ± 0%   24.34µ ± 0%   -3.17% (p=0.000 n=10)
Decompress1XNoTable/case2/262143              657.4µ ± 0%   637.9µ ± 0%   -2.96% (p=0.000 n=10)
Decompress1XNoTable/case3/100                 312.2n ± 0%   303.8n ± 0%   -2.72% (p=0.000 n=10)
Decompress1XNoTable/case3/10000               25.31µ ± 0%   24.35µ ± 0%   -3.78% (p=0.000 n=10)
Decompress1XNoTable/case3/262143              661.3µ ± 0%   636.0µ ± 0%   -3.84% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/100           328.6n ± 0%   305.6n ± 0%   -7.00% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/10000         24.74µ ± 0%   24.98µ ± 0%   +0.99% (p=0.002 n=10)
Decompress1XNoTable/pngdata.001/262143        652.6µ ± 0%   644.6µ ± 0%   -1.22% (p=0.000 n=10)
Decompress1XNoTable/normcount2/100            302.7n ± 0%   298.9n ± 0%   -1.26% (p=0.000 n=10)
Decompress1XNoTable/normcount2/10000          25.61µ ± 0%   24.37µ ± 0%   -4.85% (p=0.000 n=10)
Decompress1XNoTable/normcount2/262143         672.6µ ± 0%   638.8µ ± 0%   -5.02% (p=0.000 n=10)
geomean                                       14.40µ        13.52µ        -6.09%
4X control geomean                                       9.815µ        9.814µ       -0.01%
```


### Graviton4 (c8g.xlarge, Neoverse V2, arm64)

Only the `Decompress1X` cells are shown; the `Decompress4X` control geomean is in the last line of the summary. Same tests passed on this box before benchmarking.

```
                                            │    sec/op    │   sec/op     vs base                │
Decompress1XTable/digits                       278.0µ ± 0%   244.9µ ± 0%  -11.88% (p=0.000 n=10)
Decompress1XTable/gettysburg                   5.275µ ± 0%   5.111µ ± 0%   -3.10% (p=0.000 n=10)
Decompress1XTable/twain                        785.1µ ± 0%   678.1µ ± 0%  -13.63% (p=0.000 n=10)
Decompress1XTable/low-ent.10k                 103.70µ ± 0%   92.57µ ± 0%  -10.74% (p=0.000 n=10)
Decompress1XTable/superlow-ent-10k             27.70µ ± 0%   24.82µ ± 0%  -10.40% (p=0.000 n=10)
Decompress1XTable/crash2                       585.2n ± 0%   564.3n ± 0%   -3.58% (p=0.000 n=10)
Decompress1XTable/endzerobits                  79.52n ± 0%   63.42n ± 1%  -20.24% (p=0.000 n=10)
Decompress1XTable/endnonzero                   409.3n ± 0%   386.1n ± 0%   -5.68% (p=0.000 n=10)
Decompress1XTable/case1                        1.820µ ± 0%   1.833µ ± 0%   +0.74% (p=0.000 n=10)
Decompress1XTable/case2                        1.817µ ± 0%   1.845µ ± 0%   +1.54% (p=0.000 n=10)
Decompress1XTable/case3                        1.835µ ± 0%   1.815µ ± 0%   -1.12% (p=0.000 n=10)
Decompress1XTable/pngdata.001                  135.4µ ± 0%   134.6µ ± 0%   -0.56% (p=0.000 n=10)
Decompress1XTable/normcount2                   1.179µ ± 0%   1.173µ ± 0%   -0.51% (p=0.000 n=10)
Decompress1XNoTable/digits/100                 354.0n ± 0%   348.9n ± 0%   -1.44% (p=0.000 n=10)
Decompress1XNoTable/digits/10000               26.69µ ± 0%   24.45µ ± 0%   -8.41% (p=0.000 n=10)
Decompress1XNoTable/digits/262143              738.0µ ± 0%   639.5µ ± 0%  -13.34% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/100             359.3n ± 0%   352.6n ± 0%   -1.86% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/10000           26.95µ ± 0%   25.63µ ± 0%   -4.92% (p=0.000 n=10)
Decompress1XNoTable/gettysburg/262143          708.6µ ± 0%   671.6µ ± 0%   -5.22% (p=0.000 n=10)
Decompress1XNoTable/twain/100                  367.6n ± 0%   369.3n ± 0%   +0.46% (p=0.000 n=10)
Decompress1XNoTable/twain/10000                27.06µ ± 0%   25.61µ ± 0%   -5.37% (p=0.000 n=10)
Decompress1XNoTable/twain/262143               782.7µ ± 0%   671.9µ ± 0%  -14.15% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/100            492.1n ± 0%   491.6n ± 0%   -0.10% (p=0.013 n=10)
Decompress1XNoTable/low-ent.10k/10000          26.02µ ± 0%   23.29µ ± 0%  -10.51% (p=0.000 n=10)
Decompress1XNoTable/low-ent.10k/262143         675.9µ ± 0%   602.8µ ± 0%  -10.81% (p=0.000 n=10)
Decompress1XNoTable/superlow-ent-10k/262143    675.9µ ± 0%   603.0µ ± 0%  -10.79% (p=0.000 n=10)
Decompress1XNoTable/crash2/100                 354.3n ± 0%   342.9n ± 0%   -3.22% (p=0.000 n=10)
Decompress1XNoTable/crash2/10000               26.44µ ± 0%   23.09µ ± 0%  -12.68% (p=0.000 n=10)
Decompress1XNoTable/crash2/262143              691.5µ ± 0%   604.6µ ± 0%  -12.56% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/100            492.1n ± 0%   491.6n ± 0%   -0.10% (p=0.001 n=10)
Decompress1XNoTable/endzerobits/10000          26.02µ ± 0%   23.28µ ± 0%  -10.53% (p=0.000 n=10)
Decompress1XNoTable/endzerobits/262143         675.9µ ± 0%   602.9µ ± 0%  -10.80% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/100             492.1n ± 0%   491.7n ± 0%   -0.08% (p=0.002 n=10)
Decompress1XNoTable/endnonzero/10000           26.02µ ± 0%   23.28µ ± 0%  -10.52% (p=0.000 n=10)
Decompress1XNoTable/endnonzero/262143          675.9µ ± 0%   603.0µ ± 0%  -10.79% (p=0.000 n=10)
Decompress1XNoTable/case1/100                  349.9n ± 0%   347.1n ± 0%   -0.80% (p=0.000 n=10)
Decompress1XNoTable/case1/10000                26.68µ ± 0%   24.45µ ± 0%   -8.37% (p=0.000 n=10)
Decompress1XNoTable/case1/262143               698.4µ ± 0%   643.1µ ± 0%   -7.92% (p=0.000 n=10)
Decompress1XNoTable/case2/100                  362.1n ± 0%   387.4n ± 0%   +7.02% (p=0.000 n=10)
Decompress1XNoTable/case2/10000                26.42µ ± 0%   24.46µ ± 0%   -7.41% (p=0.000 n=10)
Decompress1XNoTable/case2/262143               690.3µ ± 0%   639.9µ ± 0%   -7.30% (p=0.000 n=10)
Decompress1XNoTable/case3/100                  371.4n ± 0%   371.4n ± 0%        ~ (p=0.582 n=10)
Decompress1XNoTable/case3/10000                26.55µ ± 0%   24.46µ ± 0%   -7.85% (p=0.000 n=10)
Decompress1XNoTable/case3/262143               694.1µ ± 0%   641.9µ ± 0%   -7.53% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/100            404.5n ± 0%   413.6n ± 0%   +2.25% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/10000          25.92µ ± 0%   25.65µ ± 0%   -1.06% (p=0.000 n=10)
Decompress1XNoTable/pngdata.001/262143         682.3µ ± 0%   674.0µ ± 0%   -1.22% (p=0.000 n=10)
Decompress1XNoTable/normcount2/100             347.9n ± 0%   354.7n ± 0%   +1.95% (p=0.000 n=10)
Decompress1XNoTable/normcount2/10000           26.87µ ± 0%   24.43µ ± 0%   -9.08% (p=0.000 n=10)
Decompress1XNoTable/normcount2/262143          703.8µ ± 0%   643.0µ ± 0%   -8.64% (p=0.000 n=10)
geomean                                        15.81µ        14.86µ        -6.02%
4X control geomean                                       10.17µ        10.17µ        -0.01%
```

### zstd `DecodeAll` (corpus)

N1 (all cells within noise or slightly faster, geomean -0.24%):

```
                                     │   sec/op    │   sec/op     vs base               │
Decoder_DecodeAll/kppkn.gtb.zst        362.7µ ± 0%   362.1µ ± 0%  -0.15% (p=0.000 n=10)
Decoder_DecodeAll/geo.protodata.zst    108.2µ ± 0%   108.0µ ± 0%       ~ (p=0.065 n=10)
Decoder_DecodeAll/plrabn12.txt.zst     1.029m ± 1%   1.026m ± 0%       ~ (p=0.247 n=10)
Decoder_DecodeAll/lcet10.txt.zst       859.9µ ± 0%   858.0µ ± 0%  -0.22% (p=0.043 n=10)
Decoder_DecodeAll/asyoulik.txt.zst     251.3µ ± 0%   251.0µ ± 0%       ~ (p=0.165 n=10)
Decoder_DecodeAll/alice29.txt.zst      339.0µ ± 0%   339.1µ ± 0%       ~ (p=0.123 n=10)
Decoder_DecodeAll/html_x_4.zst         363.7µ ± 0%   363.2µ ± 0%       ~ (p=0.105 n=10)
Decoder_DecodeAll/paper-100k.pdf.zst   42.93µ ± 0%   42.73µ ± 0%  -0.46% (p=0.000 n=10)
Decoder_DecodeAll/fireworks.jpeg.zst   34.34µ ± 0%   34.36µ ± 0%       ~ (p=0.224 n=10)
Decoder_DecodeAll/urls.10K.zst         1.008m ± 0%   1.004m ± 0%       ~ (p=0.052 n=10)
Decoder_DecodeAll/html.zst             105.9µ ± 0%   105.8µ ± 0%       ~ (p=0.105 n=10)
Decoder_DecodeAll/comp-data.bin.zst    8.998µ ± 0%   8.981µ ± 0%  -0.19% (p=0.011 n=10)
geomean                                184.2µ        183.9µ       -0.18%
```

Graviton4 (geomean -0.55%):

```
                                     │   sec/op    │   sec/op     vs base               │
Decoder_DecodeAll/kppkn.gtb.zst        207.2µ ± 1%   201.2µ ± 1%  -2.91% (p=0.000 n=10)
Decoder_DecodeAll/geo.protodata.zst    50.93µ ± 1%   49.81µ ± 0%  -2.20% (p=0.000 n=10)
Decoder_DecodeAll/plrabn12.txt.zst     627.9µ ± 0%   627.8µ ± 0%       ~ (p=1.000 n=10)
Decoder_DecodeAll/lcet10.txt.zst       505.5µ ± 0%   504.1µ ± 0%  -0.27% (p=0.007 n=10)
Decoder_DecodeAll/asyoulik.txt.zst     154.9µ ± 0%   155.0µ ± 0%       ~ (p=0.796 n=10)
Decoder_DecodeAll/alice29.txt.zst      208.2µ ± 0%   208.3µ ± 0%  +0.05% (p=0.009 n=10)
Decoder_DecodeAll/html_x_4.zst         167.8µ ± 1%   167.1µ ± 3%       ~ (p=0.739 n=10)
Decoder_DecodeAll/paper-100k.pdf.zst   16.52µ ± 0%   16.42µ ± 0%  -0.60% (p=0.000 n=10)
Decoder_DecodeAll/fireworks.jpeg.zst   9.351µ ± 0%   9.351µ ± 0%       ~ (p=1.000 n=10)
Decoder_DecodeAll/urls.10K.zst         562.9µ ± 0%   561.7µ ± 0%       ~ (p=0.143 n=10)
Decoder_DecodeAll/html.zst             54.07µ ± 0%   53.87µ ± 0%  -0.37% (p=0.011 n=10)
Decoder_DecodeAll/comp-data.bin.zst    5.963µ ± 0%   5.985µ ± 0%  +0.38% (p=0.000 n=10)
geomean                                94.51µ        93.99µ       -0.55%
```

Sapphire Rapids:

```
                                     │   sec/op    │   sec/op     vs base               │
Decoder_DecodeAll/kppkn.gtb.zst        209.5µ ± 0%   210.2µ ± 0%  +0.35% (p=0.000 n=10)
Decoder_DecodeAll/geo.protodata.zst    45.91µ ± 0%   46.06µ ± 0%  +0.32% (p=0.009 n=10)
Decoder_DecodeAll/plrabn12.txt.zst     553.0µ ± 0%   553.7µ ± 0%  +0.13% (p=0.023 n=10)
Decoder_DecodeAll/lcet10.txt.zst       502.0µ ± 0%   500.1µ ± 0%  -0.38% (p=0.019 n=10)
Decoder_DecodeAll/asyoulik.txt.zst     139.8µ ± 0%   140.4µ ± 0%  +0.39% (p=0.000 n=10)
Decoder_DecodeAll/alice29.txt.zst      185.3µ ± 0%   185.4µ ± 0%       ~ (p=0.404 n=10)
Decoder_DecodeAll/html_x_4.zst         151.3µ ± 0%   151.0µ ± 0%  -0.20% (p=0.018 n=10)
Decoder_DecodeAll/paper-100k.pdf.zst   16.82µ ± 0%   16.85µ ± 0%       ~ (p=0.148 n=10)
Decoder_DecodeAll/fireworks.jpeg.zst   11.75µ ± 0%   11.74µ ± 0%       ~ (p=0.286 n=10)
Decoder_DecodeAll/urls.10K.zst         589.7µ ± 0%   592.1µ ± 0%  +0.41% (p=0.000 n=10)
Decoder_DecodeAll/html.zst             48.64µ ± 0%   48.61µ ± 0%       ~ (p=0.240 n=10)
Decoder_DecodeAll/comp-data.bin.zst    6.162µ ± 1%   5.958µ ± 0%  -3.30% (p=0.000 n=10)
geomean                                91.96µ        91.78µ       -0.19%
```

Note Note for readers: on the corpus benchmark and in the production profile that motivated #1203/#1209, the 1X loop is below 0.5% of decode time (zstd only emits one stream for literal blocks of 17..1023 bytes), so the zstd-level number is expected to be flat; this is a huff0-level and small-block improvement.

## Validation

- `go vet` on amd64 and arm64; `go test ./huff0 ./zstd` on amd64 (Zen 3, Sapphire Rapids) and arm64 (N1); `-tags noasm` control.
- Fuzzing, 20 minutes per target, all clean: amd64 (Zen 3) `FuzzDecompress1x` 66.6M execs, `FuzzCompress` 73.4M, `FuzzDecodeAll` 82.8M, `FuzzDecAllNoBMI2` 84.2M; arm64 (N1) `FuzzDecompress1x` 33.4M, `FuzzCompress` 29.8M, `FuzzDecodeAll` 36.2M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
