### PR TITLE
zstd: account for raw and RLE blocks in maxSyncLen

### DIFF
--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -240,9 +240,11 @@ func (b *blockDec) decodeBuf(hist *history) error {
 			b.dst[i] = v
 		}
 		hist.appendKeep(b.dst)
+		hist.decoders.consumeSyncLen(len(b.dst))
 		return nil
 	case blockTypeRaw:
 		hist.appendKeep(b.data)
+		hist.decoders.consumeSyncLen(len(b.data))
 		return nil
 	case blockTypeCompressed:
 		saved := b.dst

--- a/zstd/blockdec.go
+++ b/zstd/blockdec.go
@@ -489,6 +489,7 @@ func (b *blockDec) decodeCompressed(hist *history) error {
 	}
 	if hist.decoders.nSeqs == 0 {
 		b.dst = append(b.dst, hist.decoders.literals...)
+		hist.decoders.consumeSyncLen(len(hist.decoders.literals))
 		return nil
 	}
 	before := len(hist.decoders.out)

--- a/zstd/maxsynclen_test.go
+++ b/zstd/maxsynclen_test.go
@@ -1,0 +1,129 @@
+package zstd
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/rand"
+	"testing"
+)
+
+// TestMaxSyncLenTracksEveryBlockType walks frames block by block the way
+// runDecoder does and checks, after each block, that maxSyncLen still equals
+// the number of bytes the frame has yet to produce. Compressed blocks were
+// accounted for; raw and RLE blocks were not, so a frame that started with
+// incompressible data overstated its remaining size from then on, and
+// useSafeDecodeSync chose the bounds-exact copies for every compressed block
+// after the raw ones.
+//
+// The encoder never emits RLE blocks, so that case is a hand-built frame.
+func TestMaxSyncLenTracksEveryBlockType(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	random := make([]byte, 256<<10)
+	rng.Read(random)
+
+	// Incompressible data first, so the frame opens with raw blocks, then
+	// text that compresses into ordinary sequences.
+	text := append([]byte(nil), random...)
+	line := []byte("the quick brown fox jumps over the lazy dog; ")
+	for len(text) < 1<<20 {
+		text = append(text, line...)
+		text = append(text, byte('0'+rng.Intn(10)))
+	}
+	enc, err := NewWriter(nil, WithEncoderLevel(SpeedDefault))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer enc.Close()
+	encoded := enc.EncodeAll(text, nil)
+
+	// A single-segment frame holding one raw block and one RLE block.
+	const half = 1024
+	handmade := []byte{0x28, 0xb5, 0x2f, 0xfd} // magic
+	handmade = append(handmade, 0x60)          // single segment, 2-byte FCS
+	handmade = binary.LittleEndian.AppendUint16(handmade, 2*half-256)
+	handmade = append(handmade, testBlockHeader(half, blockTypeRaw, false)...)
+	handmade = append(handmade, random[:half]...)
+	handmade = append(handmade, testBlockHeader(half, blockTypeRLE, true)...)
+	handmade = append(handmade, 'x')
+	rleWant := append(append([]byte(nil), random[:half]...), bytes.Repeat([]byte{'x'}, half)...)
+
+	cases := []struct {
+		name  string
+		comp  []byte
+		want  []byte
+		types []blockType
+	}{
+		{"raw then compressed", encoded, text, []blockType{blockTypeRaw, blockTypeCompressed}},
+		{"raw then RLE", handmade, rleWant, []blockType{blockTypeRaw, blockTypeRLE}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			seen := walkCheckingMaxSyncLen(t, c.comp, c.want)
+			for _, bt := range c.types {
+				if seen[bt] == 0 {
+					t.Fatalf("frame has no %v block; the test input needs adjusting (saw %v)", bt, seen)
+				}
+			}
+		})
+	}
+}
+
+func testBlockHeader(size int, bt blockType, last bool) []byte {
+	v := uint32(size)<<3 | uint32(bt)<<1
+	if last {
+		v |= 1
+	}
+	return []byte{byte(v), byte(v >> 8), byte(v >> 16)}
+}
+
+// walkCheckingMaxSyncLen decodes comp block by block with the buffer
+// geometry DecodeAll sets up (output straight into a frame-sized buffer,
+// maxSyncLen starting at the frame size) and fails on the first block after
+// which maxSyncLen is not the number of bytes still to come.
+func walkCheckingMaxSyncLen(t *testing.T, comp, want []byte) map[blockType]int {
+	t.Helper()
+	dec, err := NewReader(nil, WithDecoderConcurrency(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dec.Close()
+	block := <-dec.decoders
+	defer func() { dec.decoders <- block }()
+	frame := block.localFrame
+	frame.bBuf = comp
+	frame.history.reset()
+	if err := frame.reset(&frame.bBuf); err != nil {
+		t.Fatal(err)
+	}
+	if frame.FrameContentSize == fcsUnknown {
+		t.Fatal("frame content size must be known for maxSyncLen to be set")
+	}
+	fcs := int(frame.FrameContentSize)
+
+	hist := &frame.history
+	hist.b = make([]byte, 0, fcs+compressedBlockOverAlloc)
+	hist.ignoreBuffer = 0
+	hist.decoders.maxSyncLen = uint64(fcs)
+
+	seen := map[blockType]int{}
+	for {
+		if err := block.reset(frame.rawInput, frame.WindowSize); err != nil {
+			t.Fatal(err)
+		}
+		seen[block.Type]++
+		if err := block.decodeBuf(hist); err != nil {
+			t.Fatalf("block %d (%v): %v", seen[block.Type], block.Type, err)
+		}
+		if got, want := hist.decoders.maxSyncLen, uint64(fcs-len(hist.b)); got != want {
+			t.Fatalf("after a %v block with %d bytes produced: maxSyncLen = %d, want %d",
+				block.Type, len(hist.b), got, want)
+		}
+		if block.Last {
+			break
+		}
+	}
+	if !bytes.Equal(hist.b, want) {
+		t.Fatal("decoded output does not match input")
+	}
+	return seen
+}

--- a/zstd/maxsynclen_test.go
+++ b/zstd/maxsynclen_test.go
@@ -9,13 +9,15 @@ import (
 
 // TestMaxSyncLenTracksEveryBlockType walks frames block by block the way
 // runDecoder does and checks, after each block, that maxSyncLen still equals
-// the number of bytes the frame has yet to produce. Compressed blocks were
-// accounted for; raw and RLE blocks were not, so a frame that started with
+// the number of bytes the frame has yet to produce. Compressed blocks with
+// sequences were accounted for; raw blocks, RLE blocks and compressed blocks
+// holding only literals were not, so a frame that started with
 // incompressible data overstated its remaining size from then on, and
 // useSafeDecodeSync chose the bounds-exact copies for every compressed block
 // after the raw ones.
 //
-// The encoder never emits RLE blocks, so that case is a hand-built frame.
+// The encoder never emits RLE blocks or literal-only compressed blocks, so
+// those cases are hand-built frames.
 func TestMaxSyncLenTracksEveryBlockType(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 	random := make([]byte, 256<<10)
@@ -47,6 +49,19 @@ func TestMaxSyncLenTracksEveryBlockType(t *testing.T) {
 	handmade = append(handmade, 'x')
 	rleWant := append(append([]byte(nil), random[:half]...), bytes.Repeat([]byte{'x'}, half)...)
 
+	// A single-segment frame holding one raw block and one compressed block
+	// that carries 20 raw literals and no sequences.
+	lits := []byte("twenty literal bytes")
+	litOnly := []byte{0x28, 0xb5, 0x2f, 0xfd, 0x60}
+	litOnly = binary.LittleEndian.AppendUint16(litOnly, uint16(half+len(lits))-256)
+	litOnly = append(litOnly, testBlockHeader(half, blockTypeRaw, false)...)
+	litOnly = append(litOnly, random[:half]...)
+	litOnly = append(litOnly, testBlockHeader(1+len(lits)+1, blockTypeCompressed, true)...)
+	litOnly = append(litOnly, byte(len(lits))<<3) // raw literals, 1-byte size format
+	litOnly = append(litOnly, lits...)
+	litOnly = append(litOnly, 0) // zero sequences
+	litOnlyWant := append(append([]byte(nil), random[:half]...), lits...)
+
 	cases := []struct {
 		name  string
 		comp  []byte
@@ -55,6 +70,7 @@ func TestMaxSyncLenTracksEveryBlockType(t *testing.T) {
 	}{
 		{"raw then compressed", encoded, text, []blockType{blockTypeRaw, blockTypeCompressed}},
 		{"raw then RLE", handmade, rleWant, []blockType{blockTypeRaw, blockTypeRLE}},
+		{"raw then literals only", litOnly, litOnlyWant, []blockType{blockTypeRaw, blockTypeCompressed}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -68,6 +84,7 @@ func TestMaxSyncLenTracksEveryBlockType(t *testing.T) {
 	}
 }
 
+// testBlockHeader encodes a zstd block header: last flag, type, and size.
 func testBlockHeader(size int, bt blockType, last bool) []byte {
 	v := uint32(size)<<3 | uint32(bt)<<1
 	if last {

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -102,10 +102,11 @@ func (s *sequenceDecs) initialize(br *bitReader, hist *history, out []byte) erro
 // consumeSyncLen accounts for n bytes of frame output produced outside
 // decodeSync. maxSyncLen bounds how much the frame may still produce and
 // decodeSyncSimple compares it with the output buffer's slack to decide
-// whether the extended 16-byte copies are safe. decodeCompressed subtracts
-// its own output; raw and RLE blocks did not, so a frame that opened with a
-// raw block overstated its remaining size for every block after it and ran
-// the bounds-exact copies for the rest of the frame.
+// whether the extended 16-byte copies are safe. Blocks with sequences
+// subtracted their output; raw blocks, RLE blocks and compressed blocks
+// holding only literals did not, so a frame that opened with a raw block
+// overstated its remaining size for every block after it and ran the
+// bounds-exact copies for the rest of the frame.
 //
 // Zero means "no bound" and selects the conservative paths, so a block that
 // meets or exceeds the bound lands there; the frame-size checks in

--- a/zstd/seqdec.go
+++ b/zstd/seqdec.go
@@ -99,6 +99,28 @@ func (s *sequenceDecs) initialize(br *bitReader, hist *history, out []byte) erro
 	return nil
 }
 
+// consumeSyncLen accounts for n bytes of frame output produced outside
+// decodeSync. maxSyncLen bounds how much the frame may still produce and
+// decodeSyncSimple compares it with the output buffer's slack to decide
+// whether the extended 16-byte copies are safe. decodeCompressed subtracts
+// its own output; raw and RLE blocks did not, so a frame that opened with a
+// raw block overstated its remaining size for every block after it and ran
+// the bounds-exact copies for the rest of the frame.
+//
+// Zero means "no bound" and selects the conservative paths, so a block that
+// meets or exceeds the bound lands there; the frame-size checks in
+// runDecoder reject the excess afterwards.
+func (s *sequenceDecs) consumeSyncLen(n int) {
+	if s.maxSyncLen == 0 {
+		return
+	}
+	if uint64(n) >= s.maxSyncLen {
+		s.maxSyncLen = 0
+		return
+	}
+	s.maxSyncLen -= uint64(n)
+}
+
 func (s *sequenceDecs) freeDecoders() {
 	if f := s.litLengths.fse; f != nil && !f.preDefined {
 		fseDecoderPool.Put(f)


### PR DESCRIPTION
`maxSyncLen` bounds how much of the frame the synchronous decoder (`DecodeAll`, or a `Reader` with concurrency 1) may still produce. `decodeSyncSimple` compares it with the output buffer's slack to decide whether the extended 16-byte copies are safe; otherwise every block runs the bounds-exact "safe" `decodeSync` variant.

`decodeCompressed` subtracts each compressed block's output from it, but `decodeBuf`'s raw and RLE cases never did. A frame that opens with incompressible data (stored as raw blocks) therefore overstates its remaining size for every block after them, the slack check fails, and the rest of the frame runs the safe variant. `perf` on a Neoverse N1 showed 78% of `DecodeAll` inside `sequenceDecs_decodeSync_safe_arm64` on such a frame.

The bound can only be overstated, so this was never a correctness issue, just the slow copies being selected. The fix subtracts raw and RLE block sizes too, landing on zero (the existing "no bound" value, which selects the conservative paths) if a block meets or exceeds the bound; `runDecoder`'s frame-size checks reject the excess afterwards.

### Measurements

Neoverse N1 (Ampere Altra), `DecodeAll` of 70 MB frames whose first 4 MiB is random data, checksum off, `-count 5`:

| match offsets | before | after |
|---|---|---|
| under 32 KiB | 43.8 ms | 36.4 ms (−17%) |
| 128–768 KiB | 61.3 ms | 54.3 ms (−11%) |
| 1–2 MiB | 87.7 ms | 81.2 ms (−7%) |

Entirely from the fast copy variant being selected again. Frames without raw blocks are unaffected: the silesia files and the `benchdecoder` corpus never hit this (probe counted zero safe selections on a silesia subset).

amd64 not measured yet; the selection logic is shared, so the same behavior is expected there.

### Test

`TestMaxSyncLenTracksEveryBlockType` walks two frames block by block with `DecodeAll`'s buffer geometry — an encoder-produced frame that opens with raw blocks then compressed ones, and a hand-built frame with a raw block then an RLE block (the encoder never emits RLE) — and asserts after every block that `maxSyncLen` equals the bytes still to produce. It fails on the first raw block without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming decompression accounting for raw and run-length encoded blocks.
  - Ensured remaining output length is tracked correctly across all supported block types, including compressed blocks containing only literals.
  - Added validation covering mixed raw, run-length encoded, and compressed data blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->